### PR TITLE
fix(load_reporter): check for NULL file pointer in GetCpuStatsImpl

### DIFF
--- a/src/cpp/server/load_reporter/get_cpu_stats_linux.cc
+++ b/src/cpp/server/load_reporter/get_cpu_stats_linux.cc
@@ -35,6 +35,9 @@ std::pair<uint64_t, uint64_t> GetCpuStatsImpl() {
   uint64_t busy = 0, total = 0;
   FILE* fp;
   fp = fopen("/proc/stat", "r");
+  if (fp == nullptr) {
+    return std::pair<uint64_t, uint64_t>(0, 0);
+  }
   uint64_t user, nice, system, idle;
   if (fscanf(fp, "cpu %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64, &user,
              &nice, &system, &idle) != 4) {


### PR DESCRIPTION
## Summary
- Fix NULL pointer dereference when /proc/stat is not readable

## Bug
fopen("/proc/stat", "r") can return NULL in containerized environments, sandboxes, or restricted chroots. The return value is never checked, causing fscanf(fp, ...) to be called with a NULL FILE pointer — undefined behavior that typically results in a segfault.

## Fix
Add a NULL check after fopen and return default zero values if the file cannot be opened.