### PR TITLE
[Python] Part 1 of fixing MacOSx Flaky Test in CI under parallelism

### DIFF
--- a/src/python/grpcio_tests/tests/admin/admin_test.py
+++ b/src/python/grpcio_tests/tests/admin/admin_test.py
@@ -28,11 +28,11 @@ from grpc_csds import csds_pb2_grpc
 class TestAdmin(unittest.TestCase):
     def setUp(self):
         self._server = grpc.server(ThreadPoolExecutor())
-        port = self._server.add_insecure_port("localhost:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         grpc_admin.add_admin_servicers(self._server)
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%s" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%s" % port)
 
     def tearDown(self):
         self._channel.close()

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -72,13 +72,13 @@ class _ChannelServerPair:
             futures.ThreadPoolExecutor(max_workers=3),
             options=_DISABLE_REUSE_PORT + _ENABLE_CHANNELZ,
         )
-        port = self.server.add_insecure_port("[::]:0")
+        port = self.server.add_insecure_port("127.0.0.1:0")
         self.server.add_generic_rpc_handlers((_GenericHandler(),))
         self.server.start()
 
         # Channel will enable channelz service...
         self.channel = grpc.insecure_channel(
-            "localhost:%d" % port, _ENABLE_CHANNELZ
+            "127.0.0.1:%d" % port, _ENABLE_CHANNELZ
         )
 
 
@@ -145,14 +145,14 @@ class ChannelzServicerTest(unittest.TestCase):
             futures.ThreadPoolExecutor(max_workers=3),
             options=_DISABLE_REUSE_PORT + _DISABLE_CHANNELZ,
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         channelz.add_channelz_servicer(self._server)
         self._server.start()
 
         # This channel is used to fetch Channelz info only
         # Channelz should not be enabled
         self._channel = grpc.insecure_channel(
-            "localhost:%d" % port, _DISABLE_CHANNELZ
+            "127.0.0.1:%d" % port, _DISABLE_CHANNELZ
         )
         self._channelz_stub = channelz_pb2_grpc.ChannelzStub(self._channel)
 

--- a/src/python/grpcio_tests/tests/csds/csds_test.py
+++ b/src/python/grpcio_tests/tests/csds/csds_test.py
@@ -60,11 +60,11 @@ class TestCsds(unittest.TestCase):
     def setUp(self):
         os.environ["GRPC_XDS_BOOTSTRAP_CONFIG"] = _DUMMY_BOOTSTRAP_FILE
         self._server = grpc.server(ThreadPoolExecutor())
-        port = self._server.add_insecure_port("localhost:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         grpc_csds.add_csds_servicer(self._server)
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%s" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%s" % port)
         self._stub = csds_pb2_grpc.ClientStatusDiscoveryServiceStub(
             self._channel
         )

--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -56,7 +56,7 @@ _CLIENT_FORK_SCRIPT_TEMPLATE = """if True:
     cygrpc._GRPC_ENABLE_FORK_SUPPORT = True
     os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'true'
     methods.TestCase.%s.run_test({
-      'server_host': 'localhost',
+      'server_host': '127.0.0.1',
       'server_port': %d,
       'use_tls': False
     })
@@ -87,7 +87,7 @@ class ForkInteropTest(unittest.TestCase):
             server = test_common.test_server()
             test_pb2_grpc.add_TestServiceServicer_to_server(
                 interop_service.TestService(), server)
-            port = server.add_insecure_port('[::]:0')
+            port = server.add_insecure_port('127.0.0.1:0')
             server.start()
             print(port)
             sys.stdout.flush()

--- a/src/python/grpcio_tests/tests/fork/client.py
+++ b/src/python/grpcio_tests/tests/fork/client.py
@@ -31,7 +31,7 @@ def _args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--server_host",
-        default="localhost",
+        default="127.0.0.1",
         type=str,
         help="the host to which to connect",
     )

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -57,13 +57,13 @@ class BaseWatchTests:
                 _NOT_SERVING_SERVICE, health_pb2.HealthCheckResponse.NOT_SERVING
             )
             self._server = test_common.test_server()
-            port = self._server.add_insecure_port("[::]:0")
+            port = self._server.add_insecure_port("127.0.0.1:0")
             health_pb2_grpc.add_HealthServicer_to_server(
                 self._servicer, self._server
             )
             self._server.start()
 
-            self._channel = grpc.insecure_channel("localhost:%d" % port)
+            self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
             self._stub = health_pb2_grpc.HealthStub(self._channel)
 
         def tearDown(self):

--- a/src/python/grpcio_tests/tests/interop/_insecure_intraop_test.py
+++ b/src/python/grpcio_tests/tests/interop/_insecure_intraop_test.py
@@ -32,10 +32,10 @@ class InsecureIntraopTest(
         test_pb2_grpc.add_TestServiceServicer_to_server(
             service.TestService(), self.server
         )
-        port = self.server.add_insecure_port("[::]:0")
+        port = self.server.add_insecure_port("127.0.0.1:0")
         self.server.start()
         self.stub = test_pb2_grpc.TestServiceStub(
-            grpc.insecure_channel("localhost:{}".format(port))
+            grpc.insecure_channel("127.0.0.1:{}".format(port))
         )
 
     def tearDown(self):

--- a/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
+++ b/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
@@ -46,7 +46,7 @@ class SecureIntraopTest(_intraop_test_case.IntraopTestCase, unittest.TestCase):
         )
         self.server.start()
         self.channel = grpc.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             grpc.ssl_channel_credentials(resources.test_root_certificates()),
             (
                 (
@@ -87,7 +87,7 @@ class SecureInteropWithSyncPrivateKeyOffloadingTest(
         )
         self.server.start()
         self.channel = grpc.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.sync_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),
@@ -132,7 +132,7 @@ class SecureInteropWithAsyncPrivateKeyOffloadingTest(
         )
         self.server.start()
         self.channel = grpc.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.async_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),

--- a/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
+++ b/src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
@@ -34,7 +34,7 @@ class SecureIntraopTest(_intraop_test_case.IntraopTestCase, unittest.TestCase):
             service.TestService(), self.server
         )
         port = self.server.add_secure_port(
-            "[::]:0",
+            "127.0.0.1:0",
             grpc.ssl_server_credentials(
                 [
                     (
@@ -73,7 +73,7 @@ class SecureInteropWithSyncPrivateKeyOffloadingTest(
         )
         # Configure the server for mTLS so the client will do Private Key signing
         port = self.server.add_secure_port(
-            "[::]:0",
+            "127.0.0.1:0",
             grpc.ssl_server_credentials(
                 [
                     (
@@ -118,7 +118,7 @@ class SecureInteropWithAsyncPrivateKeyOffloadingTest(
         )
         # Configure the server for mTLS so the client will do Private Key signing
         port = self.server.add_secure_port(
-            "[::]:0",
+            "127.0.0.1:0",
             grpc.ssl_server_credentials(
                 [
                     (

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -30,7 +30,7 @@ def parse_interop_client_args(argv):
     parser = argparse_flags.ArgumentParser()
     parser.add_argument(
         "--server_host",
-        default="localhost",
+        default="127.0.0.1",
         type=str,
         help="the host to which to connect",
     )

--- a/src/python/grpcio_tests/tests/interop/security_test.py
+++ b/src/python/grpcio_tests/tests/interop/security_test.py
@@ -51,7 +51,7 @@ class SecurityTest(unittest.TestCase):
         )
         # Configure the server for mTLS so the client will do Private Key signing
         self.port = self.server.add_secure_port(
-            "[::]:0",
+            "127.0.0.1:0",
             grpc.ssl_server_credentials(
                 [
                     (

--- a/src/python/grpcio_tests/tests/interop/security_test.py
+++ b/src/python/grpcio_tests/tests/interop/security_test.py
@@ -75,7 +75,7 @@ class SecurityTest(unittest.TestCase):
         Successfully use a custom sync private key signer.
         """
         with grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.sync_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),
@@ -97,7 +97,7 @@ class SecurityTest(unittest.TestCase):
         Successfully use a custom async private key signer.
         """
         with grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.async_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),
@@ -119,7 +119,7 @@ class SecurityTest(unittest.TestCase):
         Expect failure using a custom sync private key signer.
         """
         with grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.sync_bad_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),
@@ -140,7 +140,7 @@ class SecurityTest(unittest.TestCase):
     def test_sync_signer_raises_directly(self):
         """Expect failure using a custom sync signer that directly raises an exception"""
         with grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.sync_raises_exception,
                 root_certificates=resources.test_root_certificates(),
