### PR TITLE
Fix client languages used for MCS connection scaling interop tests

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1813,7 +1813,7 @@ try:
     if "java" in servers:
         languages_for_mcs_cs = set(
             _LANGUAGES[l]
-            for l in _LANGUAGES_WITH_HTTP2_CLIENTS_FOR_HTTP2_SERVER_TEST_CASES
+            for l in _LANGUAGES_FOR_MCS_TEST_CASE
             if "all" in args.language or l in args.language
         )
         if not languages_for_mcs_cs:


### PR DESCRIPTION
 The connection scaling test case (max_concurrent_streams_connection_scaling / MCS) is only implemented and supported by the C++ client.

  In tools/run_tests/run_interop_tests.py, a dedicated variable was correctly defined to enforce this restriction:
    `_LANGUAGES_FOR_MCS_TEST_CASE = ["c++"]`

  However, due to an oversight during the loop initialization around line 1814, the runner used `_LANGUAGES_WITH_HTTP2_CLIENTS_FOR_HTTP2_SERVER_TEST_CASES` (which includes java, go, python, and c++) instead of
  `_LANGUAGES_FOR_MCS_TEST_CASE`. This caused the runner to attempt running this test case on all of the Python, Go, and Java clients.

  ---

  🛠️ The Fix Applied
  I updated the client language resolver block in tools/run_tests/run_interop_tests.py to use `_LANGUAGES_FOR_MCS_TEST_CASE` instead of `_LANGUAGES_WITH_HTTP2_CLIENTS_FOR_HTTP2_SERVER_TEST_CASES`.

  This correctly restricts the connection scaling test case to run only with the C++ client.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

