### PR TITLE
[fix] guard e2e test cert selector with boringssl to fix portability

### DIFF
--- a/test/cpp/end2end/tls_test_certificate_selector.h
+++ b/test/cpp/end2end/tls_test_certificate_selector.h
@@ -32,6 +32,8 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
+#if defined(OPENSSL_IS_BORINGSSL)
+
 namespace grpc {
 namespace testing {
 
@@ -103,4 +105,5 @@ class AsyncTestCertificateSelector : public grpc_core::CertificateSelector {
 }  // namespace testing
 }  // namespace grpc
 
+#endif  // OPENSSL_IS_BORINGSSL
 #endif  // GRPC_TEST_CPP_END2END_TLS_TEST_CERTIFICATE_SELECTOR_H

--- a/test/cpp/end2end/tls_test_private_key_signer.cc
+++ b/test/cpp/end2end/tls_test_private_key_signer.cc
@@ -208,4 +208,4 @@ void AsyncTestPrivateKeySigner::Cancel(
 }  // namespace testing
 }  // namespace grpc
 
-#endif
+#endif  // OPENSSL_IS_BORINGSSL


### PR DESCRIPTION
- [ ] [grpc/core/master/linux/grpc_portability_openssl](https://source.cloud.google.com/results/invocations/56ed2dd1-d78d-42e0-884b-3b469b59343a)

Portability passed.