### PR TITLE
[Python] Escape triple-quote sequences in generated Python docstrings

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -89,6 +89,25 @@ PrivateGenerator::PrivateGenerator(const GeneratorConfiguration& config,
                                    const grpc_generator::File* file)
     : config(config), file(file) {}
 
+// Escapes a comment string so it is safe to embed within a Python triple-quoted
+// docstring. Replaces backslashes first, then triple-quote sequences.
+std::string EscapePythonDocstring(const std::string& input) {
+  std::string result;
+  result.reserve(input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    if (input[i] == '\\') {
+      result += "\\\\";
+    } else if (input[i] == '"' && i + 2 < input.size() && input[i + 1] == '"' &&
+               input[i + 2] == '"') {
+      result += "\\\"\\\"\\\"";
+      i += 2;
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
 void PrivateGenerator::PrintAllComments(StringVector comments,
                                         grpc_generator::Printer* out) {
   if (comments.empty()) {
@@ -108,7 +127,8 @@ void PrivateGenerator::PrintAllComments(StringVector comments,
        ++it) {
     size_t start_pos = it->find_first_not_of(' ');
     if (start_pos != std::string::npos) {
-      out->PrintRaw(it->c_str() + start_pos);
+      std::string escaped = EscapePythonDocstring(it->substr(start_pos));
+      out->PrintRaw(escaped.c_str());
     }
     out->Print("\n");
   }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -55,11 +56,12 @@ std::string generator_file_name;
 
 // Escapes a comment string so it is safe to embed within a Python triple-quoted
 // docstring. Replaces backslashes first, then triple-quote sequences.
-std::string EscapePythonDocstring(const std::string& input, size_t start_pos) {
+std::string EscapePythonDocstring(std::string_view input, size_t start_pos) {
   std::string result;
   if (start_pos >= input.size()) return result;
   result.reserve(input.size() - start_pos);
-  for (size_t i = start_pos; i < input.size(); i++) {
+  size_t i = start_pos;
+  while (i < input.size()) {
     if (input[i] == '\\') {
       result += "\\\\";
     } else if (input[i] == '"' && i + 2 < input.size() && input[i + 1] == '"' &&
@@ -69,6 +71,7 @@ std::string EscapePythonDocstring(const std::string& input, size_t start_pos) {
     } else {
       result += input[i];
     }
+    i++;
   }
   return result;
 }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -53,6 +53,25 @@ namespace grpc_python_generator {
 
 std::string generator_file_name;
 
+// Escapes a comment string so it is safe to embed within a Python triple-quoted
+// docstring. Replaces backslashes first, then triple-quote sequences.
+std::string EscapePythonDocstring(const std::string& input) {
+  std::string result;
+  result.reserve(input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    if (input[i] == '\\') {
+      result += "\\\\";
+    } else if (input[i] == '"' && i + 2 < input.size() && input[i + 1] == '"' &&
+               input[i + 2] == '"') {
+      result += "\\\"\\\"\\\"";
+      i += 2;
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
 namespace {
 
 typedef map<std::string, std::string> StringMap;
@@ -88,25 +107,6 @@ class IndentScope {
 PrivateGenerator::PrivateGenerator(const GeneratorConfiguration& config,
                                    const grpc_generator::File* file)
     : config(config), file(file) {}
-
-// Escapes a comment string so it is safe to embed within a Python triple-quoted
-// docstring. Replaces backslashes first, then triple-quote sequences.
-std::string EscapePythonDocstring(const std::string& input) {
-  std::string result;
-  result.reserve(input.size());
-  for (size_t i = 0; i < input.size(); i++) {
-    if (input[i] == '\\') {
-      result += "\\\\";
-    } else if (input[i] == '"' && i + 2 < input.size() && input[i + 1] == '"' &&
-               input[i + 2] == '"') {
-      result += "\\\"\\\"\\\"";
-      i += 2;
-    } else {
-      result += input[i];
-    }
-  }
-  return result;
-}
 
 void PrivateGenerator::PrintAllComments(StringVector comments,
                                         grpc_generator::Printer* out) {

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -55,10 +55,11 @@ std::string generator_file_name;
 
 // Escapes a comment string so it is safe to embed within a Python triple-quoted
 // docstring. Replaces backslashes first, then triple-quote sequences.
-std::string EscapePythonDocstring(const std::string& input) {
+std::string EscapePythonDocstring(const std::string& input, size_t start_pos) {
   std::string result;
-  result.reserve(input.size());
-  for (size_t i = 0; i < input.size(); i++) {
+  if (start_pos >= input.size()) return result;
+  result.reserve(input.size() - start_pos);
+  for (size_t i = start_pos; i < input.size(); i++) {
     if (input[i] == '\\') {
       result += "\\\\";
     } else if (input[i] == '"' && i + 2 < input.size() && input[i + 1] == '"' &&
@@ -127,7 +128,7 @@ void PrivateGenerator::PrintAllComments(StringVector comments,
        ++it) {
     size_t start_pos = it->find_first_not_of(' ');
     if (start_pos != std::string::npos) {
-      std::string escaped = EscapePythonDocstring(it->substr(start_pos));
+      std::string escaped = EscapePythonDocstring(*it, start_pos);
       out->PrintRaw(escaped.c_str());
     }
     out->Print("\n");

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -78,6 +78,10 @@ class PythonGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
   GeneratorConfiguration config_;
 };
 
+// Escapes a comment string so it is safe to embed within a Python triple-quoted
+// docstring. Exposed for testing.
+std::string EscapePythonDocstring(const std::string& input);
+
 }  // namespace grpc_python_generator
 
 #endif  // GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_H

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -20,6 +20,7 @@
 #define GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_H
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -83,7 +84,7 @@ class PythonGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 // docstring. Escaping starts at start_pos, which avoids copying a substring
 // when only the trailing portion of the input needs escaping.
 // Exposed for testing.
-std::string EscapePythonDocstring(const std::string& input,
+std::string EscapePythonDocstring(std::string_view input,
                                   size_t start_pos = 0);
 
 }  // namespace grpc_python_generator

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -19,6 +19,7 @@
 #ifndef GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_H
 #define GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_H
 
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -79,8 +80,11 @@ class PythonGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 };
 
 // Escapes a comment string so it is safe to embed within a Python triple-quoted
-// docstring. Exposed for testing.
-std::string EscapePythonDocstring(const std::string& input);
+// docstring. Escaping starts at start_pos, which avoids copying a substring
+// when only the trailing portion of the input needs escaping.
+// Exposed for testing.
+std::string EscapePythonDocstring(const std::string& input,
+                                  size_t start_pos = 0);
 
 }  // namespace grpc_python_generator
 

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -106,6 +106,20 @@ genrule(
     cmd = "cat $(GENDIR)/src/proto/grpc/testing/compiler_test_mock.grpc.pb.h > $@",
 )
 
+grpc_cc_test(
+    name = "python_generator_test",
+    srcs = ["python_generator_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//src/compiler:grpc_plugin_support",
+        "//test/core/test_util:grpc_test_util",
+    ],
+)
+
 grpc_sh_test(
     name = "run_golden_file_test",
     srcs = ["run_golden_file_test.sh"],

--- a/test/cpp/codegen/python_generator_test.cc
+++ b/test/cpp/codegen/python_generator_test.cc
@@ -1,0 +1,89 @@
+//
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include "src/compiler/python_generator.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "test/core/test_util/test_config.h"
+
+namespace grpc_python_generator {
+namespace {
+
+TEST(EscapePythonDocstringTest, PlainTextUnchanged) {
+  EXPECT_EQ("Hello world", EscapePythonDocstring("Hello world"));
+}
+
+TEST(EscapePythonDocstringTest, EmptyString) {
+  EXPECT_EQ("", EscapePythonDocstring(""));
+}
+
+TEST(EscapePythonDocstringTest, SingleBackslashEscaped) {
+  EXPECT_EQ("path\\\\to\\\\file", EscapePythonDocstring("path\\to\\file"));
+}
+
+TEST(EscapePythonDocstringTest, TripleQuoteEscaped) {
+  // A triple-quote sequence in the input should be escaped so it does not
+  // terminate the docstring in generated Python code.
+  EXPECT_EQ("before\\\"\\\"\\\"after",
+            EscapePythonDocstring("before\"\"\"after"));
+}
+
+TEST(EscapePythonDocstringTest, TripleQuoteAtStart) {
+  EXPECT_EQ("\\\"\\\"\\\"start", EscapePythonDocstring("\"\"\"start"));
+}
+
+TEST(EscapePythonDocstringTest, TripleQuoteAtEnd) {
+  EXPECT_EQ("end\\\"\\\"\\\"", EscapePythonDocstring("end\"\"\""));
+}
+
+TEST(EscapePythonDocstringTest, ConsecutiveTripleQuotes) {
+  // Six quotes = two triple-quote sequences
+  EXPECT_EQ("\\\"\\\"\\\"\\\"\\\"\\\"",
+            EscapePythonDocstring("\"\"\"\"\"\""));
+}
+
+TEST(EscapePythonDocstringTest, DoubleQuoteNotEscaped) {
+  // A single double-quote or two double-quotes should not be affected.
+  EXPECT_EQ("say \"hello\"", EscapePythonDocstring("say \"hello\""));
+  EXPECT_EQ("two \"\" quotes", EscapePythonDocstring("two \"\" quotes"));
+}
+
+TEST(EscapePythonDocstringTest, BackslashBeforeTripleQuote) {
+  // Backslash immediately before triple-quote: both should be escaped.
+  EXPECT_EQ("\\\\\\\"\\\"\\\"", EscapePythonDocstring("\\\"\"\""));
+}
+
+TEST(EscapePythonDocstringTest, MaliciousInjection) {
+  // Simulates a proto comment designed to break out of the docstring and
+  // inject arbitrary Python code.
+  std::string malicious = "\"\"\"\nimport os; os.system('rm -rf /')\n\"\"\"";
+  std::string escaped = EscapePythonDocstring(malicious);
+  // The escaped output must not contain an unescaped triple-quote sequence.
+  EXPECT_EQ(std::string::npos, escaped.find("\"\"\""));
+}
+
+}  // namespace
+}  // namespace grpc_python_generator
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/cpp/codegen/python_generator_test.cc
+++ b/test/cpp/codegen/python_generator_test.cc
@@ -79,6 +79,21 @@ TEST(EscapePythonDocstringTest, MaliciousInjection) {
   EXPECT_EQ(std::string::npos, escaped.find("\"\"\""));
 }
 
+TEST(EscapePythonDocstringTest, StartPosSkipsLeadingCharacters) {
+  // Escaping from start_pos matches escaping the equivalent substring, which
+  // is how PrintAllComments skips a comment's leading indentation.
+  std::string line = "   has \"\"\" quotes";
+  EXPECT_EQ("has \\\"\\\"\\\" quotes",
+            EscapePythonDocstring(line, line.find_first_not_of(' ')));
+}
+
+TEST(EscapePythonDocstringTest, StartPosPastEndReturnsEmpty) {
+  // A start_pos at or beyond the end yields an empty result rather than
+  // reading out of bounds.
+  EXPECT_EQ("", EscapePythonDocstring("abc", 3));
+  EXPECT_EQ("", EscapePythonDocstring("abc", 99));
+}
+
 }  // namespace
 }  // namespace grpc_python_generator
 


### PR DESCRIPTION
## Summary

Add `EscapePythonDocstring()` to sanitize proto comment text before embedding it in triple-quoted Python docstrings in the gRPC Python code generator.

Fixes #43022

## Problem

`PrintAllComments()` in `python_generator.cc` wraps proto comments in `"""..."""` using `PrintRaw()` with no escaping. If a `.proto` comment contains a triple-quote sequence (`"""`), it breaks out of the docstring boundary in the generated Python code, producing syntactically invalid or exploitable output.

## Fix

The new `EscapePythonDocstring()` function escapes:
- Backslashes (`\` → `\\`)
- Triple-quote sequences (`"""` → `\"\"\"`)

Applied in `PrintAllComments()` before `PrintRaw()`, ensuring generated Python source remains valid regardless of proto comment content.

## Testing

Normal proto comments (without `"""` or `\`) pass through unchanged. Only comments containing these sequences are modified, and the resulting Python docstrings remain semantically equivalent.