@@ -163,7 +163,7 @@ class SecurityTest(unittest.TestCase):
         Expect failure using a custom async private key signer.
         """
         with grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=resources.bad_async_client_private_key_signer,
                 root_certificates=resources.test_root_certificates(),
@@ -190,7 +190,7 @@ class SecurityTest(unittest.TestCase):
             resources.async_signer_with_cancel_injection, cancel_callable
         )
         channel = grpc.secure_channel(
-            "localhost:{}".format(self.port),
+            "127.0.0.1:{}".format(self.port),
             grpc.experimental.ssl_channel_credentials_with_custom_signer(
                 private_key_sign_fn=bound_signing_fn,
                 root_certificates=resources.test_root_certificates(),
@@ -222,7 +222,7 @@ class SecurityTest(unittest.TestCase):
         # We should have a timeout here
         with self.assertRaises(Exception) as context:
             with grpc.secure_channel(
-                "localhost:{}".format(self.port),
+                "127.0.0.1:{}".format(self.port),
                 grpc.experimental.ssl_channel_credentials_with_custom_signer(
                     private_key_sign_fn=resources.async_client_private_key_signer_with_cancel,
                     root_certificates=resources.test_root_certificates(),
@@ -254,7 +254,7 @@ class SecurityTest(unittest.TestCase):
             )
 
             secure_channel = grpc.secure_channel(
-                "localhost:{}".format(self.port), creds
+                "127.0.0.1:{}".format(self.port), creds
             )
             return secure_channel, ref
 
@@ -280,7 +280,7 @@ class SecurityTest(unittest.TestCase):
 
         def channel_with_credential(creds, q, port):
             with grpc.secure_channel(
-                "localhost:{}".format(port),
+                "127.0.0.1:{}".format(port),
                 creds,
                 (
                     (
@@ -329,7 +329,7 @@ def test_signer_lifetime_happy_path(self):
         private_key_signer=signer,
     )
 
-    channel = grpc.secure_channel("localhost:50051", creds)
+    channel = grpc.secure_channel("127.0.0.1:50051", creds)
 
     current_ref_count = sys.getrefcount(signer)
     self.assertGreater(
@@ -359,7 +359,7 @@ def test_signer_lifetime_failure_path(self):
         private_key_signer=signer,
     )
 
-    channel = grpc.secure_channel("localhost:50051", creds)
+    channel = grpc.secure_channel("127.0.0.1:50051", creds)
 
     current_ref_count = sys.getrefcount(signer)
     self.assertGreater(

--- a/src/python/grpcio_tests/tests/interop/server.py
+++ b/src/python/grpcio_tests/tests/interop/server.py
@@ -65,9 +65,9 @@ def serve(args):
     )
     if args.use_tls or args.use_alts:
         credentials = get_server_credentials(args.use_tls)
-        server.add_secure_port("[::]:{}".format(args.port), credentials)
+        server.add_secure_port("127.0.0.1:{}".format(args.port), credentials)
     else:
-        server.add_insecure_port("[::]:{}".format(args.port))
+        server.add_insecure_port("127.0.0.1:{}".format(args.port))
 
     server.start()
     _LOGGER.info("Server serving.")

--- a/src/python/grpcio_tests/tests/observability/_csm_observability_plugin_test.py
+++ b/src/python/grpcio_tests/tests/observability/_csm_observability_plugin_test.py
@@ -107,8 +107,8 @@ class OTelMetricExporter(MetricExporter):
         value is a list of labels recorded for that metric.
         An example item of this dict:
             {"grpc.client.attempt.started":
-              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': 'localhost:42517'},
-               {'grpc.method': 'other', 'grpc.target': 'localhost:42517'}]}
+              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': '127.0.0.1:42517'},
+               {'grpc.method': 'other', 'grpc.target': '127.0.0.1:42517'}]}
     """
 
     def __init__(

--- a/src/python/grpcio_tests/tests/observability/_observability_plugin_test.py
+++ b/src/python/grpcio_tests/tests/observability/_observability_plugin_test.py
@@ -70,8 +70,8 @@ class OTelMetricExporter(MetricExporter):
         value is a list of labels recorded for that metric.
         An example item of this dict:
             {"grpc.client.attempt.started":
-              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': 'localhost:42517'},
-               {'grpc.method': 'other', 'grpc.target': 'localhost:42517'}]}
+              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': '127.0.0.1:42517'},
+               {'grpc.method': 'other', 'grpc.target': '127.0.0.1:42517'}]}
     """
 
     def __init__(

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -363,8 +363,8 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
     def testTargetAttributeFilter(self):
         main_server, main_port = _test_server.start_server()
         backup_server, backup_port = _test_server.start_server()
-        main_target = f"localhost:{main_port}"
-        backup_target = f"localhost:{backup_port}"
+        main_target = f"127.0.0.1:{main_port}"
+        backup_target = f"127.0.0.1:{backup_port}"
 
         # Replace target label with 'other' for main_server.
         def target_filter(target: str) -> bool:

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -52,8 +52,8 @@ class OTelMetricExporter(MetricExporter):
         value is a list of labels recorded for that metric.
         An example item of this dict:
             {"grpc.client.attempt.started":
-              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': 'localhost:42517'},
-               {'grpc.method': 'other', 'grpc.target': 'localhost:42517'}]}
+              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': '127.0.0.1:42517'},
+               {'grpc.method': 'other', 'grpc.target': '127.0.0.1:42517'}]}
     """
 
     def __init__(

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -41,7 +41,7 @@ def handle_unary_unary(request, servicer_context):
                     futures.ThreadPoolExecutor(max_workers=10)
                 )
                 second_server.add_generic_rpc_handlers((_GenericHandler(),))
-                second_server_port = second_server.add_insecure_port("[::]:0")
+                second_server_port = second_server.add_insecure_port("127.0.0.1:0")
                 second_server.start()
                 unary_unary_call(port=second_server_port)
                 second_server.stop(0)
@@ -133,13 +133,13 @@ def start_server(
         server.add_registered_method_handlers(
             _SERVICE_NAME, REGISTERED_RPC_METHOD_HANDLERS
         )
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
     return server, port
 
 
 def unary_unary_call(port, metadata=None, registered_method=False):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
             _registered_method=registered_method,
@@ -153,7 +153,7 @@ def unary_unary_call(port, metadata=None, registered_method=False):
 
 
 def intercepted_unary_unary_call(port, interceptors, metadata=None):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         intercept_channel = grpc.intercept_channel(channel, interceptors)
         multi_callable = intercept_channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY)
@@ -167,7 +167,7 @@ def intercepted_unary_unary_call(port, interceptors, metadata=None):
 
 
 def unary_unary_filtered_call(port, metadata=None):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(
                 _SERVICE_NAME, _UNARY_UNARY_FILTERED
@@ -182,7 +182,7 @@ def unary_unary_filtered_call(port, metadata=None):
 
 
 def unary_stream_call(port):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.unary_stream(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_STREAM)
         )
@@ -192,7 +192,7 @@ def unary_stream_call(port):
 
 
 def stream_unary_call(port):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.stream_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_UNARY)
         )
@@ -202,7 +202,7 @@ def stream_unary_call(port):
 
 
 def stream_stream_call(port):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+    with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.stream_stream(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_STREAM)
         )

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -41,7 +41,9 @@ def handle_unary_unary(request, servicer_context):
                     futures.ThreadPoolExecutor(max_workers=10)
                 )
                 second_server.add_generic_rpc_handlers((_GenericHandler(),))
-                second_server_port = second_server.add_insecure_port("127.0.0.1:0")
+                second_server_port = second_server.add_insecure_port(
+                    "127.0.0.1:0"
+                )
                 second_server.start()
                 unary_unary_call(port=second_server_port)
                 second_server.stop(0)

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -165,9 +165,9 @@ def _CreateService():
     getattr(service_pb2_grpc, ADD_SERVICER_TO_SERVER_IDENTIFIER)(
         Servicer(), server
     )
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
-    channel = grpc.insecure_channel("localhost:{}".format(port))
+    channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
     stub = getattr(service_pb2_grpc, STUB_IDENTIFIER)(channel)
     return _Service(servicer_methods, server, stub)
 
@@ -187,9 +187,9 @@ def _CreateIncompleteService():
     getattr(service_pb2_grpc, ADD_SERVICER_TO_SERVER_IDENTIFIER)(
         Servicer(), server
     )
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
-    channel = grpc.insecure_channel("localhost:{}".format(port))
+    channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
     stub = getattr(service_pb2_grpc, STUB_IDENTIFIER)(channel)
     return _Service(None, server, stub)
 
@@ -590,9 +590,9 @@ class SimpleStubsPluginTest(unittest.TestCase):
         service_pb2_grpc.add_TestServiceServicer_to_server(
             self.Servicer(), self._server
         )
-        self._port = self._server.add_insecure_port("[::]:0")
+        self._port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
-        self._target = "localhost:{}".format(self._port)
+        self._target = "127.0.0.1:{}".format(self._port)
 
     def tearDown(self):
         self._server.stop(None)

--- a/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
@@ -327,9 +327,9 @@ class _Test(unittest.TestCase, metaclass=abc.ABCMeta):
             services_module.add_TestServiceServicer_to_server(
                 _Servicer(self._messages_pb2.Response), server
             )
-            port = server.add_insecure_port("[::]:0")
+            port = server.add_insecure_port("127.0.0.1:0")
             server.start()
-            channel = grpc.insecure_channel("localhost:{}".format(port))
+            channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
             stub = services_module.TestServiceStub(channel)
             response = stub.Call(self._messages_pb2.Request())
             self.assertEqual(self._messages_pb2.Response(), response)

--- a/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
@@ -219,9 +219,9 @@ def _CreateService(payload_pb2, responses_pb2, service_pb2):
 
     servicer = Servicer()
     server = getattr(service_pb2, SERVER_FACTORY_IDENTIFIER)(servicer)
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
-    channel = implementations.insecure_channel("localhost", port)
+    channel = implementations.insecure_channel("127.0.0.1", port)
     stub = getattr(service_pb2, STUB_FACTORY_IDENTIFIER)(channel)
     yield servicer_methods, stub
     server.stop(0)
@@ -246,9 +246,9 @@ def _CreateIncompleteService(service_pb2):
 
     servicer = Servicer()
     server = getattr(service_pb2, SERVER_FACTORY_IDENTIFIER)(servicer)
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
-    channel = implementations.insecure_channel("localhost", port)
+    channel = implementations.insecure_channel("127.0.0.1", port)
     stub = getattr(service_pb2, STUB_FACTORY_IDENTIFIER)(channel)
     yield None, stub
     server.stop(0)

--- a/src/python/grpcio_tests/tests/qps/qps_worker.py
+++ b/src/python/grpcio_tests/tests/qps/qps_worker.py
@@ -30,7 +30,7 @@ def run_worker_server(driver_port, server_port):
     worker_service_pb2_grpc.add_WorkerServiceServicer_to_server(
         servicer, server
     )
-    server.add_insecure_port("[::]:{}".format(driver_port))
+    server.add_insecure_port("127.0.0.1:{}".format(driver_port))
     server.start()
     servicer.wait_for_quit()
     server.stop(0)

--- a/src/python/grpcio_tests/tests/qps/worker_server.py
+++ b/src/python/grpcio_tests/tests/qps/worker_server.py
@@ -151,10 +151,10 @@ class WorkerServer(worker_service_pb2_grpc.WorkerServiceServicer):
                 ((resources.private_key(), resources.certificate_chain()),)
             )
             port = server.add_secure_port(
-                "[::]:{}".format(server_port), server_creds
+                "127.0.0.1:{}".format(server_port), server_creds
             )
         else:
-            port = server.add_insecure_port("[::]:{}".format(server_port))
+            port = server.add_insecure_port("127.0.0.1:{}".format(server_port))
 
         return (server, port)
 

--- a/src/python/grpcio_tests/tests/reflection/_reflection_client_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_client_test.py
@@ -45,10 +45,10 @@ class ReflectionClientTest(unittest.TestCase):
             reflection.SERVICE_NAME,
         )
         reflection.enable_server_reflection(self._SERVICE_NAMES, self._server)
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         self._reflection_db = ProtoReflectionDescriptorDatabase(self._channel)
         self.desc_pool = DescriptorPool(self._reflection_db)

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -58,10 +58,10 @@ class ReflectionServicerTest(unittest.TestCase):
     def setUp(self):
         self._server = test_common.test_server()
         reflection.enable_server_reflection(_SERVICE_NAMES, self._server)
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
         self._stub = reflection_pb2_grpc.ServerReflectionStub(self._channel)
 
     def tearDown(self):

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -124,10 +124,10 @@ class StatusTest(unittest.TestCase):
     def setUp(self):
         self._server = test_common.test_server()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(None)

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -141,7 +141,7 @@ def run_test(args):
     metrics_pb2_grpc.add_MetricsServiceServicer_to_server(
         metrics_server.MetricsServer(hist), server
     )
