### PR TITLE
[Python] Remove unused import of `Metadata` from `aio._base_server.py`.

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -18,7 +18,6 @@ from typing import Generic, Iterable, Mapping, NoReturn, Optional, Sequence
 
 import grpc
 
-from ._metadata import Metadata  # pylint: disable=unused-import
 from ._typing import DoneCallbackType
 from ._typing import MetadataType
 from ._typing import RequestType


### PR DESCRIPTION
Remove unused import of `Metadata` from `_base_server.py`. Removing this import had caused some internal test breakage about 2+ years ago and hence had to be re-introduced in https://github.com/grpc/grpc/pull/37022

Trying to remove it again now to see if this unused import is still needed or safe to remove. Internal tests doesn't show any failures associated with this change now, so I assume this is fine.