### PR TITLE
[Security][Telemetry] Implement metric for Private Key Offloading

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4638,6 +4638,7 @@ grpc_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "gpr",
+        "grpc_public_hdrs",
         "tsi_base",
         "//src/core:tsi_ssl_types",
     ],

--- a/include/grpc/private_key_signer.h
+++ b/include/grpc/private_key_signer.h
@@ -85,6 +85,9 @@ class PrivateKeySigner {
   // Cancels an in-flight async signing operation using a handle returned
   // from a previous call to Sign().
   virtual void Cancel(std::shared_ptr<AsyncSigningHandle> handle) = 0;
+
+  // Returns a string identifying the private key signer implementation.
+  virtual absl::string_view Name() const { return ""; }
 };
 }  // namespace grpc_core
 

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -12370,6 +12370,7 @@ grpc_cc_library(
         "absl/strings",
     ],
     deps = [
+        "histogram",
         "instrument",
     ],
 )

--- a/src/core/telemetry/histogram.h
+++ b/src/core/telemetry/histogram.h
@@ -15,6 +15,7 @@
 #ifndef GRPC_SRC_CORE_TELEMETRY_HISTOGRAM_H
 #define GRPC_SRC_CORE_TELEMETRY_HISTOGRAM_H
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -109,6 +110,30 @@ class ExponentialHistogramShape {
       delete;
   ExponentialHistogramShape(ExponentialHistogramShape&&) = default;
   ExponentialHistogramShape& operator=(ExponentialHistogramShape&&) = default;
+
+  size_t buckets() const { return bounds_.size(); }
+  size_t BucketFor(int64_t value) const {
+    return BucketInBoundsFor(bounds_, value);
+  }
+
+  HistogramBuckets bounds() const { return bounds_; }
+
+ private:
+  std::vector<int64_t> bounds_;
+};
+
+class ExplicitHistogramShape {
+ public:
+  explicit ExplicitHistogramShape(const std::vector<int64_t>& bounds)
+      : bounds_(bounds) {
+    GRPC_CHECK(!bounds_.empty());
+    GRPC_CHECK(std::is_sorted(bounds_.begin(), bounds_.end()));
+  }
+
+  ExplicitHistogramShape(const ExplicitHistogramShape&) = delete;
+  ExplicitHistogramShape& operator=(const ExplicitHistogramShape&) = delete;
+  ExplicitHistogramShape(ExplicitHistogramShape&&) = default;
+  ExplicitHistogramShape& operator=(ExplicitHistogramShape&&) = default;
 
   size_t buckets() const { return bounds_.size(); }
   size_t BucketFor(int64_t value) const {

--- a/src/core/tsi/ssl_telemetry_utils.cc
+++ b/src/core/tsi/ssl_telemetry_utils.cc
@@ -16,12 +16,17 @@
 //
 //
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/tsi/ssl_telemetry_utils.h"
 
-#include <grpc/support/port_platform.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+
+#if defined(OPENSSL_IS_BORINGSSL)
+#include <grpc/private_key_signer.h>
+#endif
 
 #include "absl/strings/string_view.h"
 
@@ -296,5 +301,32 @@ absl::string_view TlsTelemetryHandshakeResultToString(
   }
   return "UNKNOWN_FAILURE";
 }
+
+#if defined(OPENSSL_IS_BORINGSSL)
+absl::string_view PrivateKeySignerSignatureAlgorithmToString(
+    PrivateKeySigner::SignatureAlgorithm algorithm) {
+  switch (algorithm) {
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha256:
+      return "RsaPkcs1Sha256";
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha384:
+      return "RsaPkcs1Sha384";
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha512:
+      return "RsaPkcs1Sha512";
+    case PrivateKeySigner::SignatureAlgorithm::kEcdsaSecp256r1Sha256:
+      return "EcdsaSecp256r1Sha256";
+    case PrivateKeySigner::SignatureAlgorithm::kEcdsaSecp384r1Sha384:
+      return "EcdsaSecp384r1Sha384";
+    case PrivateKeySigner::SignatureAlgorithm::kEcdsaSecp521r1Sha512:
+      return "EcdsaSecp521r1Sha512";
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha256:
+      return "RsaPssRsaeSha256";
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha384:
+      return "RsaPssRsaeSha384";
+    case PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha512:
+      return "RsaPssRsaeSha512";
+  }
+  return "";
+}
+#endif
 
 }  // namespace grpc_core