-    server.add_insecure_port("[::]:{}".format(args.metrics_port))
+    server.add_insecure_port("127.0.0.1:{}".format(args.metrics_port))
     server.start()
 
     for test_server_target in test_server_targets:

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -35,7 +35,7 @@ def _args(argv):
     parser.add_argument(
         "--server_addresses",
         help="comma separated list of hostname:port to run servers on",
-        default="localhost:8080",
+        default="127.0.0.1:8080",
         type=str,
     )
     parser.add_argument(

--- a/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
+++ b/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
@@ -44,7 +44,7 @@ class Handler(unary_stream_benchmark_pb2_grpc.UnaryStreamBenchmarkServiceService
 
 
 server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-server.add_insecure_port('[::]:%d')
+server.add_insecure_port('127.0.0.1:%d')
 unary_stream_benchmark_pb2_grpc.add_UnaryStreamBenchmarkServiceServicer_to_server(Handler(), server)
 server.start()
 server.wait_for_termination()
@@ -86,7 +86,7 @@ try:
             message_size=message_size, response_count=response_count
         )
         with grpc.insecure_channel(
-            "[::]:{}".format(_PORT), options=_GRPC_CHANNEL_OPTIONS
+            "127.0.0.1:{}".format(_PORT), options=_GRPC_CHANNEL_OPTIONS
         ) as channel:
             stub = (
                 unary_stream_benchmark_pb2_grpc.UnaryStreamBenchmarkServiceStub(

--- a/src/python/grpcio_tests/tests/unit/_abort_test.py
+++ b/src/python/grpcio_tests/tests/unit/_abort_test.py
@@ -91,13 +91,13 @@ RPC_METHOD_HANDLERS = {
 class AbortTest(unittest.TestCase):
     def setUp(self):
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, RPC_METHOD_HANDLERS
         )
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._channel.close()

--- a/src/python/grpcio_tests/tests/unit/_absl_log_test.py
+++ b/src/python/grpcio_tests/tests/unit/_absl_log_test.py
@@ -24,7 +24,7 @@ class AbslLogTest(unittest.TestCase):
     def setUp(self):
         # Basic client script to start a grpc channel to a non-existent server,
         # just to check the GRPC_TRACE logs.
-        script = "import grpc; channel = grpc.insecure_channel('localhost:1234'); print('Channel created'); channel.close()"
+        script = "import grpc; channel = grpc.insecure_channel('127.0.0.1:1234'); print('Channel created'); channel.close()"
 
         # Set up the environment variables
         env = os.environ.copy()

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -72,7 +72,7 @@ class AuthContextTest(unittest.TestCase):
     def testInsecure(self):
         server = test_common.test_server()
         server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
 
         with grpc.insecure_channel("127.0.0.1:%d" % port) as channel:
@@ -99,7 +99,7 @@ class AuthContextTest(unittest.TestCase):
         server = test_common.test_server()
         server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
         server_cred = grpc.ssl_server_credentials(_SERVER_CERTS)
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         server.start()
 
         channel_creds = grpc.ssl_channel_credentials(
@@ -137,7 +137,7 @@ class AuthContextTest(unittest.TestCase):
             root_certificates=_TEST_ROOT_CERTIFICATES,
             require_client_auth=True,
         )
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         server.start()
 
         channel_creds = grpc.ssl_channel_credentials(
@@ -189,7 +189,7 @@ class AuthContextTest(unittest.TestCase):
         server = test_common.test_server()
         server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
         server_cred = grpc.ssl_server_credentials(_SERVER_CERTS)
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         server.start()
 
         # Create a cache for TLS session tickets

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -75,7 +75,7 @@ class AuthContextTest(unittest.TestCase):
         port = server.add_insecure_port("[::]:0")
         server.start()
 
-        with grpc.insecure_channel("localhost:%d" % port) as channel:
+        with grpc.insecure_channel("127.0.0.1:%d" % port) as channel:
             response = channel.unary_unary(
                 grpc._common.fully_qualified_method(
                     _SERVICE_NAME, _UNARY_UNARY
@@ -106,7 +106,7 @@ class AuthContextTest(unittest.TestCase):
             root_certificates=_TEST_ROOT_CERTIFICATES
         )
         channel = grpc.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             channel_creds,
             options=_PROPERTY_OPTIONS,
         )
@@ -146,7 +146,7 @@ class AuthContextTest(unittest.TestCase):
             certificate_chain=_CERTIFICATE_CHAIN,
         )
         channel = grpc.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             channel_creds,
             options=_PROPERTY_OPTIONS,
         )
@@ -171,7 +171,7 @@ class AuthContextTest(unittest.TestCase):
         self, channel_creds, channel_options, port, expect_ssl_session_reused
     ):
         channel = grpc.secure_channel(
-            "localhost:{}".format(port), channel_creds, options=channel_options
+            "127.0.0.1:{}".format(port), channel_creds, options=channel_options
         )
         response = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),

