### PR TITLE
Fix keep alive v2

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -339,3 +339,18 @@ grpc_sh_test(
     },
     uses_polling = False,
 )
+
+grpc_sh_test(
+    name = "objc_keepalive_test",
+    srcs = ["run_keepalive_test.sh"],
+    data = [
+        ":MacTests.zip",
+        "//test/cpp/interop:interop_server",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    env = {
+        "RLOCATIONPATH_INTEROP_SERVER": "$(rlocationpath //test/cpp/interop:interop_server)",
+        "RLOCATIONPATH_MACTESTS_ZIP": "$(rlocationpath :MacTests.zip)",
+    },
+    uses_polling = False,
+)

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -339,4 +339,3 @@ grpc_sh_test(
     },
     uses_polling = False,
 )
-

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -340,17 +340,3 @@ grpc_sh_test(
     uses_polling = False,
 )
 
-grpc_sh_test(
-    name = "objc_keepalive_test",
-    srcs = ["run_keepalive_test.sh"],
-    data = [
-        ":MacTests.zip",
-        "//test/cpp/interop:interop_server",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-    env = {
-        "RLOCATIONPATH_INTEROP_SERVER": "$(rlocationpath //test/cpp/interop:interop_server)",
-        "RLOCATIONPATH_MACTESTS_ZIP": "$(rlocationpath :MacTests.zip)",
-    },
-    uses_polling = False,
-)

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1622,7 +1622,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     options.hostNameOverride = [[self class] hostNameOverride];
     options.keepaliveInterval = 1.5;
     options.keepaliveTimeout = 0;
-    options.additionalChannelArgs = @{@"grpc.http2.ping_timeout_ms": @200};
+    options.additionalChannelArgs = @{@"grpc.http2.ping_timeout_ms" : @200};
 
     __weak RMTTestService *weakService = service;
     GRPCStreamingProtoCall *call = [service

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1601,7 +1601,9 @@ static dispatch_once_t initGlobalInterceptorFactory;
 // TODO(b/268379869): This test has a race and is flaky in any configurations. One possible way to
 // deflake this test is to find a way to disable ping ack on the interop server for this test case.
 - (void)testKeepaliveWithV2API {
-  return;
+  if (getenv("GRPC_RUN_KEEPALIVE_TEST") == NULL) {
+    return;
+  }
 
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
@@ -1620,6 +1622,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     options.hostNameOverride = [[self class] hostNameOverride];
     options.keepaliveInterval = 1.5;
     options.keepaliveTimeout = 0;
+    options.additionalChannelArgs = @{@"grpc.http2.ping_timeout_ms": @200};
 
     __weak RMTTestService *weakService = service;
     GRPCStreamingProtoCall *call = [service

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1598,12 +1598,13 @@ static dispatch_once_t initGlobalInterceptorFactory;
   });
 }
 
-// TODO(b/268379869): This test has a race and is flaky in any configurations. One possible way to
-// deflake this test is to find a way to disable ping ack on the interop server for this test case.
 - (void)testKeepaliveWithV2API {
+  // Skipping this test when test case is running with ping ack is true.
+#ifndef GRPC_RUN_KEEPALIVE_TEST
   if (getenv("GRPC_RUN_KEEPALIVE_TEST") == NULL) {
     return;
   }
+#endif
 
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];

--- a/src/objective-c/tests/run_keepalive_test.sh
+++ b/src/objective-c/tests/run_keepalive_test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# --- begin runfiles.bash initialization ---
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+INTEROP_SERVER=$(rlocation "$RLOCATIONPATH_INTEROP_SERVER")
+MACTESTS_ZIP=$(rlocation "$RLOCATIONPATH_MACTESTS_ZIP")
+
+PORT_PLAIN=5252
+PORT_TLS=5253
+
+echo "Starting interop_server with --ack_pings=false on ports $PORT_PLAIN and $PORT_TLS..."
+"$INTEROP_SERVER" --port=$PORT_PLAIN --max_send_message_size=8388608 --ack_pings=false &
+PID1=$!
+"$INTEROP_SERVER" --port=$PORT_TLS --max_send_message_size=8388608 --use_tls --ack_pings=false &
+PID2=$!
+
+cleanup() {
+  echo "Stopping interop_server PIDs: $PID1 $PID2"
+  kill -9 $PID1 $PID2 2>/dev/null || true
+}
+trap cleanup EXIT
+
+sleep 1
+
+TMPDIR=$(mktemp -d)
+unzip -qq -o "$MACTESTS_ZIP" -d "$TMPDIR"
+chmod -R 755 "$TMPDIR/MacTests.xctest"
+
+export HOST_PORT_LOCAL="localhost:$PORT_PLAIN"
+export HOST_PORT_LOCALSSL="localhost:$PORT_TLS"
+export GRPC_RUN_KEEPALIVE_TEST="true"
+
+XCTEST=$(xcrun --find xctest || echo "/Applications/Xcode.app/Contents/Developer/usr/bin/xctest")
+"$XCTEST" \
+  -XCTest "InteropTestsLocalCleartext/testKeepaliveWithV2API" \
+  "$TMPDIR/MacTests.xctest"

--- a/src/objective-c/tests/run_keepalive_test.sh
+++ b/src/objective-c/tests/run_keepalive_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2026 gRPC authors.
+# Copyright 2019 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,49 +13,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Don't run this script standalone. Instead, run from the repository root:
+# ./tools/run_tests/run_tests.py -l objc
+
 set -ex
 
-# --- begin runfiles.bash initialization ---
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+cd $(dirname $0)
 
-INTEROP_SERVER=$(rlocation "$RLOCATIONPATH_INTEROP_SERVER")
-MACTESTS_ZIP=$(rlocation "$RLOCATIONPATH_MACTESTS_ZIP")
+BAZEL=../../../tools/bazel
 
-PORT_PLAIN=5252
-PORT_TLS=5253
+INTEROP=../../../bazel-bin/test/cpp/interop/interop_server
 
-echo "Starting interop_server with --ack_pings=false on ports $PORT_PLAIN and $PORT_TLS..."
-"$INTEROP_SERVER" --port=$PORT_PLAIN --max_send_message_size=8388608 --ack_pings=false &
-PID1=$!
-"$INTEROP_SERVER" --port=$PORT_TLS --max_send_message_size=8388608 --use_tls --ack_pings=false &
-PID2=$!
-
-cleanup() {
-  echo "Stopping interop_server PIDs: $PID1 $PID2"
-  kill -9 $PID1 $PID2 2>/dev/null || true
+[ -d Tests.xcworkspace ] || {
+    ./build_tests.sh
 }
-trap cleanup EXIT
 
-sleep 1
+[ -f $INTEROP ] || {
+    $BAZEL build //test/cpp/interop:interop_server
+}
 
-TMPDIR=$(mktemp -d)
-unzip -qq -o "$MACTESTS_ZIP" -d "$TMPDIR"
-chmod -R 755 "$TMPDIR/MacTests.xctest"
+[ -z "$(ps aux |egrep 'port_server\.py.*-p\s32766')" ] && {
+    echo >&2 "Can't find the port server. Start port server with tools/run_tests/start_port_server.py."
+    exit 1
+}
 
-export HOST_PORT_LOCAL="localhost:$PORT_PLAIN"
-export HOST_PORT_LOCALSSL="localhost:$PORT_TLS"
+PLAIN_PORT=$(curl localhost:32766/get)
+TLS_PORT=$(curl localhost:32766/get)
+
+# start interop_server for plaintext and interop_server for TLS on random ports obtained
+# from the port server with --ack_pings=false for keepalive testing.
+$INTEROP --port=$PLAIN_PORT --max_send_message_size=8388608 --ack_pings=false &
+$INTEROP --port=$TLS_PORT --max_send_message_size=8388608 --use_tls --ack_pings=false &
+
+function finish {
+    kill -9 `jobs -p`
+    echo "EXIT TIME:  $(date)"
+}
+trap finish EXIT
+
+set -o pipefail  # preserve xcodebuild exit code when piping output
+
+if [ -z $PLATFORM ]; then
+DESTINATION='platform=iOS Simulator,name=iPhone 11'
+elif [ $PLATFORM == ios ]; then
+DESTINATION='platform=iOS Simulator,name=iPhone 11'
+elif [ $PLATFORM == macos ]; then
+DESTINATION='platform=macOS'
+elif [ $PLATFORM == tvos ]; then
+DESTINATION='platform=tvOS Simulator,name=Apple TV'
+fi
+
+if [ -z $SCHEME ]; then
+SCHEME='InteropTests'
+fi
+
+XCODEBUILD_FLAGS="
+  -only-testing:${SCHEME}/InteropTestsLocalCleartext/testKeepaliveWithV2API
+  IPHONEOS_DEPLOYMENT_TARGET=15.0
+  ONLY_ACTIVE_ARCH=YES
+"
+
+XCODEBUILD_FILTER_OUTPUT_SCRIPT="./xcodebuild_filter_output.sh"
+
+TEST_DEFS="HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
+HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
+HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
+GRPC_RUN_KEEPALIVE_TEST=1 \
+GCC_OPTIMIZATION_LEVEL=s"
+
 export GRPC_RUN_KEEPALIVE_TEST="true"
 
+time xcodebuild \
+    -workspace Tests.xcworkspace \
+    -scheme $SCHEME \
+    -destination "${DESTINATION}" \
+    GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS'" $TEST_DEFS" \
+    build-for-testing \
+    ${XCODEBUILD_FLAGS} \
+    | "${XCODEBUILD_FILTER_OUTPUT_SCRIPT}"
+
 XCTEST=$(xcrun --find xctest || echo "/Applications/Xcode.app/Contents/Developer/usr/bin/xctest")
-"$XCTEST" \
-  -XCTest "InteropTestsLocalCleartext/testKeepaliveWithV2API" \
-  "$TMPDIR/MacTests.xctest"
+BUNDLE_PATH=$(find ~/Library/Developer/Xcode/DerivedData/Tests-* -name "MacTests.xctest" 2>/dev/null | head -n 1)
+export HOST_PORT_LOCAL="localhost:$PLAIN_PORT"
+export HOST_PORT_LOCALSSL="localhost:$TLS_PORT"
+"$XCTEST" -XCTest "InteropTestsLocalCleartext/testKeepaliveWithV2API" "$BUNDLE_PATH"

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -52,7 +52,6 @@ ABSL_FLAG(int32_t, port, 0, "Server port.");
 ABSL_FLAG(int32_t, max_send_message_size, -1, "The maximum send message size.");
 ABSL_FLAG(bool, ack_pings, true, "Whether to acknowledge HTTP/2 pings.");
 
-
 using grpc::Server;
 using grpc::ServerContext;
 using grpc::ServerCredentials;

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -50,6 +50,8 @@ ABSL_FLAG(std::string, custom_credentials_type, "",
           "User provided credentials type.");
 ABSL_FLAG(int32_t, port, 0, "Server port.");
 ABSL_FLAG(int32_t, max_send_message_size, -1, "The maximum send message size.");
+ABSL_FLAG(bool, ack_pings, true, "Whether to acknowledge HTTP/2 pings.");
+
 
 using grpc::Server;
 using grpc::ServerContext;
@@ -440,6 +442,9 @@ void grpc::testing::interop::RunServer(
   }
   if (absl::GetFlag(FLAGS_max_send_message_size) >= 0) {
     builder.SetMaxSendMessageSize(absl::GetFlag(FLAGS_max_send_message_size));
+  }
+  if (!absl::GetFlag(FLAGS_ack_pings)) {
+    builder.AddChannelArgument("grpc.http2.ack_pings", 0);
   }
   grpc::ServerBuilder::experimental_type(&builder).EnableCallMetricRecording(
       nullptr);


### PR DESCRIPTION
following the same approach as in c++ test cases.

// Disable ping ack to trigger the keepalive timeout
  InitServer(DefaultServerArgs().Set("grpc.http2.ack_pings", false));
  
  for more detail please check keepalive_timeout.cc.