### PR TITLE
[Python] Add TLS version options to channel credentials

### DIFF
--- a/doc/python/sphinx/grpc.rst
+++ b/doc/python/sphinx/grpc.rst
@@ -54,6 +54,12 @@ Local Connection Type
 .. autoclass:: LocalConnectionType
 
 
+TLS Version
+^^^^^^^^^^^
+
+.. autoclass:: TLSVersion
+
+
 RPC Method Handlers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -293,6 +293,19 @@ class StatusCode(enum.Enum):
     UNAUTHENTICATED = (_cygrpc.StatusCode.unauthenticated, "unauthenticated")
 
 
+@enum.unique
+class TLSVersion(enum.Enum):
+    """TLS protocol versions supported by gRPC.
+
+    Attributes:
+      TLS1_2: TLS 1.2.
+      TLS1_3: TLS 1.3.
+    """
+
+    TLS1_2 = _cygrpc.TLSVersion.tls1_2
+    TLS1_3 = _cygrpc.TLSVersion.tls1_3
+
+
 #############################  gRPC Status  ################################
 
 
@@ -1706,8 +1719,29 @@ def method_handlers_generic_handler(service, method_handlers):
     return _utilities.DictionaryGenericHandler(service, method_handlers)
 
 
+def _validate_tls_versions(minimum_tls_version, maximum_tls_version):
+    for name, version in (
+        ("minimum_tls_version", minimum_tls_version),
+        ("maximum_tls_version", maximum_tls_version),
+    ):
+        if version is not None and not isinstance(version, TLSVersion):
+            raise TypeError("{} must be a grpc.TLSVersion or None".format(name))
+    if (
+        minimum_tls_version is not None
+        and maximum_tls_version is not None
+        and minimum_tls_version.value > maximum_tls_version.value
+    ):
+        raise ValueError(
+            "minimum_tls_version cannot be greater than maximum_tls_version"
+        )
+
+
 def ssl_channel_credentials(
-    root_certificates=None, private_key=None, certificate_chain=None
+    root_certificates=None,
+    private_key=None,
+    certificate_chain=None,
+    minimum_tls_version=None,
+    maximum_tls_version=None,
 ):
     """Creates a ChannelCredentials for use with an SSL-enabled Channel.
 
@@ -1719,13 +1753,31 @@ def ssl_channel_credentials(
         private key should be used.
       certificate_chain: The PEM-encoded certificate chain as a byte string
         to use or None if no certificate chain should be used.
+      minimum_tls_version: The minimum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.2.
+      maximum_tls_version: The maximum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.3.
 
     Returns:
       A ChannelCredentials for use with an SSL-enabled Channel.
     """
+    _validate_tls_versions(minimum_tls_version, maximum_tls_version)
     return ChannelCredentials(
         _cygrpc.SSLChannelCredentials(
-            root_certificates, private_key, certificate_chain
+            root_certificates,
+            private_key,
+            certificate_chain,
+            None,
+            (
+                minimum_tls_version.value
+                if minimum_tls_version is not None
+                else None
+            ),
+            (
+                maximum_tls_version.value
+                if maximum_tls_version is not None
+                else None
+            ),
         )
     )
 