--- a/src/core/tsi/ssl_telemetry_utils.h
+++ b/src/core/tsi/ssl_telemetry_utils.h
@@ -21,6 +21,12 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <openssl/ssl.h>
+
+#if defined(OPENSSL_IS_BORINGSSL)
+#include <grpc/private_key_signer.h>
+#endif
+
 #include "src/core/tsi/transport_security_interface.h"
 #include "absl/strings/string_view.h"
 
@@ -78,6 +84,11 @@ TlsTelemetryHandshakeResult MapSslErrorToTlsTelemetryHandshakeResult(
 // representation for monitoring.
 absl::string_view TlsTelemetryHandshakeResultToString(
     TlsTelemetryHandshakeResult result);
+
+#if defined(OPENSSL_IS_BORINGSSL)
+absl::string_view PrivateKeySignerSignatureAlgorithmToString(
+    PrivateKeySigner::SignatureAlgorithm algorithm);
+#endif
 
 }  // namespace grpc_core
 

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -285,6 +285,8 @@ struct tsi_ssl_handshaker : public tsi_handshaker,
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu);
 
 #if defined(OPENSSL_IS_BORINGSSL)
+  void MaybeRecordOffloadPrivateKeySigningTelemetry(absl::Status status)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu);
   std::shared_ptr<AsyncCertificateSelectionHandle> cert_selection_handle
       ABSL_GUARDED_BY(mu);
   // Will be set if the certificate selector is used and the asynchronous cert
@@ -303,9 +305,6 @@ struct tsi_ssl_handshaker : public tsi_handshaker,
   absl::Time signing_start_time ABSL_GUARDED_BY(mu);
   std::string signing_algorithm_str ABSL_GUARDED_BY(mu);
   bool signing_metric_recorded ABSL_GUARDED_BY(mu) = false;
-
-  void MaybeRecordOffloadPrivateKeySigningTelemetry(absl::Status status)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu);
 #endif
 };
 
@@ -362,34 +361,6 @@ void tsi_ssl_handshaker::MaybeRecordTelemetry(
 }
 
 #if defined(OPENSSL_IS_BORINGSSL)
-absl::string_view PrivateKeySignerSignatureAlgorithmToString(
-    grpc_core::PrivateKeySigner::SignatureAlgorithm algorithm) {
-  switch (algorithm) {
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha256:
-      return "RsaPkcs1Sha256";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha384:
-      return "RsaPkcs1Sha384";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha512:
-      return "RsaPkcs1Sha512";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
-        kEcdsaSecp256r1Sha256:
-      return "EcdsaSecp256r1Sha256";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
-        kEcdsaSecp384r1Sha384:
-      return "EcdsaSecp384r1Sha384";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
-        kEcdsaSecp521r1Sha512:
-      return "EcdsaSecp521r1Sha512";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha256:
-      return "RsaPssRsaeSha256";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha384:
-      return "RsaPssRsaeSha384";
-    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha512:
-      return "RsaPssRsaeSha512";
-  }
-  return "";
-}
-
 void tsi_ssl_handshaker::MaybeRecordOffloadPrivateKeySigningTelemetry(
     absl::Status status) {
   if (collection_scope == nullptr) return;
@@ -399,8 +370,8 @@ void tsi_ssl_handshaker::MaybeRecordOffloadPrivateKeySigningTelemetry(
   std::string status_str = absl::StatusCodeToString(status.code());
   std::string offloader_name =
       key_signer != nullptr ? std::string(key_signer->Name()) : "";
-  int64_t duration_sec =
-      absl::ToInt64Seconds(absl::Now() - signing_start_time);
+  int64_t duration_us =
+      absl::ToInt64Microseconds(absl::Now() - signing_start_time);
 
   if (is_client) {
     auto storage =
@@ -409,7 +380,7 @@ void tsi_ssl_handshaker::MaybeRecordOffloadPrivateKeySigningTelemetry(
             signing_algorithm_str, locality, backend_service);
     storage->Increment(
         grpc_core::TlsClientPrivateKeyOffloadTelemetryDomain::kDuration,
-        duration_sec);
+        duration_us);
   } else {
     auto storage =
         grpc_core::TlsServerPrivateKeyOffloadTelemetryDomain::GetStorage(
@@ -417,7 +388,7 @@ void tsi_ssl_handshaker::MaybeRecordOffloadPrivateKeySigningTelemetry(
             signing_algorithm_str);
     storage->Increment(
         grpc_core::TlsServerPrivateKeyOffloadTelemetryDomain::kDuration,
-        duration_sec);
+        duration_us);
   }
 }
 #endif

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -300,6 +300,12 @@ struct tsi_ssl_handshaker : public tsi_handshaker,
   // The handle for an in-flight async signing operation.
   std::shared_ptr<grpc_core::PrivateKeySigner::AsyncSigningHandle>
       signing_handle ABSL_GUARDED_BY(mu);
