### PR TITLE
[Python] grpc-status: Relax protobuf dependency lower bound to allow 6.x

### DIFF
--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -54,7 +54,9 @@ CLASSIFIERS = [
 
 
 INSTALL_REQUIRES = (
-    "protobuf>=7.35.1,<8.0.0",
+    # Note that we don't ship pb2 files with this package, so the protobuf
+    # version bounds don't have to be in lockstep with grpcio-tools.
+    "protobuf>=6.33.5,<8.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
     "googleapis-common-protos>=1.5.5",
 )


### PR DESCRIPTION
Relaxes the minimum protobuf version requirement in `grpcio_status` from `7.35.1` to `6.33.5` to allow compatibility with older protobuf.

Note that we don't ship pb2 files with this package, so the protobuf version bounds doesn't have to be in lockstep with grpcio-tools.