@@ -2287,6 +2339,7 @@ __all__ = (
     "ServicerContext",
     "Status",
     "StatusCode",
+    "TLSVersion",
     "StreamStreamClientInterceptor",
     "StreamStreamMultiCallable",
     "StreamUnaryClientInterceptor",

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -64,6 +64,8 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   cdef readonly object _private_key
   cdef readonly object _certificate_chain
   cdef readonly object _private_key_signer
+  cdef readonly object _minimum_tls_version
+  cdef readonly object _maximum_tls_version
 
   cdef grpc_channel_credentials *c(self) except *
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -186,15 +186,24 @@ cdef class SSLSessionCacheLRU:
     grpc_shutdown()
 
 
+class TLSVersion:
+  tls1_2 = TLS1_2
+  tls1_3 = TLS1_3
+
+
 cdef class SSLChannelCredentials(ChannelCredentials):
 
-  def __cinit__(self, pem_root_certificates, private_key, certificate_chain, private_key_signer=None):
+  def __cinit__(self, pem_root_certificates, private_key, certificate_chain,
+                private_key_signer=None, minimum_tls_version=None,
+                maximum_tls_version=None):
     if pem_root_certificates is not None and not isinstance(pem_root_certificates, bytes):
       raise TypeError('expected certificate to be bytes, got %s' % (type(pem_root_certificates)))
     self._pem_root_certificates = pem_root_certificates
     self._private_key = private_key
     self._certificate_chain = certificate_chain
     self._private_key_signer = private_key_signer
+    self._minimum_tls_version = minimum_tls_version
+    self._maximum_tls_version = maximum_tls_version
     # This gets passed around C++, make sure it stays
     if self._private_key_signer is not None:
       Py_INCREF(self._private_key_signer)
@@ -215,6 +224,14 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     cdef Status private_key_status
 
     c_tls_credentials_options = grpc_tls_credentials_options_create()
+    if self._minimum_tls_version is not None:
+      grpc_tls_credentials_options_set_min_tls_version(
+        c_tls_credentials_options,
+        <grpc_tls_version>self._minimum_tls_version)
+    if self._maximum_tls_version is not None:
+      grpc_tls_credentials_options_set_max_tls_version(
+        c_tls_credentials_options,
+        <grpc_tls_version>self._maximum_tls_version)
     c_pem_root_certificates = self._pem_root_certificates or <const char*>NULL
     if self._private_key or self._certificate_chain or self._private_key_signer:
       c_tls_identity_pairs = grpc_tls_identity_pairs_create()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -542,6 +542,10 @@ cdef extern from "grpc/grpc_security_constants.h":
     GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_NEW
     GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL
 
+  ctypedef enum grpc_tls_version:
+    TLS1_2
+    TLS1_3
+
   ctypedef grpc_ssl_certificate_config_reload_status (*grpc_ssl_server_certificate_config_callback)(
     void *user_data,
     grpc_ssl_server_certificate_config **config)
@@ -594,6 +598,14 @@ cdef extern from "grpc/credentials.h":
 
   grpc_tls_credentials_options *grpc_tls_credentials_options_create() nogil
   void grpc_tls_credentials_options_destroy(grpc_tls_credentials_options* options) nogil
+
+  void grpc_tls_credentials_options_set_min_tls_version(
+    grpc_tls_credentials_options *options,
+    grpc_tls_version version) nogil
+
+  void grpc_tls_credentials_options_set_max_tls_version(
+    grpc_tls_credentials_options *options,
+    grpc_tls_version version) nogil
 
   ctypedef struct grpc_tls_certificate_provider:
     # We don't care about the internals (and in fact don't know them)

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -60,6 +60,7 @@ class AllTest(unittest.TestCase):
             "Server",
             "ServerInterceptor",
             "LocalConnectionType",
+            "TLSVersion",
             "local_channel_credentials",
             "local_server_credentials",
             "alts_channel_credentials",

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -67,6 +67,32 @@ class CredentialsTest(unittest.TestCase):
             certificate_chain=None,
         )
 
+    def test_tls_version_values(self):
+        self.assertSequenceEqual(
+            (grpc.TLSVersion.TLS1_2, grpc.TLSVersion.TLS1_3),
+            tuple(grpc.TLSVersion),
+        )
+
+    def test_tls_versions_create_channel_credentials(self):
+        credentials = grpc.ssl_channel_credentials(
+            minimum_tls_version=grpc.TLSVersion.TLS1_2,
+            maximum_tls_version=grpc.TLSVersion.TLS1_3,
+        )
+        self.assertIsInstance(credentials, grpc.ChannelCredentials)
+
+    def test_invalid_tls_version_types(self):
+        for argument in ("minimum_tls_version", "maximum_tls_version"):
+            with self.subTest(argument=argument):
+                with self.assertRaises(TypeError):
+                    grpc.ssl_channel_credentials(**{argument: "TLS1_2"})
+
+    def test_minimum_tls_version_greater_than_maximum(self):
+        with self.assertRaises(ValueError):
+            grpc.ssl_channel_credentials(
+                minimum_tls_version=grpc.TLSVersion.TLS1_3,
+                maximum_tls_version=grpc.TLSVersion.TLS1_2,
+            )
+
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
## Summary

Adds Python channel APIs for constraining the TLS protocol versions negotiated by secure channels.

- Introduces `grpc.TLSVersion` with TLS 1.2 and TLS 1.3 values.
- Adds optional `minimum_tls_version` and `maximum_tls_version` arguments to `grpc.ssl_channel_credentials()`.
- Validates argument types and rejects a minimum version greater than the maximum.
- Documents the public enum and adds focused unit coverage.

## Motivation

gRPC Core already supports minimum and maximum TLS version bounds, but Python channel callers cannot configure them through the credential API. Exposing the existing Core functionality lets applications enforce TLS policy through the public Python API.

## Implementation

Channel credentials apply the existing Core TLS version setters to the `grpc_tls_credentials_options` object that Python already uses for SSL channel credentials.

## Compatibility and scope

- Both arguments default to `None`, preserving the Core defaults of TLS 1.2 minimum and TLS 1.3 maximum.
- Only TLS 1.2 and TLS 1.3 are exposed, matching the versions supported by the Core enum.
- Server credentials are intentionally out of scope for this PR. They require separate Core plumbing so Python can configure the legacy SSL server-credential path without changing observable auth-context metadata.

## Testing

- 13 focused credential and public-API unit tests passed.
- Cython source generation succeeded.
- The native `grpcio` extension compiled and linked.

Fixes #37305