+  absl::Time signing_start_time ABSL_GUARDED_BY(mu);
+  std::string signing_algorithm_str ABSL_GUARDED_BY(mu);
+  bool signing_metric_recorded ABSL_GUARDED_BY(mu) = false;
+
+  void MaybeRecordOffloadPrivateKeySigningTelemetry(absl::Status status)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu);
 #endif
 };
 
@@ -354,6 +360,67 @@ void tsi_ssl_handshaker::MaybeRecordTelemetry(
         grpc_core::TlsServerHandshakeTelemetryDomain::kHandshakes);
   }
 }
+
+#if defined(OPENSSL_IS_BORINGSSL)
+absl::string_view PrivateKeySignerSignatureAlgorithmToString(
+    grpc_core::PrivateKeySigner::SignatureAlgorithm algorithm) {
+  switch (algorithm) {
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha256:
+      return "RsaPkcs1Sha256";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha384:
+      return "RsaPkcs1Sha384";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPkcs1Sha512:
+      return "RsaPkcs1Sha512";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
+        kEcdsaSecp256r1Sha256:
+      return "EcdsaSecp256r1Sha256";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
+        kEcdsaSecp384r1Sha384:
+      return "EcdsaSecp384r1Sha384";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::
+        kEcdsaSecp521r1Sha512:
+      return "EcdsaSecp521r1Sha512";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha256:
+      return "RsaPssRsaeSha256";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha384:
+      return "RsaPssRsaeSha384";
+    case grpc_core::PrivateKeySigner::SignatureAlgorithm::kRsaPssRsaeSha512:
+      return "RsaPssRsaeSha512";
+  }
+  return "";
+}
+
+void tsi_ssl_handshaker::MaybeRecordOffloadPrivateKeySigningTelemetry(
+    absl::Status status) {
+  if (collection_scope == nullptr) return;
+  if (signing_metric_recorded) return;
+  signing_metric_recorded = true;
+
+  std::string status_str = absl::StatusCodeToString(status.code());
+  std::string offloader_name =
+      key_signer != nullptr ? std::string(key_signer->Name()) : "";
+  int64_t duration_sec =
+      absl::ToInt64Seconds(absl::Now() - signing_start_time);
+
+  if (is_client) {
+    auto storage =
+        grpc_core::TlsClientPrivateKeyOffloadTelemetryDomain::GetStorage(
+            collection_scope, status_str, target, offloader_name,
+            signing_algorithm_str, locality, backend_service);
+    storage->Increment(
+        grpc_core::TlsClientPrivateKeyOffloadTelemetryDomain::kDuration,
+        duration_sec);
+  } else {
+    auto storage =
+        grpc_core::TlsServerPrivateKeyOffloadTelemetryDomain::GetStorage(
+            collection_scope, status_str, offloader_name,
+            signing_algorithm_str);
+    storage->Increment(
+        grpc_core::TlsServerPrivateKeyOffloadTelemetryDomain::kDuration,
+        duration_sec);
+  }
+}
+#endif
 
 static std::pair<tsi_result, std::optional<HandshakerNextArgs>>
 ssl_handshaker_next_async(tsi_ssl_handshaker* self)
