### PR TITLE
remove unused alts_handshaker_client.h include from alts_tsi_handshaker.h

### DIFF
--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -22,9 +22,11 @@
 #include <grpc/grpc.h>
 #include <grpc/support/port_platform.h>
 
+#include <optional>
+#include <string>
+
 #include "src/core/credentials/transport/alts/grpc_alts_credentials_options.h"
 #include "src/core/lib/iomgr/pollset_set.h"
-#include "src/core/tsi/alts/handshaker/alts_handshaker_client.h"
 #include "src/core/tsi/transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
 #include "src/proto/grpc/gcp/altscontext.upb.h"


### PR DESCRIPTION
alts_tsi_handshaker.h includes alts_handshaker_client.h, and
alts_handshaker_client.h includes alts_tsi_handshaker.h back, so the two
headers form an include cycle.

The edge from alts_tsi_handshaker.h is unused: the header references none
of the types, functions, macros or constants that alts_handshaker_client.h
declares. Everything that uses the handshaker client API already includes
alts_handshaker_client.h directly, including alts_tsi_handshaker.cc and both
alts handshaker tests, so removing the include leaves call sites untouched.

While here: the header declares `std::optional<std::string>
preferred_transport_protocols` but includes neither <optional> nor <string>,
picking both up transitively. Added them so the header declares what it uses.

alts_tsi_handshaker.h still type-checks standalone with -std=c++17 after the
change.

Found while running my open-source include-graph checker
(https://github.com/blurman-ai/archcheck) over the gRPC include graph.
