### PR TITLE
Fix bare except clauses in tools/run_tests/run_tests.py

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1429,7 +1429,7 @@ def runs_per_test_type(arg_str):
         if n <= 0:
             raise ValueError
         return n
-    except:
+    except (ValueError, TypeError):
         msg = "'{}' is not a positive integer or 'inf'".format(arg_str)
         raise argparse.ArgumentTypeError(msg)
 
@@ -1457,7 +1457,7 @@ def _shut_down_legacy_server(legacy_server_port):
                 timeout=10,
             ).read()
         )
-    except:
+    except Exception:
         pass
     else:
         urllib.request.urlopen(


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types in `tools/run_tests/run_tests.py`.

Two fixes:
1. `positive_int_or_inf` arg parser: bare `except:` after `int(arg_str)` → `except (ValueError, TypeError):` since those are the only exceptions `int()` raises for bad input
2. `_shut_down_legacy_server` URL fetch: bare `except:` catching connection failures → `except Exception:` to allow signals to propagate