### PR TITLE
[PSM Interop] : add cleanup for the orphaned resources left for SPIFFE cluster.

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
+++ b/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
@@ -108,6 +108,14 @@ cleanup::job::cleanup_cluster_dualstack() {
 }
 
 #######################################
+# The Fleet cluster is used by the spiffe test suites.
+#######################################
+cleanup::job::cleanup_cluster_fleet() {
+  cleanup::activate_cluster GKE_CLUSTER_PSM_INTEROP_FLEET
+  cleanup::run_clean "$1" --mode=k8s
+}
+
+#######################################
 # Set common variables for the cleanup script.
 # Globals:
 #   TEST_DRIVER_FLAGFILE: Relative path to test driver flagfile
@@ -164,6 +172,7 @@ main() {
     "cleanup_cluster_url_map"
     "cleanup_cluster_gamma"
     "cleanup_cluster_dualstack"
+    "cleanup_cluster_fleet"
   )
   for job_name in "${cleanup_jobs[@]}"; do
     echo "-------------------- Starting job ${job_name} --------------------"


### PR DESCRIPTION
Passing run of cleanup job: https://fusion2.corp.google.com/ci/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_resource_cleanup/activity/323560a0-ddbd-4a81-b107-9d91c228b0b9/log