### PR TITLE
[Python] SYNC Part 10 - Type Hints fixes and add Pyright for Sync stack _observability.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ reportIncompleteStub = "none"
 reportUnusedClass = "none"
 
 include = [
+    "src/python/grpcio/grpc/_auth.py",
+    "src/python/grpcio/grpc/_compression.py",
+    "src/python/grpcio/grpc/_grpcio_metadata.py",
+    "src/python/grpcio/grpc/_observability.py",
+    "src/python/grpcio/grpc/_typing.py",
     "src/python/grpcio/grpc/_interceptor.py",
     "src/python/grpcio/grpc/_channel.py",
     "src/python/grpcio/grpc/_server.py",

--- a/src/python/grpcio/grpc/_observability.py
+++ b/src/python/grpcio/grpc/_observability.py
@@ -31,10 +31,11 @@ from typing import (
 )
 
 from grpc._cython import cygrpc as _cygrpc
-from grpc._typing import ChannelArgumentType
+from grpc._typing import ChannelArgumentType, ResponseType
 
 if TYPE_CHECKING:
-    from grpc._channel import _RPCState
+    import grpc
+    from grpc._channel import _RPCState  # pyright: ignore[reportPrivateUsage]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ ClientCallTracerCapsule = TypeVar("ClientCallTracerCapsule")
 ServerCallTracerFactoryCapsule = TypeVar("ServerCallTracerFactoryCapsule")
 
 _plugin_lock: threading.RLock = threading.RLock()
-_OBSERVABILITY_PLUGIN: Optional["ObservabilityPlugin"] = None
+_OBSERVABILITY_PLUGIN: Optional[ObservabilityPlugin[Any, Any]] = None
 _SERVICES_TO_EXCLUDE: List[bytes] = [
     b"google.monitoring.v3.MetricService",
     b"google.devtools.cloudtrace.v2.TraceService",
@@ -56,10 +57,10 @@ class ServerCallTracerFactory:
     grpc.experimental.server_call_tracer_factory option
     """
 
-    def __init__(self, address):
+    def __init__(self, address: int):
         self._address = address
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self._address
 
 
@@ -159,7 +160,11 @@ class ObservabilityPlugin(
 
     @abc.abstractmethod
     def record_rpc_latency(
-        self, method: str, target: str, rpc_latency: float, status_code: Any
+        self,
+        method: str,
+        target: str,
+        rpc_latency: float,
+        status_code: Optional[grpc.StatusCode],
     ) -> None:
         """Record the latency of the RPC.
 
@@ -217,7 +222,7 @@ class ObservabilityPlugin(
 
 
 @contextlib.contextmanager
-def get_plugin() -> Generator[Optional[ObservabilityPlugin], None, None]:
+def get_plugin() -> Generator[Optional[ObservabilityPlugin[Any, Any]], None, None]:
     """Get the ObservabilityPlugin in _observability module.
 
     Returns:
@@ -228,7 +233,9 @@ def get_plugin() -> Generator[Optional[ObservabilityPlugin], None, None]:
         yield _OBSERVABILITY_PLUGIN
 
 
-def set_plugin(observability_plugin: Optional[ObservabilityPlugin]) -> None:
+def set_plugin(
+    observability_plugin: Optional[ObservabilityPlugin[Any, Any]],
+) -> None:
     """Save ObservabilityPlugin to _observability module.
 
     Args:
@@ -246,7 +253,9 @@ def set_plugin(observability_plugin: Optional[ObservabilityPlugin]) -> None:
         _OBSERVABILITY_PLUGIN = observability_plugin
 
 
-def observability_init(observability_plugin: ObservabilityPlugin) -> None:
+def observability_init(
+    observability_plugin: ObservabilityPlugin[Any, Any],
+) -> None:
     """Initialize observability with provided ObservabilityPlugin.
 
     This method have to be called at the start of a program, before any
@@ -273,7 +282,7 @@ def observability_deinit() -> None:
     _cygrpc.clear_server_call_tracer_factory()
 
 
-def maybe_record_rpc_latency(state: "_RPCState") -> None:
+def maybe_record_rpc_latency(state: _RPCState[ResponseType]) -> None:
     """Record the latency of the RPC, if the plugin is registered and stats is enabled.
 
     This method will be called at the end of each RPC.
@@ -282,6 +291,13 @@ def maybe_record_rpc_latency(state: "_RPCState") -> None:
       state: a grpc._channel._RPCState object which contains the stats related to the
     RPC.
     """
+    if (
+        state.method is None
+        or state.target is None
+        or state.rpc_start_time is None
+        or state.rpc_end_time is None
+    ):
+        return
     # TODO(xuanwn): use channel args to exclude those metrics.
     for exclude_prefix in _SERVICES_TO_EXCLUDE:
         if exclude_prefix in state.method.encode("utf8"):

--- a/src/python/grpcio/grpc/_typing.py
+++ b/src/python/grpcio/grpc/_typing.py
@@ -32,7 +32,7 @@ from grpc._cython import cygrpc
 
 if TYPE_CHECKING:
     from grpc import ServicerContext
-    from grpc._server import _RPCState
+    from grpc._server import _RPCState  # pyright: ignore[reportPrivateUsage]
 
 RequestType = TypeVar("RequestType")
 ResponseType = TypeVar("ResponseType")


### PR DESCRIPTION
# Description

Type Hints fixes and add Pyright for `_observability.py`, `_typing.py`, `_auth.py`, `_compression.py` and `_grpcio_metadata.py`

```python
+ [19:53:14 IST]         exec pyright
  src/python/grpcio/grpc/_observability.py:37:31 - error: "_RPCState" is private and used outside of the module in which it is declared (reportPrivateUsage)
  src/python/grpcio/grpc/_observability.py:45:34 - error: Expected type arguments for generic class "ObservabilityPlugin" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_observability.py:59:24 - error: Type of parameter "address" is unknown (reportUnknownParameterType)
  src/python/grpcio/grpc/_observability.py:59:24 - error: Type annotation is missing for parameter "address" (reportMissingParameterType)
  src/python/grpcio/grpc/_observability.py:220:5 - error: Return type, "Generator[ObservabilityPlugin[Unknown, Unknown] | None, None, None]", is partially unknown (reportUnknownParameterType)
  src/python/grpcio/grpc/_observability.py:220:40 - error: Expected type arguments for generic class "ObservabilityPlugin" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_observability.py:231:16 - error: Type of parameter "observability_plugin" is partially unknown
  src/python/grpcio/grpc/_observability.py:231:47 - error: Expected type arguments for generic class "ObservabilityPlugin" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_observability.py:246:9 - error: Type of "_OBSERVABILITY_PLUGIN" is partially unknown
  src/python/grpcio/grpc/_observability.py:249:24 - error: Type of parameter "observability_plugin" is partially unknown
  src/python/grpcio/grpc/_observability.py:249:46 - error: Expected type arguments for generic class "ObservabilityPlugin" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_observability.py:276:30 - error: Type of parameter "state" is partially unknown
  src/python/grpcio/grpc/_observability.py:276:38 - error: Expected type arguments for generic class "_RPCState" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_observability.py:287:43 - error: "encode" is not a known attribute of "None" (reportOptionalMemberAccess)
  src/python/grpcio/grpc/_observability.py:289:26 - error: Type of "plugin" is partially unknown
  src/python/grpcio/grpc/_observability.py:291:13 - error: Type of "rpc_latency_s" is partially unknown
  src/python/grpcio/grpc/_observability.py:291:29 - error: Operator "-" not supported for types "float | None" and "float | None"
  src/python/grpcio/grpc/_observability.py:292:13 - error: Type of "rpc_latency_ms" is partially unknown
  src/python/grpcio/grpc/_observability.py:294:17 - error: Argument of type "str | None" cannot be assigned to parameter "method" of type "str" in function "record_rpc_latency"
  src/python/grpcio/grpc/_observability.py:294:31 - error: Argument of type "str | None" cannot be assigned to parameter "target" of type "str" in function "record_rpc_latency"
  src/python/grpcio/grpc/_observability.py:294:45 - error: Argument type is partially unknown
  src/python/grpcio/grpc/_observability.py:301:26 - error: Type of "plugin" is partially unknown
  src/python/grpcio/grpc/_typing.py:35:30 - error: "_RPCState" is private and used outside of the module in which it is declared (reportPrivateUsage)
23 errors, 18 warnings, 0 informations
```