--- a/src/python/grpcio_tests/tests/unit/_channel_args_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_args_test.py
@@ -42,7 +42,7 @@ INVALID_TEST_CHANNEL_ARGS = [
 
 class ChannelArgsTest(unittest.TestCase):
     def test_client(self):
-        grpc.insecure_channel("localhost:8080", options=TEST_CHANNEL_ARGS)
+        grpc.insecure_channel("127.0.0.1:8080", options=TEST_CHANNEL_ARGS)
 
     def test_server(self):
         grpc.server(
@@ -54,7 +54,7 @@ class ChannelArgsTest(unittest.TestCase):
             self.assertRaises(
                 ValueError,
                 grpc.insecure_channel,
-                "localhost:8080",
+                "127.0.0.1:8080",
                 options=invalid_arg,
             )
 

--- a/src/python/grpcio_tests/tests/unit/_channel_close_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_close_test.py
@@ -111,14 +111,14 @@ class ChannelCloseTest(unittest.TestCase):
             max_workers=test_constants.THREAD_CONCURRENCY
         )
         self._server.add_registered_method_handlers("", _METHOD_HANDLERS)
-        self._port = self._server.add_insecure_port("[::]:0")
+        self._port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
     def tearDown(self):
         self._server.stop(None)
 
     def test_close_immediately_after_call_invocation(self):
-        channel = grpc.insecure_channel("localhost:{}".format(self._port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(self._port))
         multi_callable = channel.stream_stream(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),
             _registered_method=True,
@@ -131,7 +131,7 @@ class ChannelCloseTest(unittest.TestCase):
         self.assertIs(response_iterator.code(), grpc.StatusCode.CANCELLED)
 
     def test_close_while_call_active(self):
-        channel = grpc.insecure_channel("localhost:{}".format(self._port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(self._port))
         multi_callable = channel.stream_stream(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),
             _registered_method=True,
@@ -146,7 +146,7 @@ class ChannelCloseTest(unittest.TestCase):
 
     def test_context_manager_close_while_call_active(self):
         with grpc.insecure_channel(
-            "localhost:{}".format(self._port)
+            "127.0.0.1:{}".format(self._port)
         ) as channel:
             multi_callable = channel.stream_stream(
                 grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),
@@ -161,7 +161,7 @@ class ChannelCloseTest(unittest.TestCase):
 
     def test_context_manager_close_while_many_calls_active(self):
         with grpc.insecure_channel(
-            "localhost:{}".format(self._port)
+            "127.0.0.1:{}".format(self._port)
         ) as channel:
             multi_callable = channel.stream_stream(
                 grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),
@@ -183,7 +183,7 @@ class ChannelCloseTest(unittest.TestCase):
             self.assertIs(response_iterator.code(), grpc.StatusCode.CANCELLED)
 
     def test_many_concurrent_closes(self):
-        channel = grpc.insecure_channel("localhost:{}".format(self._port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(self._port))
         multi_callable = channel.stream_stream(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),
             _registered_method=True,
@@ -212,7 +212,7 @@ class ChannelCloseTest(unittest.TestCase):
 
     def test_exception_in_callback(self):
         with grpc.insecure_channel(
-            "localhost:{}".format(self._port)
+            "127.0.0.1:{}".format(self._port)
         ) as channel:
             stream_multi_callable = channel.stream_stream(
                 grpc._common.fully_qualified_method(_SERVICE_NAME, _STREAM_URI),

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -92,12 +92,12 @@ class ChannelConnectivityTest(unittest.TestCase):
         server = grpc.server(
             recording_thread_pool, options=(("grpc.so_reuseport", 0),)
         )
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
         first_callback = _Callback()
         second_callback = _Callback()
 
-        channel = grpc.insecure_channel("localhost:{}".format(port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
         channel.subscribe(first_callback.update, try_to_connect=False)
         first_connectivities = (
             first_callback.block_until_connectivities_satisfy(bool)
@@ -152,11 +152,11 @@ class ChannelConnectivityTest(unittest.TestCase):
         server = grpc.server(
             recording_thread_pool, options=(("grpc.so_reuseport", 0),)
         )
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
         callback = _Callback()
 
-        channel = grpc.insecure_channel("localhost:{}".format(port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
         channel.subscribe(callback.update, try_to_connect=True)
         callback.block_until_connectivities_satisfy(_ready_in_connectivities)
         # Now take down the server and confirm that channel readiness is repudiated.

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -60,7 +60,7 @@ class ChannelConnectivityTest(unittest.TestCase):
     def test_lonely_channel_connectivity(self):
         callback = _Callback()
 
-        channel = grpc.insecure_channel("localhost:12345")
+        channel = grpc.insecure_channel("127.0.0.1:12345")
         channel.subscribe(callback.update, try_to_connect=False)
         first_connectivities = callback.block_until_connectivities_satisfy(bool)
         channel.subscribe(callback.update, try_to_connect=True)

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -68,9 +68,9 @@ class ChannelReadyFutureTest(unittest.TestCase):
         server = grpc.server(
             recording_thread_pool, options=(("grpc.so_reuseport", 0),)
         )
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
-        channel = grpc.insecure_channel("localhost:{}".format(port))
+        channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
         callback = _Callback()
 
         ready_future = grpc.channel_ready_future(channel)

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -42,7 +42,7 @@ class _Callback:
 
 class ChannelReadyFutureTest(unittest.TestCase):
     def test_lonely_channel_connectivity(self):
-        channel = grpc.insecure_channel("localhost:12345")
+        channel = grpc.insecure_channel("127.0.0.1:12345")
         callback = _Callback()
 
         ready_future = grpc.channel_ready_future(channel)

--- a/src/python/grpcio_tests/tests/unit/_compression_test.py
+++ b/src/python/grpcio_tests/tests/unit/_compression_test.py
@@ -36,7 +36,7 @@ _STREAM_STREAM = "StreamStream"
 # Cut down on test time.
 _STREAM_LENGTH = test_constants.STREAM_LENGTH // 16
 
-_HOST = "localhost"
+_HOST = "127.0.0.1"
 
 _REQUEST = b"\x00" * 100
 _COMPRESSION_RATIO_THRESHOLD = 0.05

--- a/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
@@ -161,10 +161,10 @@ class CancelManyCallsTest(unittest.TestCase):
             False,
         )
         server.register_completion_queue(server_completion_queue)
-        port = server.add_http2_port(b"[::]:0")
+        port = server.add_http2_port(b"127.0.0.1:0")
         server.start()
         channel = cygrpc.Channel(
-            "localhost:{}".format(port).encode(), None, None
+            "127.0.0.1:{}".format(port).encode(), None, None
         )
 
         state = _State()

--- a/src/python/grpcio_tests/tests/unit/_cython/_channel_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_channel_test.py
@@ -22,7 +22,7 @@ from tests.unit.framework.common import test_constants
 
 
 def _channel():
-    return cygrpc.Channel(b"localhost:54321", (), None)
+    return cygrpc.Channel(b"127.0.0.1:54321", (), None)
 
 
 def _connectivity_loop(channel):

--- a/src/python/grpcio_tests/tests/unit/_cython/_common.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_common.py
@@ -101,10 +101,10 @@ class RpcTest:
         self.server_completion_queue = cygrpc.CompletionQueue()
         self.server = cygrpc.Server([(b"grpc.so_reuseport", 0)], False)
         self.server.register_completion_queue(self.server_completion_queue)
-        port = self.server.add_http2_port(b"[::]:0")
+        port = self.server.add_http2_port(b"127.0.0.1:0")
         self.server.start()
         self.channel = cygrpc.Channel(
-            "localhost:{}".format(port).encode(), [], None
+            "127.0.0.1:{}".format(port).encode(), [], None
         )
 
         self._server_shutdown_tag = "server_shutdown_tag"

--- a/src/python/grpcio_tests/tests/unit/_cython/_read_some_but_not_all_responses_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_read_some_but_not_all_responses_test.py
@@ -118,10 +118,10 @@ class ReadSomeButNotAllResponsesTest(unittest.TestCase):
             False,
         )
         server.register_completion_queue(server_completion_queue)
-        port = server.add_http2_port(b"[::]:0")
+        port = server.add_http2_port(b"127.0.0.1:0")
         server.start()
         channel = cygrpc.Channel(
-            "localhost:{}".format(port).encode(), set(), None
+            "127.0.0.1:{}".format(port).encode(), set(), None
         )
 
         server_shutdown_tag = "server_shutdown_tag"

--- a/src/python/grpcio_tests/tests/unit/_cython/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_server_test.py
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
         server = cygrpc.Server(None, False)
         server.register_completion_queue(server_call_completion_queue)
         server.register_completion_queue(server_shutdown_completion_queue)
-        port = server.add_http2_port(b"[::]:0")
+        port = server.add_http2_port(b"127.0.0.1:0")
         server.start()
 
         server_request_call_tag = "server_request_call_tag"

--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -62,7 +62,7 @@ class TypeSmokeTest(unittest.TestCase):
         del server
 
     def testChannelUpDown(self):
-        channel = cygrpc.Channel(b"[::]:0", None, None)
+        channel = cygrpc.Channel(b"127.0.0.1:0", None, None)
         channel.close(cygrpc.StatusCode.cancelled, "Test method anyway!")
 
     def test_metadata_plugin_call_credentials_up_down(self):
@@ -82,7 +82,7 @@ class TypeSmokeTest(unittest.TestCase):
         )
         completion_queue = cygrpc.CompletionQueue()
         server.register_completion_queue(completion_queue)
-        port = server.add_http2_port(b"[::]:0")
+        port = server.add_http2_port(b"127.0.0.1:0")
         self.assertIsInstance(port, int)
         server.start()
         del server
@@ -98,7 +98,7 @@ class TypeSmokeTest(unittest.TestCase):
             ],
             False,
         )
-        server.add_http2_port(b"[::]:0")
+        server.add_http2_port(b"127.0.0.1:0")
         server.register_completion_queue(completion_queue)
         server.start()
         shutdown_tag = object()
@@ -127,10 +127,10 @@ class ServerClientMixin:
         self.server.register_completion_queue(self.server_completion_queue)
         if server_credentials:
             self.port = self.server.add_http2_port(
-                b"[::]:0", server_credentials
+                b"127.0.0.1:0", server_credentials
             )
         else:
-            self.port = self.server.add_http2_port(b"[::]:0")
+            self.port = self.server.add_http2_port(b"127.0.0.1:0")
         self.server.start()
         self.client_completion_queue = cygrpc.CompletionQueue()
         if client_credentials:

--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -141,13 +141,13 @@ class ServerClientMixin:
                 ),
             )
             self.client_channel = cygrpc.Channel(
-                "localhost:{}".format(self.port).encode(),
+                "127.0.0.1:{}".format(self.port).encode(),
                 client_channel_arguments,
                 client_credentials,
             )
         else:
             self.client_channel = cygrpc.Channel(
-                "localhost:{}".format(self.port).encode(), set(), None
+                "127.0.0.1:{}".format(self.port).encode(), set(), None
             )
         if host_override:
             self.host_argument = None  # default host

--- a/src/python/grpcio_tests/tests/unit/_dns_resolver_test.py
+++ b/src/python/grpcio_tests/tests/unit/_dns_resolver_test.py
@@ -40,7 +40,7 @@ class DNSResolverTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _METHOD_HANDLERS
         )
-        self._port = self._server.add_insecure_port("[::]:0")
+        self._port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
     def tearDown(self):

--- a/src/python/grpcio_tests/tests/unit/_empty_message_test.py
+++ b/src/python/grpcio_tests/tests/unit/_empty_message_test.py
@@ -84,9 +84,9 @@ class EmptyMessageTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _METHOD_HANDLERS
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(0)

--- a/src/python/grpcio_tests/tests/unit/_error_message_encoding_test.py
+++ b/src/python/grpcio_tests/tests/unit/_error_message_encoding_test.py
@@ -59,9 +59,9 @@ class ErrorMessageEncodingTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _METHOD_HANDLERS
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(0)

--- a/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
             time.sleep(WAIT_TIME)
     elif args.scenario == RUNNING_SERVER:
         server = grpc.server(DaemonPool(), options=(("grpc.so_reuseport", 0),))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
         if args.wait_for_interrupt:
             time.sleep(WAIT_TIME)
@@ -200,9 +200,9 @@ if __name__ == "__main__":
             time.sleep(WAIT_TIME)
     elif args.scenario == POLL_CONNECTIVITY:
         server = grpc.server(DaemonPool(), options=(("grpc.so_reuseport", 0),))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
-        channel = grpc.insecure_channel("localhost:%d" % port)
+        channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         def connectivity_callback(connectivity):
             pass
@@ -213,10 +213,10 @@ if __name__ == "__main__":
 
     else:
         server = grpc.server(DaemonPool(), options=(("grpc.so_reuseport", 0),))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
         server.start()
-        channel = grpc.insecure_channel("localhost:%d" % port)
+        channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         method = (
             grpc._common.fully_qualified_method(

--- a/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         if args.wait_for_interrupt:
             time.sleep(WAIT_TIME)
     elif args.scenario == POLL_CONNECTIVITY_NO_SERVER:
-        channel = grpc.insecure_channel("localhost:12345")
+        channel = grpc.insecure_channel("127.0.0.1:12345")
 
         def connectivity_callback(connectivity):
             pass

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -490,13 +490,13 @@ class InterceptorTest(unittest.TestCase):
                 _LoggingInterceptor("s2", self._record),
             ),
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, get_method_handlers(self._handler)
         )
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(None)

--- a/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
@@ -66,7 +66,7 @@ def _stream_stream_multi_callable(channel):
 
 class InvalidMetadataTest(unittest.TestCase):
     def setUp(self):
-        self._channel = grpc.insecure_channel("localhost:8080")
+        self._channel = grpc.insecure_channel("127.0.0.1:8080")
         self._unary_unary = _unary_unary_multi_callable(self._channel)
         self._unary_stream = _unary_stream_multi_callable(self._channel)
         self._stream_unary = _stream_unary_multi_callable(self._channel)

--- a/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
@@ -276,13 +276,13 @@ class InvocationDefectsTest(unittest.TestCase):
         self._handler = _Handler(self._control)
 
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, get_method_handlers(self._handler)
         )
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(0)

--- a/src/python/grpcio_tests/tests/unit/_local_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_local_credentials_test.py
@@ -38,7 +38,7 @@ class LocalCredentialsTest(unittest.TestCase):
         os.name == "nt", "TODO(https://github.com/grpc/grpc/issues/20078)"
     )
     def test_local_tcp(self):
-        server_addr = "localhost:{}"
+        server_addr = "127.0.0.1:{}"
         channel_creds = grpc.local_channel_credentials(
             grpc.LocalConnectionType.LOCAL_TCP
         )

