### PR TITLE
[Python] SYNC Part 11 - Type Hints fixes and add Pyright for Sync stack _plugin_wrapping.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,14 +83,15 @@ reportUnusedClass = "none"
 
 include = [
     "src/python/grpcio/grpc/_auth.py",
+    "src/python/grpcio/grpc/_channel.py",
+    "src/python/grpcio/grpc/_common.py",
     "src/python/grpcio/grpc/_compression.py",
     "src/python/grpcio/grpc/_grpcio_metadata.py",
-    "src/python/grpcio/grpc/_observability.py",
-    "src/python/grpcio/grpc/_typing.py",
     "src/python/grpcio/grpc/_interceptor.py",
-    "src/python/grpcio/grpc/_channel.py",
+    "src/python/grpcio/grpc/_observability.py",
+    "src/python/grpcio/grpc/_plugin_wrapping.py",
+    "src/python/grpcio/grpc/_typing.py",
     "src/python/grpcio/grpc/_server.py",
-    "src/python/grpcio/grpc/_common.py",
     "src/python/grpcio/grpc/aio"
 ]
 

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import logging
 import threading
-from typing import Callable, Optional, Type, Union
+from typing import Callable, NamedTuple, Optional, Union
 
 import grpc
 from grpc import _common
@@ -25,36 +24,39 @@ from grpc._typing import MetadataType
 _LOGGER = logging.getLogger(__name__)
 
 
-class _AuthMetadataContext(
-    collections.namedtuple(
-        "AuthMetadataContext",
-        (
-            "service_url",
-            "method_name",
-        ),
-    ),
-    grpc.AuthMetadataContext,
-):
+class _AuthMetadataContextTuple(NamedTuple):
+    service_url: str
+    method_name: str
+
+
+class _AuthMetadataContext(_AuthMetadataContextTuple, grpc.AuthMetadataContext):
     pass
 
 
 class _CallbackState:
+    exception: Optional[Exception]
+
     def __init__(self):
         self.lock = threading.Lock()
         self.called = False
         self.exception = None
 
 
+_WrappedCallback = Callable[
+    [Optional[MetadataType], cygrpc.StatusCode, Optional[bytes]], None
+]
+
+
 class _AuthMetadataPluginCallback(grpc.AuthMetadataPluginCallback):
     _state: _CallbackState
-    _callback: Callable
+    _callback: _WrappedCallback
 
-    def __init__(self, state: _CallbackState, callback: Callable):
+    def __init__(self, state: _CallbackState, callback: _WrappedCallback):
         self._state = state
         self._callback = callback
 
     def __call__(
-        self, metadata: MetadataType, error: Optional[Type[BaseException]]
+        self, metadata: MetadataType, error: Optional[Exception]
     ) -> None:
         with self._state.lock:
             if self._state.exception is None:
@@ -100,7 +102,7 @@ class _Plugin:
         self,
         service_url: Union[str, bytes],
         method_name: Union[str, bytes],
-        callback: Callable,
+        callback: _WrappedCallback,
     ) -> None:
         context = _AuthMetadataContext(
             _common.decode(service_url), _common.decode(method_name)
@@ -139,3 +141,4 @@ def metadata_plugin_call_credentials(
             _Plugin(metadata_plugin), _common.encode(effective_name)
         )
     )
+


### PR DESCRIPTION
Fixes Type Hints fixes and add Pyright for `_plugin_wrapping.py`

```python
+ [20:08:38 IST]         exec pyright
  src/python/grpcio/grpc/_plugin_wrapping.py:29:5 - error: "namedtuple" provides no types for tuple entries; use "NamedTuple" instead (reportUntypedNamedTuple)
  src/python/grpcio/grpc/_plugin_wrapping.py:50:16 - error: Expected type arguments for generic class "Callable" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_plugin_wrapping.py:52:47 - error: Type of parameter "callback" is partially unknown
  src/python/grpcio/grpc/_plugin_wrapping.py:52:57 - error: Expected type arguments for generic class "Callable" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_plugin_wrapping.py:56:9 - error: Method "__call__" overrides class "AuthMetadataPluginCallback" in an incompatible manner
  src/python/grpcio/grpc/_plugin_wrapping.py:74:13 - error: Type of "_callback" is partially unknown
src/python/grpcio/grpc/_plugin_wrapping.py:76:13 - error: Type of "_callback" is partially unknown
  src/python/grpcio/grpc/_plugin_wrapping.py:103:9 - error: Type of parameter "callback" is partially unknown
  src/python/grpcio/grpc/_plugin_wrapping.py:103:19 - error: Expected type arguments for generic class "Callable" (reportMissingTypeArgument)
  src/python/grpcio/grpc/_plugin_wrapping.py:119:32 - error: Cannot assign to attribute "exception" for class "_CallbackState"
10 errors, 19 warnings, 0 informations
```