### PR TITLE
initialize absl::InsecureBitGen on init to avoid crash when descripto…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -634,12 +634,13 @@ grpc_cc_library(
     defines = ["GRPC_NO_XDS"],
     external_deps = [
         "absl/base:core_headers",
+        "absl/functional:any_invocable",
         "absl/log:log",
+        "absl/random",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
         "absl/time:time",
-        "absl/functional:any_invocable",
     ],
     public_hdrs = GRPC_PUBLIC_HDRS,
     tags = [
@@ -721,12 +722,13 @@ grpc_cc_library(
     }),
     external_deps = [
         "absl/base:core_headers",
+        "absl/functional:any_invocable",
         "absl/log:log",
+        "absl/random",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
         "absl/time:time",
-        "absl/functional:any_invocable",
     ],
     public_hdrs = GRPC_PUBLIC_HDRS,
     select_deps = [

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -18,6 +18,12 @@
 
 #include "src/core/lib/surface/init.h"
 
+#include "absl/base/thread_annotations.h"
+#include "absl/log/log.h"
+#include "absl/random/random.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+
 #include <address_sorting/address_sorting.h>
 #include <grpc/fork.h>
 #include <grpc/grpc.h>
@@ -44,10 +50,6 @@
 #include "src/core/util/fork.h"
 #include "src/core/util/sync.h"
 #include "src/core/util/thd.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/log/log.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
 
 // Remnants of the old plugin system
 void grpc_resolver_dns_ares_init(void);
@@ -102,6 +104,9 @@ static void do_basic_init(void) {
   grpc_fork_handlers_auto_register();
   grpc_tracer_init();
   grpc_client_channel_global_init_backup_polling();
+  // Pre-warm Abseil random entropy pool while file descriptors are available,
+  // preventing late-runtime SeedGenException crashes under FD exhaustion.
+  (void)absl::InsecureBitGen()();
 }
 
 void grpc_init(void) {

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -18,12 +18,6 @@
 
 #include "src/core/lib/surface/init.h"
 
-#include "absl/base/thread_annotations.h"
-#include "absl/log/log.h"
-#include "absl/random/random.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
-
 #include <address_sorting/address_sorting.h>
 #include <grpc/fork.h>
 #include <grpc/grpc.h>
@@ -50,6 +44,11 @@
 #include "src/core/util/fork.h"
 #include "src/core/util/sync.h"
 #include "src/core/util/thd.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/log/log.h"
+#include "absl/random/random.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 
 // Remnants of the old plugin system
 void grpc_resolver_dns_ares_init(void);


### PR DESCRIPTION
**RCA**
On iOS devices and sandboxed CI environments where kernel entropy syscalls (getentropy) are restricted by sandbox profiles or platform detection, Abseil's random number generator (absl::InsecureBitGen) falls back to opening /dev/urandom. If gRPC channels, subchannels, or backoff timers initialize RNG lazily after FDs are exhausted, Abseil cannot read seed material and throws absl::SeedGenException (or terminates the app).

**Test Case used to reproduce this issue**
```
- (void)testSeedGenExceptionThrownWhenFileDescriptorsExhausted {
#ifdef ABSL_HAVE_EXCEPTIONS
  // 1. Consume all available file descriptors in the process until EMFILE is reached.
  std::vector<int> exhausted_fds;
  while (true) {
    int fd = open("/dev/null", O_RDONLY);
    if (fd < 0) {
      XCTAssertTrue(errno == EMFILE || errno == ENFILE,
                    @"Expected EMFILE/ENFILE upon exhausting file descriptors, got errno=%d",
                    errno);
      break;
    }
    exhausted_fds.push_back(fd);
  }

  // 2. Attempting to construct an absl::BitGen forces open("/dev/urandom", O_RDONLY)
  // to fail with EMFILE, reproducing the exact exception thrown at seed_gen_exception.cc:36.
  bool caught_seed_gen_exception = false;
  @try {
    try {
      absl::BitGen bitgen;
      (void)bitgen();
    } catch (const absl::SeedGenException& e) {
      caught_seed_gen_exception = true;
    }
  } @finally {
    // 3. Clean up exhausted file descriptors so subsequent tests aren't affected.
    for (int fd : exhausted_fds) {
      close(fd);
    }
  }

  XCTAssertTrue(caught_seed_gen_exception,
                @"Expected absl::SeedGenException to be thrown when file descriptors are exhausted "
                @"and /dev/urandom cannot be opened.");
#else
  NSLog(@"ABSL_HAVE_EXCEPTIONS is not enabled; ThrowSeedGenException calls std::terminate().");
#endif
}
```

**What we have fixed**
during early app startup (when grpc_init() is invoked and FDs are still plentiful), Abseil initializes and caches its entropy pool. Subsequent gRPC network and channel operations reuse this pool and will never crash, even if the iOS app later exhausts 100% of its file descriptors.