@@ -586,6 +653,8 @@ void TlsOffloadSignDoneCallback(
     if (handshaker->is_shutdown) return;
     handshaker->signed_bytes = std::move(signed_data);
     handshaker->signing_handle.reset();
+    handshaker->MaybeRecordOffloadPrivateKeySigningTelemetry(
+        handshaker->signed_bytes.status());
     // Once the signed bytes are obtained, tell everything to resume the
     // pending async operation.
     auto async_result = ssl_handshaker_next_async(handshaker.get());
@@ -638,6 +707,8 @@ enum ssl_private_key_result_t TlsPrivateKeySignWrapper(
     handshaker->MaybeSetError("Handshaker is shutting down");
     return ssl_private_key_failure;
   }
+  handshaker->signing_start_time = absl::Now();
+  handshaker->signing_metric_recorded = false;
   // Create the completion callback by binding the current context.
   auto done_callback =
       absl::bind_front(TlsOffloadSignDoneCallback, handshaker->Ref());
@@ -648,10 +719,17 @@ enum ssl_private_key_result_t TlsPrivateKeySignWrapper(
   auto algorithm = ToSignatureAlgorithmClass(signature_algorithm);
   if (!algorithm.ok()) {
     handshaker->MaybeSetError(algorithm.status().ToString());
+    handshaker->signing_algorithm_str.clear();
+    handshaker->MaybeRecordOffloadPrivateKeySigningTelemetry(
+        algorithm.status());
     return ssl_private_key_failure;
   }
+  handshaker->signing_algorithm_str = std::string(
+      PrivateKeySignerSignatureAlgorithmToString(*algorithm));
   if (handshaker->key_signer == nullptr) {
     handshaker->MaybeSetError("PrivateKeySigner is null");
+    handshaker->MaybeRecordOffloadPrivateKeySigningTelemetry(
+        absl::InternalError("PrivateKeySigner is null"));
     return ssl_private_key_failure;
   }
   auto result = handshaker->key_signer->Sign(
@@ -663,6 +741,8 @@ enum ssl_private_key_result_t TlsPrivateKeySignWrapper(
       [&](absl::StatusOr<std::string>* status_or_string)
           ABSL_NO_THREAD_SAFETY_ANALYSIS {
             handshaker->signed_bytes = std::move(*status_or_string);
+            handshaker->MaybeRecordOffloadPrivateKeySigningTelemetry(
+                handshaker->signed_bytes.status());
             return TlsPrivateKeyOffloadComplete(ssl, out, out_len, max_out);
           },
       [&](std::shared_ptr<grpc_core::PrivateKeySigner::AsyncSigningHandle>*
@@ -2828,6 +2908,8 @@ static void ssl_handshaker_shutdown(tsi_handshaker* self, bool peer_closed) {
     });
 #if defined(OPENSSL_IS_BORINGSSL)
     if (impl->key_signer != nullptr && impl->signing_handle != nullptr) {
+      impl->MaybeRecordOffloadPrivateKeySigningTelemetry(
+          absl::CancelledError("Handshaker shutdown"));
       key_signer = std::move(impl->key_signer);
       signing_handle = std::move(impl->signing_handle);
     }

--- a/src/core/tsi/tls_telemetry.cc
+++ b/src/core/tsi/tls_telemetry.cc
@@ -17,6 +17,20 @@
 #include "src/core/telemetry/instrument.h"
 
 namespace grpc_core {
+namespace {
+
+const std::vector<int64_t>& GetLatencyBuckets() {
+  static const auto* buckets = new std::vector<int64_t>{
+      0,      10,     50,     100,    300,    600,    800,
+      1000,   2000,   3000,   4000,   5000,   6000,   8000,
+      10000,  13000,  16000,  20000,  25000,  30000,  40000,
+      50000,  65000,  80000,  100000, 130000, 160000, 200000,
+      250000, 300000, 400000, 500000, 650000, 800000, 1000000,
+      2000000, 5000000, 10000000, 20000000, 50000000, 100000000};
+  return *buckets;
+}
+
+}  // namespace
 
 TlsClientHandshakeTelemetryDomain::CounterHandle
     TlsClientHandshakeTelemetryDomain::kHandshakes = RegisterCounter(
@@ -29,21 +43,21 @@ TlsServerHandshakeTelemetryDomain::CounterHandle
         "Total number of server-side TLS handshakes", "{handshake}");
 
 TlsClientPrivateKeyOffloadTelemetryDomain::HistogramHandle<
-    ExponentialHistogramShape>
+    ExplicitHistogramShape>
     TlsClientPrivateKeyOffloadTelemetryDomain::kDuration =
-        RegisterHistogram<ExponentialHistogramShape>(
+        RegisterHistogram<ExplicitHistogramShape>(
             "grpc.client.tls.offload_private_key_signing_duration",
             "EXPERIMENTAL: Measures the duration of the offloaded private key "
             "signing operation.",
-            "s", 60, 20);
+            "us", GetLatencyBuckets());
 
 TlsServerPrivateKeyOffloadTelemetryDomain::HistogramHandle<
-    ExponentialHistogramShape>
+    ExplicitHistogramShape>
     TlsServerPrivateKeyOffloadTelemetryDomain::kDuration =
-        RegisterHistogram<ExponentialHistogramShape>(
+        RegisterHistogram<ExplicitHistogramShape>(
             "grpc.server.tls.offload_private_key_signing_duration",
             "EXPERIMENTAL: Measures the duration of the offloaded private key "
             "signing operation.",
-            "s", 60, 20);
+            "us", GetLatencyBuckets());
 
 }  // namespace grpc_core

--- a/src/core/tsi/tls_telemetry.cc
+++ b/src/core/tsi/tls_telemetry.cc
@@ -28,4 +28,22 @@ TlsServerHandshakeTelemetryDomain::CounterHandle
         "grpc.server.tls.handshakes",
         "Total number of server-side TLS handshakes", "{handshake}");
 
+TlsClientPrivateKeyOffloadTelemetryDomain::HistogramHandle<
+    ExponentialHistogramShape>
+    TlsClientPrivateKeyOffloadTelemetryDomain::kDuration =
+        RegisterHistogram<ExponentialHistogramShape>(
+            "grpc.client.tls.offload_private_key_signing_duration",
+            "EXPERIMENTAL: Measures the duration of the offloaded private key "
+            "signing operation.",
+            "s", 60, 20);
+
+TlsServerPrivateKeyOffloadTelemetryDomain::HistogramHandle<
+    ExponentialHistogramShape>
+    TlsServerPrivateKeyOffloadTelemetryDomain::kDuration =
+        RegisterHistogram<ExponentialHistogramShape>(
+            "grpc.server.tls.offload_private_key_signing_duration",
+            "EXPERIMENTAL: Measures the duration of the offloaded private key "
+            "signing operation.",
+            "s", 60, 20);
+
 }  // namespace grpc_core

--- a/src/core/tsi/tls_telemetry.h
+++ b/src/core/tsi/tls_telemetry.h
@@ -15,6 +15,7 @@
 #ifndef GRPC_SRC_CORE_TSI_TLS_TELEMETRY_H
 #define GRPC_SRC_CORE_TSI_TLS_TELEMETRY_H
 
+#include "src/core/telemetry/histogram.h"
 #include "src/core/telemetry/instrument.h"
 
 namespace grpc_core {
@@ -52,7 +53,7 @@ class TlsClientPrivateKeyOffloadTelemetryDomain final
   using Backend = LowContentionBackend;
   static constexpr absl::string_view kName = "tls_client_private_key_offload";
 
-  static HistogramHandle<ExponentialHistogramShape> kDuration;
+  static HistogramHandle<ExplicitHistogramShape> kDuration;
 };
 
 class TlsServerPrivateKeyOffloadTelemetryDomain final
@@ -64,7 +65,7 @@ class TlsServerPrivateKeyOffloadTelemetryDomain final
   using Backend = LowContentionBackend;
   static constexpr absl::string_view kName = "tls_server_private_key_offload";
 
-  static HistogramHandle<ExponentialHistogramShape> kDuration;
+  static HistogramHandle<ExplicitHistogramShape> kDuration;
 };
 
 }  // namespace grpc_core

