### PR TITLE
bazel: disable experimental_python_import_all_repositories

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -27,6 +27,10 @@ common:bzlmod --noenable_workspace
 build:python-bzlmod --incompatible_default_to_explicit_init_py
 build:python-bzlmod --config=bzlmod # inherit bzlmod configuration
 
+# Confirmed fix (macOS, Bazel 8.7, tested with plain `bazel test //src/python/...`,
+# no --config flag needed): resolves the same ModuleNotFoundError above.
+test --noexperimental_python_import_all_repositories
+
 # Can be explicitly disable via --config=no-bzlmod
 # TODO(weizheyuan): Remove this after migration is done.
 common:no-bzlmod --noenable_bzlmod


### PR DESCRIPTION
Partially fixes #43028 

`bazel test //src/python/...` fails 40 targets on a clean checkout
with `ModuleNotFoundError: No module named 'src.python'` or `ModuleNotFoundError 'src.proto'`,

The failures are caused by Bazel exposing all workspace repositories on
`sys.path` through `experimental_python_import_all_repositories`, which
interferes with implicit PEP 420 namespace package resolution.

Disable this behavior by adding
`--noexperimental_python_import_all_repositories` to `.bazelrc`.
This scopes each target's `sys.path` to its declared dependencies instead
of including Python roots from all repositories in the workspace.

This fix resolves:
- all `ModuleNotFoundError: No module named 'src.python'` problems
- 4/8  `ModuleNotFoundError 'src.proto'` problems

The fix was verified with identical results on the three Apple Silicon
Macs listed in the issue.

Note:
This change resolves 33 of the 40 failing test targets. The remaining
7 failures are caused by a separate namespace package issue and will be
addressed in a follow-up PR.