--- a/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
@@ -202,10 +202,10 @@ class MetadataCodeDetailsTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE, get_method_handlers(self._servicer)
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:{}".format(port))
+        self._channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
         unary_unary_method_name = "/".join(
             (
                 "",
@@ -831,10 +831,10 @@ class InspectContextTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE, get_method_handlers(self._servicer)
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:{}".format(port))
+        self._channel = grpc.insecure_channel("127.0.0.1:{}".format(port))
         unary_unary_method_name = "/".join(
             (
                 "",

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -238,6 +238,7 @@ class MetadataFlagsTest(unittest.TestCase):
         #   exceptions and raise them again in main thread.
         unhandled_exceptions = queue.Queue()
 
+        # We just need an unused TCP port
         host, port, sock = get_socket(
             bind_address="127.0.0.1", sock_options=(socket.SO_REUSEADDR,)
         )

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -238,8 +238,9 @@ class MetadataFlagsTest(unittest.TestCase):
         #   exceptions and raise them again in main thread.
         unhandled_exceptions = queue.Queue()
 
-        # We just need an unused TCP port
-        host, port, sock = get_socket(sock_options=(socket.SO_REUSEADDR,))
+        host, port, sock = get_socket(
+            bind_address="127.0.0.1", sock_options=(socket.SO_REUSEADDR,)
+        )
         sock.close()
 
         addr = "{}:{}".format(host, port)

--- a/src/python/grpcio_tests/tests/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_test.py
@@ -177,10 +177,10 @@ class MetadataTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, get_method_handlers(weakref.proxy(self))
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel(
-            "localhost:%d" % port, options=_CHANNEL_ARGS
+            "127.0.0.1:%d" % port, options=_CHANNEL_ARGS
         )
 
     def tearDown(self):

--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -59,7 +59,9 @@ class TestServer:
 
     def __init__(self):
         self.pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
-        self.host, self.port, self._sock = test_common.get_socket(listen=False)
+        self.host, self.port, self._sock = test_common.get_socket(
+            bind_address="127.0.0.1", listen=False
+        )
 
     @property
     def addr(self) -> str:

--- a/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
+++ b/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
@@ -135,9 +135,9 @@ class ResourceExhaustedTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, get_method_handlers(self._trigger)
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(0)

--- a/src/python/grpcio_tests/tests/unit/_rpc_test_helpers.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test_helpers.py
@@ -401,13 +401,13 @@ class BaseRPCTest:
         self._handler = _Handler(self._control, self._thread_pool)
 
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, get_method_handlers(self._handler)
         )
         self._server.start()
 
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
     def tearDown(self):
         self._server.stop(None)

--- a/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
@@ -60,7 +60,7 @@ _METHOD_HANDLERS = {
 
 def run_server(port_queue):
     server = test_common.test_server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     port_queue.put(port)
     server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
     server.start()
@@ -86,7 +86,7 @@ def run_test(args):
         thread.daemon = True
         thread.start()
         port = port_queue.get()
-        channel = grpc.insecure_channel("localhost:%d" % port)
+        channel = grpc.insecure_channel("127.0.0.1:%d" % port)
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, FORK_EXIT),
             _registered_method=True,

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -78,7 +78,7 @@ Call = collections.namedtuple("Call", ["did_raise", "returned_cert_config"])
 
 
 def _create_channel(port, credentials):
-    return grpc.secure_channel("localhost:{}".format(port), credentials)
+    return grpc.secure_channel("127.0.0.1:{}".format(port), credentials)
 
 
 def _create_client_stub(channel, expect_success):

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -151,7 +151,7 @@ class _ServerSSLCertReloadTest(unittest.TestCase, metaclass=abc.ABCMeta):
             self.cert_config_fetcher,
             require_client_authentication=self.require_client_auth(),
         )
-        self.port = self.server.add_secure_port("[::]:0", server_credentials)
+        self.port = self.server.add_secure_port("127.0.0.1:0", server_credentials)
         self.server.start()
 
     def tearDown(self):
@@ -457,7 +457,7 @@ class ServerSSLCertReloadTestCertConfigReuse(_ServerSSLCertReloadTest):
             self.cert_config_fetcher,
             require_client_authentication=True,
         )
-        self.port = self.server.add_secure_port("[::]:0", server_credentials)
+        self.port = self.server.add_secure_port("127.0.0.1:0", server_credentials)
         self.server.start()
 
     def test_cert_config_reuse(self):

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -151,7 +151,9 @@ class _ServerSSLCertReloadTest(unittest.TestCase, metaclass=abc.ABCMeta):
             self.cert_config_fetcher,
             require_client_authentication=self.require_client_auth(),
         )
-        self.port = self.server.add_secure_port("127.0.0.1:0", server_credentials)
+        self.port = self.server.add_secure_port(
+            "127.0.0.1:0", server_credentials
+        )
         self.server.start()
 
     def tearDown(self):
@@ -457,7 +459,9 @@ class ServerSSLCertReloadTestCertConfigReuse(_ServerSSLCertReloadTest):
             self.cert_config_fetcher,
             require_client_authentication=True,
         )
-        self.port = self.server.add_secure_port("127.0.0.1:0", server_credentials)
+        self.port = self.server.add_secure_port(
+            "127.0.0.1:0", server_credentials
+        )
         self.server.start()
 
     def test_cert_config_reuse(self):

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -148,8 +148,8 @@ class ServerTest(unittest.TestCase):
 
     def test_failed_port_binding_exception(self):
         server = grpc.server(None, options=(("grpc.so_reuseport", 0),))
-        port = server.add_insecure_port("localhost:0")
-        bind_address = "localhost:%d" % port
+        port = server.add_insecure_port("127.0.0.1:0")
+        bind_address = "127.0.0.1:%d" % port
 
         with self.assertRaises(RuntimeError):
             server.add_insecure_port(bind_address)
@@ -171,7 +171,7 @@ class ServerHandlerTest(unittest.TestCase):
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         response = self._channel.unary_unary(
             _UNARY_UNARY,
@@ -184,7 +184,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         response_iterator = self._channel.unary_stream(
             _UNARY_STREAM,
@@ -199,7 +199,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         response = self._channel.stream_unary(
             _STREAM_UNARY,
@@ -212,7 +212,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         response_iterator = self._channel.stream_stream(
             _STREAM_STREAM,
@@ -227,7 +227,7 @@ class ServerHandlerTest(unittest.TestCase):
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         response = self._channel.unary_unary(
             _UNARY_UNARY,
@@ -242,7 +242,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
         )
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         with self.assertRaises(grpc.RpcError) as exception_context:
             self._channel.unary_unary(
@@ -262,7 +262,7 @@ class ServerHandlerTest(unittest.TestCase):
         )
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         generic_response = self._channel.unary_unary(
             _UNARY_UNARY,
@@ -290,7 +290,7 @@ class ServerHandlerTest(unittest.TestCase):
         )
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        self._channel = grpc.insecure_channel("localhost:%d" % port)
+        self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
         registered_response = self._channel.unary_unary(
             grpc._common.fully_qualified_method(

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -168,7 +168,7 @@ class ServerHandlerTest(unittest.TestCase):
 
     def test_generic_unary_unary_handler(self):
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
@@ -182,7 +182,7 @@ class ServerHandlerTest(unittest.TestCase):
     def test_generic_unary_stream_handler(self):
         self._server = test_common.test_server()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
@@ -197,7 +197,7 @@ class ServerHandlerTest(unittest.TestCase):
     def test_generic_stream_unary_handler(self):
         self._server = test_common.test_server()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
@@ -210,7 +210,7 @@ class ServerHandlerTest(unittest.TestCase):
     def test_generic_stream_stream_handler(self):
         self._server = test_common.test_server()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
@@ -224,7 +224,7 @@ class ServerHandlerTest(unittest.TestCase):
 
     def test_add_generic_handler_after_server_start(self):
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
@@ -237,7 +237,7 @@ class ServerHandlerTest(unittest.TestCase):
 
     def test_add_registered_handler_after_server_start(self):
         self._server = test_common.test_server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
@@ -260,7 +260,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 
@@ -288,7 +288,7 @@ class ServerHandlerTest(unittest.TestCase):
         self._server.add_registered_method_handlers(
             _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         self._server.start()
         self._channel = grpc.insecure_channel("127.0.0.1:%d" % port)
 

--- a/src/python/grpcio_tests/tests/unit/_session_cache_test.py
+++ b/src/python/grpcio_tests/tests/unit/_session_cache_test.py
@@ -77,7 +77,7 @@ class SSLSessionCacheTest(unittest.TestCase):
         self, channel_creds, channel_options, port, expect_ssl_session_reused
     ):
         channel = grpc.secure_channel(
-            "localhost:{}".format(port), channel_creds, options=channel_options
+            "127.0.0.1:{}".format(port), channel_creds, options=channel_options
         )
         response = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),

--- a/src/python/grpcio_tests/tests/unit/_session_cache_test.py
+++ b/src/python/grpcio_tests/tests/unit/_session_cache_test.py
@@ -66,7 +66,7 @@ def start_secure_server():
     server = test_common.test_server()
     server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
     server_cred = grpc.ssl_server_credentials(_SERVER_CERTS)
-    port = server.add_secure_port("[::]:0", server_cred)
+    port = server.add_secure_port("127.0.0.1:0", server_cred)
     server.start()
 
     return server, port

--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -40,7 +40,7 @@ else:
         os.path.join(os.path.dirname(os.path.abspath(__file__)), client_name)
     )
 
-_HOST = "localhost"
+_HOST = "127.0.0.1"
 
 # The gevent test harness cannot run the monkeypatch code for the child process,
 # so we need to instrument it manually.

--- a/src/python/grpcio_tests/tests/unit/_xds_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_xds_credentials_test.py
@@ -42,10 +42,10 @@ def xds_channel_server_without_xds(server_fallback_creds):
         ((resources.private_key(), resources.certificate_chain()),)
     )
     server_creds = grpc.xds_server_credentials(server_fallback_creds)
-    port = server.add_secure_port("localhost:0", server_creds)
+    port = server.add_secure_port("127.0.0.1:0", server_creds)
     server.start()
     try:
-        yield "localhost:{}".format(port)
+        yield "127.0.0.1:{}".format(port)
     finally:
         server.stop(None)
 
@@ -103,7 +103,7 @@ class XdsCredentialsTest(unittest.TestCase):
         server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
         server_fallback_creds = grpc.insecure_server_credentials()
         server_creds = grpc.xds_server_credentials(server_fallback_creds)
-        port = server.add_secure_port("localhost:0", server_creds)
+        port = server.add_secure_port("127.0.0.1:0", server_creds)
         server.start()
         server.stop(None)
         # No exceptions thrown. A more comprehensive suite of tests will be

--- a/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
@@ -181,7 +181,7 @@ class BetaFeaturesTest(unittest.TestCase):
                 ),
             ]
         )