--- a/src/core/tsi/tls_telemetry.h
+++ b/src/core/tsi/tls_telemetry.h
@@ -42,6 +42,31 @@ class TlsServerHandshakeTelemetryDomain final
   static CounterHandle kHandshakes;
 };
 
+class TlsClientPrivateKeyOffloadTelemetryDomain final
+    : public InstrumentDomain<TlsClientPrivateKeyOffloadTelemetryDomain> {
+ public:
+  GRPC_INSTRUMENT_DOMAIN_LABELS("grpc.status", "grpc.target",
+                                "grpc.tls.private_key.offloader_name",
+                                "grpc.tls.private_key_algorithm",
+                                "grpc.lb.locality", "grpc.lb.backend_service");
+  using Backend = LowContentionBackend;
+  static constexpr absl::string_view kName = "tls_client_private_key_offload";
+
+  static HistogramHandle<ExponentialHistogramShape> kDuration;
+};
+
+class TlsServerPrivateKeyOffloadTelemetryDomain final
+    : public InstrumentDomain<TlsServerPrivateKeyOffloadTelemetryDomain> {
+ public:
+  GRPC_INSTRUMENT_DOMAIN_LABELS("grpc.status",
+                                "grpc.tls.private_key.offloader_name",
+                                "grpc.tls.private_key_algorithm");
+  using Backend = LowContentionBackend;
+  static constexpr absl::string_view kName = "tls_server_private_key_offload";
+
+  static HistogramHandle<ExponentialHistogramShape> kDuration;
+};
+
 }  // namespace grpc_core
 
 #endif  // GRPC_SRC_CORE_TSI_TLS_TELEMETRY_H

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -349,6 +349,7 @@ grpc_cc_test(
         "//src/core:wait_for_single_owner",
         "//test/core/event_engine/fuzzing_event_engine",
         "//test/core/event_engine/fuzzing_event_engine:fuzzing_event_engine_cc_proto",
+        "//test/core/test_util:fake_stats_plugin",
         "//test/core/test_util:grpc_test_util",
     ],
 )

