### PR TITLE
Fix filename identifier signed char undefined behavior

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -42,9 +42,8 @@ inline bool ServerOnlyStreaming(const grpc_generator::Method* method) {
 
 std::string FilenameIdentifier(const std::string& filename) {
   std::string result;
-  for (unsigned i = 0; i < filename.size(); i++) {
-    char c = filename[i];
-    if (isalnum(c)) {
+  for (char c : filename) {
+    if (c >= 0 && std::isalnum(c)) {
       result.push_back(c);
     } else {
       static char hex[] = "0123456789abcdef";


### PR DESCRIPTION
Passing a signed char with a negative value to isalnum is [undefined
behavior](https://en.cppreference.com/cpp/string/byte/isalnum#:~:text=The%20behavior%20is,.). This fixes it by iterating with unsigned char, which makes
the behavior well-defined regardless of platform char signedness.

Also:
- Modernized the loop to range-based for
- Added static_cast<char> for the push_back to make the narrowing
  conversion explicit
- Qualified isalnum with std:: for clarity