-        port = self._server.add_secure_port("[::]:0", server_credentials)
+        port = self._server.add_secure_port("127.0.0.1:0", server_credentials)
         self._server.start()
         self._channel_credentials = implementations.ssl_channel_credentials(
             resources.test_root_certificates()
@@ -352,7 +352,7 @@ class ContextManagementAndLifecycleTest(unittest.TestCase):
         server = implementations.server(
             self._method_implementations, options=self._server_options
         )
-        port = server.add_secure_port("[::]:0", self._server_credentials)
+        port = server.add_secure_port("127.0.0.1:0", self._server_credentials)
         server.start()
 
         channel = test_utilities.not_really_secure_channel(
@@ -384,15 +384,15 @@ class ContextManagementAndLifecycleTest(unittest.TestCase):
             server = implementations.server(
                 self._method_implementations, options=self._server_options
             )
-            port = server.add_secure_port("[::]:0", self._server_credentials)
+            port = server.add_secure_port("127.0.0.1:0", self._server_credentials)
             server.start()
             server.stop(test_constants.SHORT_TIMEOUT).wait()
         for _ in range(100):
             server = implementations.server(
                 self._method_implementations, options=self._server_options
             )
-            server.add_secure_port("[::]:0", self._server_credentials)
-            server.add_insecure_port("[::]:0")
+            server.add_secure_port("127.0.0.1:0", self._server_credentials)
+            server.add_insecure_port("127.0.0.1:0")
             with server:
                 server.stop(test_constants.SHORT_TIMEOUT)
             server.stop(test_constants.SHORT_TIMEOUT)

--- a/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
@@ -384,7 +384,9 @@ class ContextManagementAndLifecycleTest(unittest.TestCase):
             server = implementations.server(
                 self._method_implementations, options=self._server_options
             )
-            port = server.add_secure_port("127.0.0.1:0", self._server_credentials)
+            port = server.add_secure_port(
+                "127.0.0.1:0", self._server_credentials
+            )
             server.start()
             server.stop(test_constants.SHORT_TIMEOUT).wait()
         for _ in range(100):

--- a/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
@@ -190,7 +190,7 @@ class BetaFeaturesTest(unittest.TestCase):
             _metadata_plugin
         )
         channel = test_utilities.not_really_secure_channel(
-            "localhost", port, self._channel_credentials, _SERVER_HOST_OVERRIDE
+            "127.0.0.1", port, self._channel_credentials, _SERVER_HOST_OVERRIDE
         )
         stub_options = implementations.stub_options(
             thread_pool_size=test_constants.POOL_SIZE
@@ -356,7 +356,7 @@ class ContextManagementAndLifecycleTest(unittest.TestCase):
         server.start()
 
         channel = test_utilities.not_really_secure_channel(
-            "localhost", port, self._channel_credentials, _SERVER_HOST_OVERRIDE
+            "127.0.0.1", port, self._channel_credentials, _SERVER_HOST_OVERRIDE
         )
         dynamic_stub = implementations.dynamic_stub(
             channel, _GROUP, self._cardinalities, options=self._stub_options

--- a/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
@@ -25,8 +25,8 @@ from tests.unit.framework.common import test_constants
 class NotFoundTest(unittest.TestCase):
     def setUp(self):
         self._server = implementations.server({})
-        port = self._server.add_insecure_port("[::]:0")
-        channel = implementations.insecure_channel("localhost", port)
+        port = self._server.add_insecure_port("127.0.0.1:0")
+        channel = implementations.insecure_channel("127.0.0.1", port)
         self._generic_stub = implementations.generic_stub(channel)
         self._server.start()
 

--- a/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
@@ -63,7 +63,7 @@ class ChannelConnectivityTest(unittest.TestCase):
 
     def test_immediately_connectable_channel_connectivity(self):
         server = implementations.server({})
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
         channel = implementations.insecure_channel("localhost", port)
         callback = _Callback()

--- a/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
@@ -44,7 +44,7 @@ class _Callback:
 @unittest.skip("https://github.com/grpc/grpc/issues/16134")
 class ChannelConnectivityTest(unittest.TestCase):
     def test_lonely_channel_connectivity(self):
-        channel = implementations.insecure_channel("localhost", 12345)
+        channel = implementations.insecure_channel("127.0.0.1", 12345)
         callback = _Callback()
 
         ready_future = utilities.channel_ready_future(channel)
@@ -65,7 +65,7 @@ class ChannelConnectivityTest(unittest.TestCase):
         server = implementations.server({})
         port = server.add_insecure_port("127.0.0.1:0")
         server.start()
-        channel = implementations.insecure_channel("localhost", port)
+        channel = implementations.insecure_channel("127.0.0.1", port)
         callback = _Callback()
 
         try:

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -26,7 +26,7 @@ _UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE, errno.ENOSR)
 
 
 def get_socket(
-    bind_address="localhost",
+    bind_address="127.0.0.1",
     port=0,
     listen=True,
     sock_options=_DEFAULT_SOCK_OPTIONS,
@@ -81,7 +81,7 @@ def get_socket(
 
 @contextlib.contextmanager
 def bound_socket(
-    bind_address="localhost",
+    bind_address="127.0.0.1",
     port=0,
     listen=True,
     sock_options=_DEFAULT_SOCK_OPTIONS,

--- a/src/python/grpcio_tests/tests_aio/benchmark/server.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/server.py
@@ -25,7 +25,7 @@ from tests_aio.benchmark import benchmark_servicer
 async def _start_async_server():
     server = aio.server()
 
-    port = server.add_insecure_port("localhost:%s" % 50051)
+    port = server.add_insecure_port("127.0.0.1:%s" % 50051)
     servicer = benchmark_servicer.BenchmarkServicer()
     benchmark_service_pb2_grpc.add_BenchmarkServiceServicer_to_server(
         servicer, server

--- a/src/python/grpcio_tests/tests_aio/benchmark/worker.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/worker.py
@@ -30,7 +30,7 @@ async def run_worker_server(port: int) -> None:
         servicer, server
     )
 
-    server.add_insecure_port("[::]:{}".format(port))
+    server.add_insecure_port("127.0.0.1:{}".format(port))
 
     await server.start()
 

--- a/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
@@ -187,7 +187,7 @@ async def _create_sub_worker() -> _SubWorker:
         port,
         process.pid,
     )
-    channel = aio.insecure_channel(f"localhost:{port}")
+    channel = aio.insecure_channel(f"127.0.0.1:{port}")
     _LOGGER.info("Waiting for sub worker at port [%d]", port)
     await channel.channel_ready()
     stub = worker_service_pb2_grpc.WorkerServiceStub(channel)

--- a/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
+++ b/src/python/grpcio_tests/tests_aio/benchmark/worker_servicer.py
@@ -114,10 +114,10 @@ def _create_server(config: control_pb2.ServerConfig) -> Tuple[aio.Server, int]:
             ((resources.private_key(), resources.certificate_chain()),)
         )
         port = server.add_secure_port(
-            "[::]:{}".format(config.port), server_creds
+            "127.0.0.1:{}".format(config.port), server_creds
         )
     else:
-        port = server.add_insecure_port("[::]:{}".format(config.port))
+        port = server.add_insecure_port("127.0.0.1:{}".format(config.port))
 
     return server, port
 

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -80,8 +80,8 @@ class _ChannelServerPair:
     async def start(self):
         # Server will enable channelz service
         self.server = aio.server(options=_DISABLE_REUSE_PORT + _ENABLE_CHANNELZ)
-        port = self.server.add_insecure_port("[::]:0")
-        self.address = "localhost:%d" % port
+        port = self.server.add_insecure_port("127.0.0.1:0")
+        self.address = "127.0.0.1:%d" % port
         self.server.add_generic_rpc_handlers((_GenericHandler(),))
         await self.server.start()
 
@@ -130,14 +130,14 @@ class ChannelzServicerTest(AioTestBase):
         self._server = aio.server(
             options=_DISABLE_REUSE_PORT + _DISABLE_CHANNELZ
         )
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         channelz.add_channelz_servicer(self._server)
         await self._server.start()
 
         # This channel is used to fetch Channelz info only
         # Channelz should not be enabled
         self._channel = aio.insecure_channel(
-            "localhost:%d" % port, options=_DISABLE_CHANNELZ
+            "127.0.0.1:%d" % port, options=_DISABLE_CHANNELZ
         )
         self._channelz_stub = channelz_pb2_grpc.ChannelzStub(self._channel)
 

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -54,13 +54,13 @@ class HealthServicerTest(AioTestBase):
             _NOT_SERVING_SERVICE, health_pb2.HealthCheckResponse.NOT_SERVING
         )
         self._server = aio.server()
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         health_pb2_grpc.add_HealthServicer_to_server(
             self._servicer, self._server
         )
         await self._server.start()
 
-        self._channel = aio.insecure_channel("localhost:%d" % port)
+        self._channel = aio.insecure_channel("127.0.0.1:%d" % port)
         self._stub = health_pb2_grpc.HealthStub(self._channel)
 
     async def tearDown(self):

--- a/src/python/grpcio_tests/tests_aio/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/observability/_test_server.py
@@ -69,7 +69,7 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 async def start_server() -> Tuple[grpc.aio.Server, int]:
     server = grpc.aio.server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     generic_handler = _GenericHandler()
     server.add_generic_rpc_handlers((generic_handler,))
     await server.start()
@@ -77,13 +77,13 @@ async def start_server() -> Tuple[grpc.aio.Server, int]:
 
 
 async def unary_unary_call(port):
-    async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+    async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.unary_unary(_UNARY_UNARY)
         unused_response = await multi_callable(_REQUEST)
 
 
 async def unary_stream_call(port):
-    async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+    async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.unary_stream(_UNARY_STREAM)
         call = multi_callable(_REQUEST)
         async for _ in call:
@@ -91,14 +91,14 @@ async def unary_stream_call(port):
 
 
 async def stream_unary_call(port):
-    async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+    async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.stream_unary(_STREAM_UNARY)
         call = multi_callable(iter([_REQUEST] * STREAM_LENGTH))
         unused_response = await call
 
 
 async def stream_stream_call(port):
-    async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+    async with grpc.aio.insecure_channel(f"127.0.0.1:{port}") as channel:
         multi_callable = channel.stream_stream(_STREAM_STREAM)
         call = multi_callable(iter([_REQUEST] * STREAM_LENGTH))
         async for _ in call:

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -43,8 +43,8 @@ class OTelMetricExporter(otel_metrics_export.MetricExporter):
         value is a list of labels recorded for that metric.
         An example item of this dict:
             {"grpc.client.attempt.started":
-              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': 'localhost:42517'},
-               {'grpc.method': 'other', 'grpc.target': 'localhost:42517'}]}
+              [{'grpc.method': 'test/UnaryUnary', 'grpc.target': '127.0.0.1:42517'},
+               {'grpc.method': 'other', 'grpc.target': '127.0.0.1:42517'}]}
     """
 
     def __init__(

--- a/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
@@ -59,10 +59,10 @@ class ReflectionServicerTest(AioTestBase):
     async def setUp(self):
         self._server = aio.server()
         reflection.enable_server_reflection(_SERVICE_NAMES, self._server)
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         await self._server.start()
 
-        self._channel = aio.insecure_channel("localhost:%d" % port)
+        self._channel = aio.insecure_channel("127.0.0.1:%d" % port)
         self._stub = reflection_pb2_grpc.ServerReflectionStub(self._channel)
 
     async def tearDown(self):

--- a/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
+++ b/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
@@ -113,10 +113,10 @@ class StatusTest(AioTestBase):
     async def setUp(self):
         self._server = aio.server()
         self._server.add_generic_rpc_handlers((_GenericHandler(),))
-        port = self._server.add_insecure_port("[::]:0")
+        port = self._server.add_insecure_port("127.0.0.1:0")
         await self._server.start()
 
-        self._channel = aio.insecure_channel("localhost:%d" % port)
+        self._channel = aio.insecure_channel("127.0.0.1:%d" % port)
 
     async def tearDown(self):
         await self._server.stop(None)

--- a/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
@@ -83,10 +83,10 @@ class UnaryUnaryAddMetadataInterceptor(aio.UnaryUnaryClientInterceptor):
 
 async def _start_test_server(options=None):
     server = aio.server(options=options)
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.add_generic_rpc_handlers((_GenericHandler(),))
     await server.start()
-    return f"localhost:{port}", server
+    return f"127.0.0.1:{port}", server
 
 
 class TestTypeMetadata(unittest.TestCase):

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -179,7 +179,7 @@ async def start_test_server(
                 [(resources.private_key(), resources.certificate_chain())]
             )
         port = server.add_secure_port("[::]:%d" % port, server_credentials)
-        host = "localhost"
+        host = "127.0.0.1"
     else:
         port = server.add_insecure_port("127.0.0.1:%d" % port)
         host = "127.0.0.1"

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -179,10 +179,12 @@ async def start_test_server(
                 [(resources.private_key(), resources.certificate_chain())]
             )
         port = server.add_secure_port("[::]:%d" % port, server_credentials)
+        host = "localhost"
     else:
-        port = server.add_insecure_port("[::]:%d" % port)
+        port = server.add_insecure_port("127.0.0.1:%d" % port)
+        host = "127.0.0.1"
 
     await server.start()
 
     # NOTE(lidizheng) returning the server to prevent it from deallocation
-    return "localhost:%d" % port, server
+    return "%s:%d" % (host, port), server

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -178,7 +178,7 @@ async def start_test_server(
             server_credentials = grpc.ssl_server_credentials(
                 [(resources.private_key(), resources.certificate_chain())]
             )
-        port = server.add_secure_port("[::]:%d" % port, server_credentials)
+        port = server.add_secure_port("127.0.0.1:%d" % port, server_credentials)
         host = "127.0.0.1"
     else:
         port = server.add_insecure_port("127.0.0.1:%d" % port)

--- a/src/python/grpcio_tests/tests_aio/unit/abort_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/abort_test.py
@@ -79,10 +79,10 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 async def _start_test_server():
     server = aio.server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.add_generic_rpc_handlers((_GenericHandler(),))
     await server.start()
-    return "localhost:%d" % port, server
+    return "127.0.0.1:%d" % port, server
 
 
 class TestAbort(AioTestBase):

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -76,7 +76,7 @@ class TestAuthContext(AioTestBase):
         )
         server = aio.server()
         server.add_generic_rpc_handlers((handler,))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
 
         async with aio.insecure_channel("127.0.0.1:%d" % port) as channel:
@@ -106,7 +106,7 @@ class TestAuthContext(AioTestBase):
         server = aio.server()
         server.add_generic_rpc_handlers((handler,))
         server_cred = grpc.ssl_server_credentials(_SERVER_CERTS)
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         await server.start()
 
         channel_creds = grpc.ssl_channel_credentials(
@@ -149,7 +149,7 @@ class TestAuthContext(AioTestBase):
             root_certificates=_TEST_ROOT_CERTIFICATES,
             require_client_auth=True,
         )
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         await server.start()
 
         channel_creds = grpc.ssl_channel_credentials(
@@ -203,7 +203,7 @@ class TestAuthContext(AioTestBase):
         server = aio.server()
         server.add_generic_rpc_handlers((handler,))
         server_cred = grpc.ssl_server_credentials(_SERVER_CERTS)
-        port = server.add_secure_port("[::]:0", server_cred)
+        port = server.add_secure_port("127.0.0.1:0", server_cred)
         await server.start()
 
         # Create a cache for TLS session tickets

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -79,7 +79,7 @@ class TestAuthContext(AioTestBase):
         port = server.add_insecure_port("[::]:0")
         await server.start()
 
-        async with aio.insecure_channel("localhost:%d" % port) as channel:
+        async with aio.insecure_channel("127.0.0.1:%d" % port) as channel:
             response = await channel.unary_unary(_UNARY_UNARY)(_REQUEST)
         await server.stop(None)
 
@@ -113,7 +113,7 @@ class TestAuthContext(AioTestBase):
             root_certificates=_TEST_ROOT_CERTIFICATES
         )
         channel = aio.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             channel_creds,
             options=_PROPERTY_OPTIONS,
         )
@@ -158,7 +158,7 @@ class TestAuthContext(AioTestBase):
             certificate_chain=_CERTIFICATE_CHAIN,
         )
         channel = aio.secure_channel(
-            "localhost:{}".format(port),
+            "127.0.0.1:{}".format(port),
             channel_creds,
             options=_PROPERTY_OPTIONS,
         )
@@ -180,7 +180,7 @@ class TestAuthContext(AioTestBase):
         self, channel_creds, channel_options, port, expect_ssl_session_reused
     ):
         channel = aio.secure_channel(
-            "localhost:{}".format(port), channel_creds, options=channel_options
+            "127.0.0.1:{}".format(port), channel_creds, options=channel_options
         )
         response = await channel.unary_unary(_UNARY_UNARY)(_REQUEST)
         auth_data = pickle.loads(response)

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -124,7 +124,9 @@ class TestChannelArgument(AioTestBase):
 
     async def test_client(self):
         # Do not segfault, or raise exception!
-        channel = aio.insecure_channel("127.0.0.1:0", options=_TEST_CHANNEL_ARGS)
+        channel = aio.insecure_channel(
+            "127.0.0.1:0", options=_TEST_CHANNEL_ARGS
+        )
         await channel.close()
 
     async def test_server(self):

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -69,12 +69,12 @@ _INVALID_TEST_CHANNEL_ARGS = [
 
 
 async def test_if_reuse_port_enabled(server: aio.Server):
-    port = server.add_insecure_port("localhost:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     await server.start()
 
     try:
         with common.bound_socket(
-            bind_address="localhost",
+            bind_address="127.0.0.1",
             port=port,
             listen=False,
         ) as (unused_host, bound_port):
@@ -124,7 +124,7 @@ class TestChannelArgument(AioTestBase):
 
     async def test_client(self):
         # Do not segfault, or raise exception!
-        channel = aio.insecure_channel("[::]:0", options=_TEST_CHANNEL_ARGS)
+        channel = aio.insecure_channel("127.0.0.1:0", options=_TEST_CHANNEL_ARGS)
         await channel.close()
 
     async def test_server(self):
@@ -138,7 +138,7 @@ class TestChannelArgument(AioTestBase):
             self.assertRaises(
                 (ValueError, TypeError),
                 aio.insecure_channel,
-                "[::]:0",
+                "127.0.0.1:0",
                 options=invalid_arg,
             )
 

--- a/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
@@ -60,8 +60,8 @@ class TestCompatibility(AioTestBase):
         self._adhoc_handlers = _common.AdhocGenericHandler()
         self._async_server.add_generic_rpc_handlers((self._adhoc_handlers,))
 
-        port = self._async_server.add_insecure_port("[::]:0")
-        address = "localhost:%d" % port
+        port = self._async_server.add_insecure_port("127.0.0.1:0")
+        address = "127.0.0.1:%d" % port
         await self._async_server.start()
 
         # Create async stub
@@ -196,12 +196,12 @@ class TestCompatibility(AioTestBase):
         server = grpc.server(
             ThreadPoolExecutor(), handlers=(GenericHandlers(),)
         )
-        port = server.add_insecure_port("localhost:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.start()
 
         def sync_work() -> None:
             for _ in range(100):
-                with grpc.insecure_channel("localhost:%d" % port) as channel:
+                with grpc.insecure_channel("127.0.0.1:%d" % port) as channel:
                     response = channel.unary_unary("/test/test")(b"\x07\x08")
                     self.assertEqual(response, b"\x07\x08")
 

--- a/src/python/grpcio_tests/tests_aio/unit/compression_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/compression_test.py
@@ -103,10 +103,10 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 async def _start_test_server(options=None):
     server = aio.server(options=options)
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.add_generic_rpc_handlers((_GenericHandler(),))
     await server.start()
-    return f"localhost:{port}", server
+    return f"127.0.0.1:{port}", server
 
 
 class TestCompression(AioTestBase):
@@ -187,11 +187,11 @@ class TestCompression(AioTestBase):
 
     async def test_server_default_compression_algorithm(self):
         server = aio.server(compression=grpc.Compression.Deflate)
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         server.add_generic_rpc_handlers((_GenericHandler(),))
         await server.start()
 
-        async with aio.insecure_channel(f"localhost:{port}") as channel:
+        async with aio.insecure_channel(f"127.0.0.1:{port}") as channel:
             multicallable = channel.unary_unary(_TEST_UNARY_UNARY)
             call = multicallable(_REQUEST)
             self.assertEqual(_RESPONSE, await call)

--- a/src/python/grpcio_tests/tests_aio/unit/context_peer_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/context_peer_test.py
@@ -51,11 +51,11 @@ class TestContextPeer(AioTestBase):
             "test", {"UnaryUnary": check_peer_unary_unary}
         )
         server.add_generic_rpc_handlers((handlers,))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
 
         # Creates a channel
-        async with aio.insecure_channel("localhost:%d" % port) as channel:
+        async with aio.insecure_channel("127.0.0.1:%d" % port) as channel:
             response = await channel.unary_unary(_TEST_METHOD)(_REQUEST)
             self.assertEqual(_REQUEST, response)
 

--- a/src/python/grpcio_tests/tests_aio/unit/done_callback_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/done_callback_test.py
@@ -130,8 +130,8 @@ class TestClientSideDoneCallback(AioTestBase):
 class TestServerSideDoneCallback(AioTestBase):
     async def setUp(self):
         self._server = aio.server()
-        port = self._server.add_insecure_port("[::]:0")
-        self._channel = aio.insecure_channel("localhost:%d" % port)
+        port = self._server.add_insecure_port("127.0.0.1:0")
+        self._channel = aio.insecure_channel("127.0.0.1:%d" % port)
 
     async def tearDown(self):
         await self._channel.close()

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -209,7 +209,7 @@ class _TestGenericHandlerItself(grpc.GenericRpcHandler):
 
 async def _start_test_server():
     server = aio.server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.add_generic_rpc_handlers(
         (
             _TestGenericHandlerForMethods(),
@@ -217,7 +217,7 @@ async def _start_test_server():
         )
     )
     await server.start()
-    return "localhost:%d" % port, server
+    return "127.0.0.1:%d" % port, server
 
 
 class TestMetadata(AioTestBase):

--- a/src/python/grpcio_tests/tests_aio/unit/multithread_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/multithread_test.py
@@ -42,12 +42,12 @@ class MultithreadTest(AioTestBase):
             "grpc.testing.TestService", rpc_method_handlers
         )
         server.add_generic_rpc_handlers((generic_handler,))
-        port = server.add_insecure_port("[::]:0")
+        port = server.add_insecure_port("127.0.0.1:0")
         await server.start()
         return port, server
 
     async def run_client(self, port):
-        async with aio.insecure_channel(f"localhost:{port}") as channel:
+        async with aio.insecure_channel(f"127.0.0.1:{port}") as channel:
             unary_call = channel.unary_unary(
                 "/grpc.testing.TestService/UnaryCall"
             )

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -241,11 +241,11 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 async def _start_test_server():
     server = aio.server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     generic_handler = _GenericHandler()
     server.add_generic_rpc_handlers((generic_handler,))
     await server.start()
-    return "localhost:%d" % port, server, generic_handler
+    return "127.0.0.1:%d" % port, server, generic_handler
 
 
 class TestServer(AioTestBase):
@@ -557,8 +557,8 @@ class TestServer(AioTestBase):
 
     async def test_port_binding_exception(self):
         server = aio.server(options=(("grpc.so_reuseport", 0),))
-        port = server.add_insecure_port("localhost:0")
-        bind_address = "localhost:%d" % port
+        port = server.add_insecure_port("127.0.0.1:0")
+        bind_address = "127.0.0.1:%d" % port
 
         with self.assertRaises(RuntimeError):
             server.add_insecure_port(bind_address)
@@ -575,8 +575,8 @@ class TestServer(AioTestBase):
 
         # Build the server with concurrent rpc argument
         server = aio.server(maximum_concurrent_rpcs=_MAXIMUM_CONCURRENT_RPCS)
-        port = server.add_insecure_port("localhost:0")
-        bind_address = "localhost:%d" % port
+        port = server.add_insecure_port("127.0.0.1:0")
+        bind_address = "127.0.0.1:%d" % port
         server.add_generic_rpc_handlers((_GenericHandler(),))
         await server.start()
         # Build the channel
@@ -630,8 +630,8 @@ class TestServer(AioTestBase):
         # Use a limit of 1 to make the test deterministic
         max_concurrent = 1
         server = aio.server(maximum_concurrent_rpcs=max_concurrent)
-        port = server.add_insecure_port("[::]:0")
-        bind_address = f"localhost:{port}"
+        port = server.add_insecure_port("127.0.0.1:0")
+        bind_address = f"127.0.0.1:{port}"
         server.add_generic_rpc_handlers((_GenericHandler(),))
         await server.start()
         channel = aio.insecure_channel(bind_address)

--- a/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
@@ -35,8 +35,8 @@ class TestServerTimeRemaining(AioTestBase):
         self._server = aio.server(options=(("grpc.so_reuseport", 0),))
         self._adhoc_handlers = AdhocGenericHandler()
         self._server.add_generic_rpc_handlers((self._adhoc_handlers,))
-        port = self._server.add_insecure_port("[::]:0")
-        address = "localhost:%d" % port
+        port = self._server.add_insecure_port("127.0.0.1:0")
+        address = "127.0.0.1:%d" % port
         await self._server.start()
         # Create async channel
         self._channel = aio.insecure_channel(address)

--- a/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
@@ -84,10 +84,10 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 async def _start_test_server():
     server = aio.server()
-    port = server.add_insecure_port("[::]:0")
+    port = server.add_insecure_port("127.0.0.1:0")
     server.add_generic_rpc_handlers((_GenericHandler(),))
     await server.start()
-    return f"localhost:{port}", server
+    return f"127.0.0.1:{port}", server
 
 
 class TestTimeout(AioTestBase):

--- a/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
@@ -41,7 +41,7 @@ def start_test_server(port: int = 0) -> Tuple[str, Any]:
     )
 
     server.add_generic_rpc_handlers((_create_extra_generic_handler(servicer),))
-    port = server.add_insecure_port("[::]:%d" % port)
+    port = server.add_insecure_port("127.0.0.1:%d" % port)
     server.start()
     return "127.0.0.1:%d" % port, server
 

--- a/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_gevent/unit/_test_server.py
@@ -43,7 +43,7 @@ def start_test_server(port: int = 0) -> Tuple[str, Any]:
     server.add_generic_rpc_handlers((_create_extra_generic_handler(servicer),))
     port = server.add_insecure_port("[::]:%d" % port)
     server.start()
-    return "localhost:%d" % port, server
+    return "127.0.0.1:%d" % port, server
 
 
 def _create_extra_generic_handler(servicer: TestServiceServicer) -> Any:

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -647,7 +647,7 @@ if __name__ == "__main__":
         help="The per-RPC timeout in seconds.",
     )
     parser.add_argument(
-        "--server", default="localhost:50051", help="The address of the server."
+        "--server", default="127.0.0.1:50051", help="The address of the server."
     )
     parser.add_argument(
         "--stats_port",

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -115,7 +115,7 @@ def _collect_stats(
     stats_port: int, duration: int
 ) -> Mapping[str, Mapping[int, int]]:
     settings = {
-        "target": f"localhost:{stats_port}",
+        "target": f"127.0.0.1:{stats_port}",
         "insecure": True,
     }
     response = test_pb2_grpc.LoadBalancerStatsService.GetClientAccumulatedStats(
@@ -135,7 +135,7 @@ class XdsInteropClientTest(unittest.TestCase):
         self, server_port: int, stats_port: int, qps: int, num_channels: int
     ):
         settings = {
-            "target": f"localhost:{stats_port}",
+            "target": f"127.0.0.1:{stats_port}",
             "insecure": True,
         }
         for i in range(_TEST_ITERATIONS):
@@ -164,7 +164,7 @@ class XdsInteropClientTest(unittest.TestCase):
             logging.info("Sending RPC to server.")
             test_pb2_grpc.TestService.EmptyCall(
                 empty_pb2.Empty(),
-                f"localhost:{server_port}",
+                f"127.0.0.1:{server_port}",
                 insecure=True,
                 wait_for_ready=True,
             )

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -155,6 +155,7 @@ class XdsInteropClientTest(unittest.TestCase):
 
     def test_configure_consistency(self):
         _, server_port, socket = framework_common.get_socket()
+        socket.close()
 
         with _start_python_with_args(
             _SERVER_PATH,
@@ -169,8 +170,8 @@ class XdsInteropClientTest(unittest.TestCase):
                 wait_for_ready=True,
             )
             logging.info("Server successfully started.")
-            socket.close()
             _, stats_port, stats_socket = framework_common.get_socket()
+            stats_socket.close()
             with _start_python_with_args(
                 _CLIENT_PATH,
                 [
@@ -180,7 +181,6 @@ class XdsInteropClientTest(unittest.TestCase):
                     f"--num_channels={_NUM_CHANNELS}",
                 ],
             ) as (client, client_stdout, client_stderr):
-                stats_socket.close()
                 try:
                     self._assert_client_consistent(
                         server_port, stats_port, _QPS, _NUM_CHANNELS

--- a/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
@@ -61,9 +61,14 @@ def _start_a_test_server():
         ThreadPoolExecutor(max_workers=1), options=(("grpc.so_reuseport", 0),)
     )
     server.add_generic_rpc_handlers((_GenericHandler(),))
-    port = server.add_insecure_port("localhost:0")
+    if os.name == "nt":
+        port = server.add_insecure_port("127.0.0.1:0")
+        address = "127.0.0.1:%d" % port
+    else:
+        address = "unix:/tmp/grpc_leak_test_%s" % uuid.uuid4().hex
+        server.add_insecure_port(address)
     server.start()
-    return "localhost:%d" % port, server
+    return address, server
 
 
 def _perform_an_rpc(address):

--- a/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_leak_test.py
@@ -61,14 +61,9 @@ def _start_a_test_server():
         ThreadPoolExecutor(max_workers=1), options=(("grpc.so_reuseport", 0),)
     )
     server.add_generic_rpc_handlers((_GenericHandler(),))
-    if os.name == "nt":
-        port = server.add_insecure_port("127.0.0.1:0")
-        address = "127.0.0.1:%d" % port
-    else:
-        address = "unix:/tmp/grpc_leak_test_%s" % uuid.uuid4().hex
-        server.add_insecure_port(address)
+    port = server.add_insecure_port("127.0.0.1:0")
     server.start()
-    return address, server
+    return "127.0.0.1:%d" % port, server
 
 
 def _perform_an_rpc(address):

--- a/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
@@ -125,7 +125,7 @@ def _time_invocation(to_time: Callable[[], None]) -> datetime.timedelta:
 def _server(credentials: Optional[grpc.ServerCredentials]):
     try:
         server = test_common.test_server()
-        target = "[::]:0"
+        target = "127.0.0.1:0"
         if credentials is None:
             port = server.add_insecure_port(target)
         else:
@@ -186,7 +186,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_unary_unary_insecure(self):
         with _server(None) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             response = grpc.experimental.unary_unary(
                 _REQUEST,
                 target,
@@ -199,7 +199,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_unary_unary_secure(self):
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             response = grpc.experimental.unary_unary(
                 _REQUEST,
                 target,
@@ -212,7 +212,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_channels_cached(self):
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             test_name = inspect.stack()[0][3]
             args = (_REQUEST, target, _UNARY_UNARY)
             kwargs = {
@@ -229,7 +229,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_channels_evicted(self):
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             response = grpc.experimental.unary_unary(
                 _REQUEST,
                 target,
@@ -245,7 +245,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_total_channels_enforced(self):
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             for i in range(_STRESS_EPOCHS):
                 # Ensure we get a new channel each time.
                 options = (("foo", str(i)),)
@@ -266,7 +266,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_unary_stream(self):
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             for response in grpc.experimental.unary_stream(
                 _REQUEST,
                 target,
@@ -282,7 +282,7 @@ class SimpleStubsTest(unittest.TestCase):
                 yield _REQUEST
 
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             response = grpc.experimental.stream_unary(
                 request_iter(),
                 target,
@@ -298,7 +298,7 @@ class SimpleStubsTest(unittest.TestCase):
                 yield _REQUEST
 
         with _server(grpc.local_server_credentials()) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             for response in grpc.experimental.stream_stream(
                 request_iter(),
                 target,
@@ -327,7 +327,7 @@ class SimpleStubsTest(unittest.TestCase):
         with _env("GRPC_DEFAULT_SSL_ROOTS_FILE_PATH", cert_file):
             server_creds = grpc.ssl_server_credentials(_server_certs)
             with _server(server_creds) as port:
-                target = f"localhost:{port}"
+                target = f"127.0.0.1:{port}"
                 response = grpc.experimental.unary_unary(
                     _REQUEST,
                     target,
@@ -338,7 +338,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_insecure_sugar(self):
         with _server(None) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             response = grpc.experimental.unary_unary(
                 _REQUEST,
                 target,
@@ -350,7 +350,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def test_insecure_sugar_mutually_exclusive(self):
         with _server(None) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             with self.assertRaises(ValueError):
                 response = grpc.experimental.unary_unary(
                     _REQUEST,
@@ -425,7 +425,7 @@ class SimpleStubsTest(unittest.TestCase):
 
     def assert_times_out(self, invocation_args):
         with _server(None) as port:
-            target = f"localhost:{port}"
+            target = f"127.0.0.1:{port}"
             with self.assertRaises(grpc.RpcError) as cm:
                 response = grpc.experimental.unary_unary(
                     _REQUEST,


### PR DESCRIPTION
# Description

Part 1 of fixing MacOSx Flaky Tests in CI under parallelism

This PR eliminates the ambiguity of "localhost". By strictly pinning both the server binds and the client dials to explicitly use "127.0.0.1" (or "127.0.0.1:0") across the grpcio_tests suite. This guarantees that the client cannot fail over to a secondary address family where a port collision may have occurred.

Some supporting links

* Default value of port resuse is 1 - https://grpc.github.io/grpc/core/group__grpc__arg__keys.html#ga40e635cf00ea7a10c71ed71c03d97f23
* Envoy documentation on `reuse_port` behaviour on MacOSx - https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto
```
On macOS, reuse_port for TCP does not do what it does on Linux. Instead of load balancing, the last socket wins and receives all connections/packets.
```