--- a/test/core/tsi/private_key_offload_test.cc
+++ b/test/core/tsi/private_key_offload_test.cc
@@ -36,6 +36,7 @@
 #include "absl/synchronization/notification.h"
 
 #if defined(OPENSSL_IS_BORINGSSL)
+#include "test/core/test_util/fake_stats_plugin.h"
 #include "test/core/tsi/private_key_signer_test_util.h"
 
 namespace grpc_core {
@@ -51,13 +52,17 @@ enum class OffloadParty {
 
 class SslOffloadTsiTestFixture {
  public:
-  SslOffloadTsiTestFixture(OffloadParty offload_party,
-                           std::shared_ptr<PrivateKeySigner> signer,
-                           tsi_tls_version tls_version, std::string sni = "")
+  SslOffloadTsiTestFixture(
+      OffloadParty offload_party, std::shared_ptr<PrivateKeySigner> signer,
+      tsi_tls_version tls_version, std::string sni = "",
+      RefCountedPtr<CollectionScope> client_collection_scope = nullptr,
+      RefCountedPtr<CollectionScope> server_collection_scope = nullptr)
       : offload_party_(offload_party),
         signer_(std::move(signer)),
         tls_version_(tls_version),
-        sni_(std::move(sni)) {
+        sni_(std::move(sni)),
+        client_collection_scope_(std::move(client_collection_scope)),
+        server_collection_scope_(std::move(server_collection_scope)) {
     tsi_test_fixture_init(&base_);
     base_.test_unused_bytes = true;
     base_.vtable = &kVtable;
@@ -157,13 +162,13 @@ class SslOffloadTsiTestFixture {
     ASSERT_EQ(
         tsi_ssl_client_handshaker_factory_create_handshaker(
             client_handshaker_factory_, sni_.empty() ? nullptr : sni_.c_str(),
-            0, 0, std::nullopt, /*collection_scope=*/nullptr,
+            0, 0, std::nullopt, /*collection_scope=*/client_collection_scope_,
             /*target=*/sni_, /*locality=*/"",
             /*backend_service=*/"", &client_hs),
         TSI_OK);
     ASSERT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
                   server_handshaker_factory_, 0, 0,
-                  /*collection_scope=*/nullptr, &server_hs),
+                  /*collection_scope=*/server_collection_scope_, &server_hs),
               TSI_OK);
     base_.client_handshaker = client_hs;
     base_.server_handshaker = server_hs;
@@ -216,6 +221,23 @@ class SslOffloadTsiTestFixture {
   std::string sni_;
   bool expect_success_ = false;
   bool expect_success_on_client_ = false;
+  RefCountedPtr<CollectionScope> client_collection_scope_ =
+      grpc_core::CreateCollectionScope(
+          {}, {"grpc.status", "grpc.target",
+               "grpc.tls.private_key.offloader_name",
+               "grpc.tls.private_key_algorithm", "grpc.lb.locality",
+               "grpc.lb.backend_service"});
+  RefCountedPtr<CollectionScope> server_collection_scope_ =
+      grpc_core::CreateCollectionScope(
+          {}, {"grpc.status", "grpc.tls.private_key.offloader_name",
+               "grpc.tls.private_key_algorithm"});
+ public:
+  RefCountedPtr<CollectionScope> client_collection_scope() const {
+    return client_collection_scope_;
+  }
+  RefCountedPtr<CollectionScope> server_collection_scope() const {
+    return server_collection_scope_;
+  }
 };
 
 struct tsi_test_fixture_vtable SslOffloadTsiTestFixture::kVtable = {
@@ -437,6 +459,34 @@ TEST_P(PrivateKeyOffloadTest, OffloadFailsWithSignCancelledOnClient) {
   fixture->Run(/*expect_success=*/false, /*expect_success_on_client*/ false,
                event_engine_.get());
   EXPECT_TRUE(signer->WasCancelled());
+}
+
+TEST_P(PrivateKeyOffloadTest, OffloadTelemetryRecordedOnServer) {
+  auto plugin = MakeStatsPluginForTarget("");
+  auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
+      OffloadParty::kServer, nullptr, GetParam(), "",
+      /*client_collection_scope=*/nullptr,
+      /*server_collection_scope=*/plugin->GetCollectionScope());
+  fixture->Run(/*expect_success=*/true, /*expect_success_on_client*/ true,
+               event_engine_.get());
+  auto hist = plugin->GetHistogramValueByName(
+      "grpc.server.tls.offload_private_key_signing_duration",
+      {"OK", "SyncTestPrivateKeySigner", "RsaPssRsaeSha256"});
+  ASSERT_TRUE(hist.has_value());
+}
+
+TEST_P(PrivateKeyOffloadTest, OffloadTelemetryRecordedOnClient) {
+  auto plugin = MakeStatsPluginForTarget("");
+  auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
+      OffloadParty::kClient, nullptr, GetParam(), "",
+      /*client_collection_scope=*/plugin->GetCollectionScope(),
+      /*server_collection_scope=*/nullptr);
+  fixture->Run(/*expect_success=*/true, /*expect_success_on_client*/ true,
+               event_engine_.get());
+  auto hist = plugin->GetHistogramValueByName(
+      "grpc.client.tls.offload_private_key_signing_duration",
+      {"OK", "", "SyncTestPrivateKeySigner", "RsaPssRsaeSha256", "", ""});
+  ASSERT_TRUE(hist.has_value());
 }
 
 std::string TestNameSuffix(

--- a/test/core/tsi/private_key_signer_test_util.h
+++ b/test/core/tsi/private_key_signer_test_util.h
@@ -51,6 +51,8 @@ class SyncTestPrivateKeySigner final : public PrivateKeySigner {
 
   void Cancel(std::shared_ptr<AsyncSigningHandle> /*handle*/) override;
 
+  absl::string_view Name() const override { return "SyncTestPrivateKeySigner"; }
+
  private:
   bssl::UniquePtr<EVP_PKEY> pkey_;
   Mode mode_;
@@ -73,6 +75,8 @@ class AsyncTestPrivateKeySigner final
        OnSignComplete on_sign_complete) override;
 
   void Cancel(std::shared_ptr<AsyncSigningHandle> /*handle*/) override;
+
+  absl::string_view Name() const override { return "AsyncTestPrivateKeySigner"; }
 
   bool WasCancelled();
 


### PR DESCRIPTION
This PR adds a non-per-call metric for Private Key Offloading.

Release Notes:

Add grpc.client.tls.offload_private_key_signing_duration and grpc.server.tls.offload_private_key_signing_duration metrics.