### PR TITLE
[Python] Use --config=python in Bazel test instructions

### DIFF
--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -56,11 +56,11 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
    * **Using Bazel (Recommended):**
      * To run a single unit test:
        ```bash
-       bazel test --cache_test_results=no "//src/python/grpcio_tests/tests/unit:_abort_test" 
+       bazel test --config=python --cache_test_results=no "//src/python/grpcio_tests/tests/unit:_abort_test"
        ```
      * To execute all unit tests for Python:
        ```bash
-       bazel test --cache_test_results=no "//src/python/..." 
+       bazel test --config=python --cache_test_results=no "//src/python/..."
        ```
    * **Using Provided Scripts (Alternative):**
      * Install Python Modules:


### PR DESCRIPTION
# Description

Update both Bazel test commands in `src/python/CONTRIBUTING.md` to use `--config=python`. This applies the repository-managed Python Bazel settings needed for reliable imports while keeping the contributor documentation decoupled from the underlying compatibility flag.

This supersedes #42425 and incorporates @sergiitk's review feedback there.

Thank you to @asheshvidyut for the original contribution and for allowing me to take it over. Ashesh is also credited as a co-author on the commit.

# Testing

Documentation-only change
