### PR TITLE
[Slicer] Implement SliceMap and SlicerPicker for request-key sharding (gRFC A119)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1785,7 +1785,9 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx simple_request_bad_client_test)
   add_dependencies(buildtests_cxx single_set_ptr_test)
   add_dependencies(buildtests_cxx sleep_test)
+  add_dependencies(buildtests_cxx slice_map_test)
   add_dependencies(buildtests_cxx slice_string_helpers_test)
+  add_dependencies(buildtests_cxx slicer_picker_test)
   add_dependencies(buildtests_cxx sockaddr_resolver_test)
   add_dependencies(buildtests_cxx sockaddr_utils_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -33126,6 +33128,49 @@ target_link_libraries(sleep_test
 endif()
 if(gRPC_BUILD_TESTS)
 
+add_executable(slice_map_test
+  src/core/load_balancing/slicer/slice_map.cc
+  test/core/load_balancing/slice_map_test.cc
+)
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(slice_map_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
+target_compile_features(slice_map_test PUBLIC cxx_std_17)
+target_include_directories(slice_map_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(slice_map_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
+  grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
 add_executable(slice_string_helpers_test
   src/core/lib/debug/trace.cc
   src/core/lib/debug/trace_flags.cc
@@ -33168,6 +33213,50 @@ target_link_libraries(slice_string_helpers_test
   absl::flat_hash_map
   absl::hash
   gpr
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(slicer_picker_test
+  src/core/load_balancing/slicer/slice_map.cc
+  src/core/load_balancing/slicer/slicer_picker.cc
+  test/core/load_balancing/slicer_picker_test.cc
+)
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(slicer_picker_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
+target_compile_features(slicer_picker_test PUBLIC cxx_std_17)
+target_include_directories(slicer_picker_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(slicer_picker_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
+  grpc_test_util
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -23674,6 +23674,18 @@ targets:
   deps:
   - gtest
   - grpc
+- name: slice_map_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - src/core/load_balancing/slicer/slice_map.h
+  src:
+  - src/core/load_balancing/slicer/slice_map.cc
+  - test/core/load_balancing/slice_map_test.cc
+  deps:
+  - gtest
+  - grpc_test_util
 - name: slice_string_helpers_test
   gtest: true
   build: test
@@ -23699,6 +23711,20 @@ targets:
   - absl/container:flat_hash_map
   - absl/hash:hash
   - gpr
+- name: slicer_picker_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - src/core/load_balancing/slicer/slice_map.h
+  - src/core/load_balancing/slicer/slicer_picker.h
+  src:
+  - src/core/load_balancing/slicer/slice_map.cc
+  - src/core/load_balancing/slicer/slicer_picker.cc
+  - test/core/load_balancing/slicer_picker_test.cc
+  deps:
+  - gtest
+  - grpc_test_util
 - name: sockaddr_resolver_test
   gtest: true
   build: test

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -8136,6 +8136,51 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "slice_map",
+    srcs = [
+        "load_balancing/slicer/slice_map.cc",
+    ],
+    hdrs = [
+        "load_balancing/slicer/slice_map.h",
+    ],
+    external_deps = [
+        "absl/functional:any_invocable",
+        "absl/status:statusor",
+        "absl/strings",
+    ],
+    deps = [
+        "lb_policy",
+        "ref_counted",
+        "//:gpr",
+        "//:grpc_public_hdrs",
+        "//:ref_counted_ptr",
+    ],
+)
+
+grpc_cc_library(
+    name = "slicer_picker",
+    srcs = [
+        "load_balancing/slicer/slicer_picker.cc",
+    ],
+    hdrs = [
+        "load_balancing/slicer/slicer_picker.h",
+    ],
+    external_deps = [
+        "absl/random:distributions",
+        "absl/status",
+        "absl/strings",
+    ],
+    deps = [
+        "lb_policy",
+        "shared_bit_gen",
+        "slice_map",
+        "//:gpr",
+        "//:grpc_public_hdrs",
+        "//:ref_counted_ptr",
+    ],
+)
+
+grpc_cc_library(
     name = "static_stride_scheduler",
     srcs = [
         "load_balancing/weighted_round_robin/static_stride_scheduler.cc",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -8171,6 +8171,7 @@ grpc_cc_library(
         "absl/strings",
     ],
     deps = [
+        "grpc_check",
         "lb_policy",
         "shared_bit_gen",
         "slice_map",

--- a/src/core/load_balancing/slicer/slice_map.cc
+++ b/src/core/load_balancing/slicer/slice_map.cc
@@ -16,23 +16,18 @@
 
 #include "src/core/load_balancing/slicer/slice_map.h"
 
-#include <grpc/support/port_platform.h>
-
 #include <algorithm>
-#include <cstddef>
 #include <optional>
 #include <utility>
 
 #include "src/core/util/ref_counted_ptr.h"
-#include "absl/strings/str_cat.h"
 
 namespace grpc_core {
 
 absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     const EndpointMap& endpoint_map, const LogicalAssignment* assignment) {
   auto slice_map = MakeRefCounted<SliceMap>();
-  // No assignment yet: build a "total fallback" map containing every endpoint
-  // and no slices. Every pick will use the fallback pool (all_endpoints_).
+  // No assignment: build total-fallback map.
   if (assignment == nullptr || assignment->slices.empty()) {
     slice_map->all_endpoints_.reserve(endpoint_map.size());
     for (const auto& [name, state] : endpoint_map) {
@@ -41,11 +36,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     return slice_map;
   }
   slice_map->generation_ = assignment->generation;
-  // Assign a stable index to each endpoint, with the assignment's endpoints
-  // first (in the order they appear) followed by any resolver endpoints not
-  // named by the assignment. `index_for_name` maps hostname -> index into
-  // all_endpoints_ and is local to Make(): only the resulting indices are
-  // retained in the SliceMap.
+  // Assign endpoint indices (assigned first, then unmapped).
   std::map<absl::string_view, size_t> index_for_name;
   auto index_of = [&](const std::string& name) -> std::optional<size_t> {
     auto it = index_for_name.find(name);
@@ -57,7 +48,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     index_for_name.emplace(ep_it->first, index);
     return index;
   };
-  // Build the slices, indexing each assigned endpoint as we go.
+  // Build slices.
   slice_map->slices_.reserve(assignment->slices.size());
   for (const auto& slice_assignment : assignment->slices) {
     SliceEntry entry;
@@ -68,25 +59,25 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
       grpc_connectivity_state state =
           slice_map->all_endpoints_[*index]->connectivity_state();
       entry.all_endpoints_in_slice.push_back(*index);
-      entry.endpoints_by_state[state].push_back(*index);
+      if (state >= 0 &&
+          static_cast<size_t>(state) < entry.endpoints_by_state.size()) {
+        entry.endpoints_by_state[state].push_back(*index);
+      }
     }
-    // A slice falls back if it has no endpoints, or if all of its endpoints are
-    // in TRANSIENT_FAILURE.
+    // Slice falls back if empty or all endpoints in TRANSIENT_FAILURE.
     entry.in_fallback =
         entry.all_endpoints_in_slice.empty() ||
         entry.endpoints_by_state[GRPC_CHANNEL_TRANSIENT_FAILURE].size() ==
             entry.all_endpoints_in_slice.size();
     slice_map->slices_.push_back(std::move(entry));
   }
-  // Append any resolver endpoints not named by the assignment so they remain
-  // reachable via the fallback pool.
+  // Append unmapped endpoints for global fallback.
   for (const auto& [name, state] : endpoint_map) {
     if (index_for_name.find(name) == index_for_name.end()) {
       slice_map->all_endpoints_.push_back(state);
     }
   }
-  // The sharding service does not guarantee sorted slices; sort by start_key so
-  // Lookup() can binary-search.
+  // Sort slices by start_key for binary search lookup.
   std::sort(slice_map->slices_.begin(), slice_map->slices_.end(),
             [](const SliceEntry& a, const SliceEntry& b) {
               return a.start_key < b.start_key;
@@ -96,8 +87,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
 
 const SliceEntry* SliceMap::Lookup(absl::string_view key) const {
   if (slices_.empty()) return nullptr;
-  // Find the first slice whose start_key is strictly greater than `key`; the
-  // slice immediately before it is the one whose range contains `key`.
+  // Upper-bound binary search for slice containing key.
   auto it = std::upper_bound(
       slices_.begin(), slices_.end(), key,
       [](absl::string_view k, const SliceEntry& e) { return k < e.start_key; });

--- a/src/core/load_balancing/slicer/slice_map.cc
+++ b/src/core/load_balancing/slicer/slice_map.cc
@@ -30,7 +30,6 @@ namespace grpc_core {
 absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     const EndpointMap& endpoint_map, const LogicalAssignment* assignment) {
   auto slice_map = MakeRefCounted<SliceMap>();
-
   // No assignment yet: build a "total fallback" map containing every endpoint
   // and no slices. Every pick will use the fallback pool (all_endpoints_).
   if (assignment == nullptr || assignment->slices.empty()) {
@@ -40,9 +39,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     }
     return slice_map;
   }
-
   slice_map->generation_ = assignment->generation;
-
   // Assign a stable index to each endpoint, with the assignment's endpoints
   // first (in the order they appear) followed by any resolver endpoints not
   // named by the assignment. `index_for_name` maps hostname -> index into
@@ -62,7 +59,6 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     index_for_name.emplace(ep_it->first, index);
     return index;
   };
-
   // Build the slices, indexing each assigned endpoint as we go.
   slice_map->slices_.reserve(assignment->slices.size());
   for (const auto& slice_assignment : assignment->slices) {
@@ -84,7 +80,6 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
             entry.all_endpoints_in_slice.size();
     slice_map->slices_.push_back(std::move(entry));
   }
-
   // Append any resolver endpoints not named by the assignment so they remain
   // reachable via the fallback pool.
   for (const auto& [name, state] : endpoint_map) {
@@ -92,14 +87,12 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
       slice_map->all_endpoints_.push_back(state);
     }
   }
-
   // The sharding service does not guarantee sorted slices; sort by start_key so
   // Lookup() can binary-search.
   std::sort(slice_map->slices_.begin(), slice_map->slices_.end(),
             [](const SliceEntry& a, const SliceEntry& b) {
               return a.start_key < b.start_key;
             });
-
   return slice_map;
 }
 

--- a/src/core/load_balancing/slicer/slice_map.cc
+++ b/src/core/load_balancing/slicer/slice_map.cc
@@ -59,8 +59,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
       grpc_connectivity_state state =
           slice_map->all_endpoints_[*index]->connectivity_state();
       entry.all_endpoints_in_slice.push_back(*index);
-      if (state >= 0 &&
-          static_cast<size_t>(state) < entry.endpoints_by_state.size()) {
+      if (static_cast<size_t>(state) < entry.endpoints_by_state.size()) {
         entry.endpoints_by_state[state].push_back(*index);
       }
     }

--- a/src/core/load_balancing/slicer/slice_map.cc
+++ b/src/core/load_balancing/slicer/slice_map.cc
@@ -20,10 +20,11 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <utility>
 
-#include "absl/strings/str_cat.h"
 #include "src/core/util/ref_counted_ptr.h"
+#include "absl/strings/str_cat.h"
 
 namespace grpc_core {
 
@@ -46,14 +47,11 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
   // all_endpoints_ and is local to Make(): only the resulting indices are
   // retained in the SliceMap.
   std::map<absl::string_view, size_t> index_for_name;
-  auto index_of = [&](const std::string& name) -> absl::StatusOr<size_t> {
+  auto index_of = [&](const std::string& name) -> std::optional<size_t> {
     auto it = index_for_name.find(name);
     if (it != index_for_name.end()) return it->second;
     auto ep_it = endpoint_map.find(name);
-    if (ep_it == endpoint_map.end()) {
-      return absl::NotFoundError(absl::StrCat(
-          "endpoint \"", name, "\" named by slice assignment not found"));
-    }
+    if (ep_it == endpoint_map.end()) return std::nullopt;
     size_t index = slice_map->all_endpoints_.size();
     slice_map->all_endpoints_.push_back(ep_it->second);
     index_for_name.emplace(ep_it->first, index);
@@ -66,7 +64,7 @@ absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
     entry.start_key = slice_assignment.start_key;
     for (const auto& name : slice_assignment.endpoint_names) {
       auto index = index_of(name);
-      if (!index.ok()) return index.status();
+      if (!index.has_value()) continue;
       grpc_connectivity_state state =
           slice_map->all_endpoints_[*index]->connectivity_state();
       entry.all_endpoints_in_slice.push_back(*index);

--- a/src/core/load_balancing/slicer/slice_map.cc
+++ b/src/core/load_balancing/slicer/slice_map.cc
@@ -1,0 +1,117 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/load_balancing/slicer/slice_map.h"
+
+#include <grpc/support/port_platform.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+#include "absl/strings/str_cat.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+namespace grpc_core {
+
+absl::StatusOr<RefCountedPtr<SliceMap>> SliceMap::Make(
+    const EndpointMap& endpoint_map, const LogicalAssignment* assignment) {
+  auto slice_map = MakeRefCounted<SliceMap>();
+
+  // No assignment yet: build a "total fallback" map containing every endpoint
+  // and no slices. Every pick will use the fallback pool (all_endpoints_).
+  if (assignment == nullptr || assignment->slices.empty()) {
+    slice_map->all_endpoints_.reserve(endpoint_map.size());
+    for (const auto& [name, state] : endpoint_map) {
+      slice_map->all_endpoints_.push_back(state);
+    }
+    return slice_map;
+  }
+
+  slice_map->generation_ = assignment->generation;
+
+  // Assign a stable index to each endpoint, with the assignment's endpoints
+  // first (in the order they appear) followed by any resolver endpoints not
+  // named by the assignment. `index_for_name` maps hostname -> index into
+  // all_endpoints_ and is local to Make(): only the resulting indices are
+  // retained in the SliceMap.
+  std::map<absl::string_view, size_t> index_for_name;
+  auto index_of = [&](const std::string& name) -> absl::StatusOr<size_t> {
+    auto it = index_for_name.find(name);
+    if (it != index_for_name.end()) return it->second;
+    auto ep_it = endpoint_map.find(name);
+    if (ep_it == endpoint_map.end()) {
+      return absl::NotFoundError(absl::StrCat(
+          "endpoint \"", name, "\" named by slice assignment not found"));
+    }
+    size_t index = slice_map->all_endpoints_.size();
+    slice_map->all_endpoints_.push_back(ep_it->second);
+    index_for_name.emplace(ep_it->first, index);
+    return index;
+  };
+
+  // Build the slices, indexing each assigned endpoint as we go.
+  slice_map->slices_.reserve(assignment->slices.size());
+  for (const auto& slice_assignment : assignment->slices) {
+    SliceEntry entry;
+    entry.start_key = slice_assignment.start_key;
+    for (const auto& name : slice_assignment.endpoint_names) {
+      auto index = index_of(name);
+      if (!index.ok()) return index.status();
+      grpc_connectivity_state state =
+          slice_map->all_endpoints_[*index]->connectivity_state();
+      entry.all_endpoints_in_slice.push_back(*index);
+      entry.endpoints_by_state[state].push_back(*index);
+    }
+    // A slice falls back if it has no endpoints, or if all of its endpoints are
+    // in TRANSIENT_FAILURE.
+    entry.in_fallback =
+        entry.all_endpoints_in_slice.empty() ||
+        entry.endpoints_by_state[GRPC_CHANNEL_TRANSIENT_FAILURE].size() ==
+            entry.all_endpoints_in_slice.size();
+    slice_map->slices_.push_back(std::move(entry));
+  }
+
+  // Append any resolver endpoints not named by the assignment so they remain
+  // reachable via the fallback pool.
+  for (const auto& [name, state] : endpoint_map) {
+    if (index_for_name.find(name) == index_for_name.end()) {
+      slice_map->all_endpoints_.push_back(state);
+    }
+  }
+
+  // The sharding service does not guarantee sorted slices; sort by start_key so
+  // Lookup() can binary-search.
+  std::sort(slice_map->slices_.begin(), slice_map->slices_.end(),
+            [](const SliceEntry& a, const SliceEntry& b) {
+              return a.start_key < b.start_key;
+            });
+
+  return slice_map;
+}
+
+const SliceEntry* SliceMap::Lookup(absl::string_view key) const {
+  if (slices_.empty()) return nullptr;
+  // Find the first slice whose start_key is strictly greater than `key`; the
+  // slice immediately before it is the one whose range contains `key`.
+  auto it = std::upper_bound(
+      slices_.begin(), slices_.end(), key,
+      [](absl::string_view k, const SliceEntry& e) { return k < e.start_key; });
+  if (it == slices_.begin()) return nullptr;
+  return &*(it - 1);
+}
+
+}  // namespace grpc_core

--- a/src/core/load_balancing/slicer/slice_map.h
+++ b/src/core/load_balancing/slicer/slice_map.h
@@ -29,12 +29,12 @@
 #include <utility>
 #include <vector>
 
-#include "absl/functional/any_invocable.h"
-#include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
 #include "src/core/load_balancing/lb_policy.h"
 #include "src/core/util/ref_counted.h"
 #include "src/core/util/ref_counted_ptr.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 
 namespace grpc_core {
 
@@ -70,7 +70,7 @@ class EndpointState final : public RefCounted<EndpointState> {
   // request is issued at most once for the life of this EndpointState (the
   // first caller wins); later calls are no-ops. Returns true iff this call was
   // the one that triggered the request. Safe to call concurrently from picks.
-  bool ExitIdle() {
+  bool ExitIdle() const {
     bool expected = false;
     if (!connect_triggered_.compare_exchange_strong(
             expected, true, std::memory_order_relaxed)) {
@@ -88,8 +88,8 @@ class EndpointState final : public RefCounted<EndpointState> {
  private:
   grpc_connectivity_state connectivity_state_;
   RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> picker_;
-  absl::AnyInvocable<void()> exit_idle_;
-  std::atomic<bool> connect_triggered_{false};
+  mutable absl::AnyInvocable<void()> exit_idle_;
+  mutable std::atomic<bool> connect_triggered_{false};
 };
 
 // One key-range entry within a SliceMap. The range starts at start_key

--- a/src/core/load_balancing/slicer/slice_map.h
+++ b/src/core/load_balancing/slicer/slice_map.h
@@ -1,0 +1,179 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICE_MAP_H
+#define GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICE_MAP_H
+
+#include <grpc/impl/connectivity_state.h>
+#include <grpc/support/port_platform.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <array>
+#include <atomic>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/functional/any_invocable.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "src/core/load_balancing/lb_policy.h"
+#include "src/core/util/ref_counted.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+namespace grpc_core {
+
+// The state of a single endpoint as seen by the slicer LB policy: its current
+// connectivity state and the picker used to route a pick to it. This mirrors
+// the RLS policy's ChildPolicyWrapper (which similarly bundles a connectivity
+// state and a picker); the child policy that produces these is owned by the LB
+// policy, not by this snapshot. The connectivity state and picker are
+// immutable: when either changes, a new SliceMap is built with a new
+// EndpointState. The one piece of mutable state is a latch recording whether a
+// connection attempt has been triggered for this generation (see ExitIdle()).
+class EndpointState final : public RefCounted<EndpointState> {
+ public:
+  // `exit_idle` is invoked (at most once, by the first ExitIdle() call) to ask
+  // the endpoint's child policy to leave IDLE and start connecting. The LB
+  // policy supplies a closure that hops to the control plane; it may be null
+  // (e.g. in tests), in which case ExitIdle() only flips the latch.
+  EndpointState(grpc_connectivity_state connectivity_state,
+                RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> picker,
+                absl::AnyInvocable<void()> exit_idle = nullptr)
+      : connectivity_state_(connectivity_state),
+        picker_(std::move(picker)),
+        exit_idle_(std::move(exit_idle)) {}
+
+  grpc_connectivity_state connectivity_state() const {
+    return connectivity_state_;
+  }
+  const RefCountedPtr<LoadBalancingPolicy::SubchannelPicker>& picker() const {
+    return picker_;
+  }
+
+  // Asks this endpoint's child policy to leave IDLE and start connecting. The
+  // request is issued at most once for the life of this EndpointState (the
+  // first caller wins); later calls are no-ops. Returns true iff this call was
+  // the one that triggered the request. Safe to call concurrently from picks.
+  bool ExitIdle() {
+    bool expected = false;
+    if (!connect_triggered_.compare_exchange_strong(
+            expected, true, std::memory_order_relaxed)) {
+      return false;
+    }
+    if (exit_idle_ != nullptr) exit_idle_();
+    return true;
+  }
+
+  // True once a connection attempt has been triggered on this endpoint.
+  bool connect_triggered() const {
+    return connect_triggered_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  grpc_connectivity_state connectivity_state_;
+  RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> picker_;
+  absl::AnyInvocable<void()> exit_idle_;
+  std::atomic<bool> connect_triggered_{false};
+};
+
+// One key-range entry within a SliceMap. The range starts at start_key
+// (inclusive) and extends to the start_key of the next slice.
+struct SliceEntry {
+  // The (inclusive) lower bound of this slice's key range. Keys are opaque byte
+  // strings; std::string comparison gives the required lexicographic ordering.
+  std::string start_key;
+  // Indices (into SliceMap::all_endpoints()) of all endpoints assigned to this
+  // slice. The picker selects a random endpoint from this list first, then
+  // consults the per-state lists below.
+  std::vector<size_t> all_endpoints_in_slice;
+  // The same indices, bucketed by connectivity state. Indexed directly by
+  // grpc_connectivity_state (GRPC_CHANNEL_IDLE..GRPC_CHANNEL_SHUTDOWN == 0..4).
+  std::array<std::vector<size_t>, 5> endpoints_by_state;
+  // Precomputed: true if this slice has no assigned endpoints or if all of its
+  // assigned endpoints are in TRANSIENT_FAILURE. When true, picks for this
+  // slice are routed to the global fallback pool.
+  bool in_fallback = false;
+};
+
+// An immutable structure that maps a request key to the set of endpoints that
+// should serve it, produced by combining the resolver's endpoints with the
+// key-range assignment from the sharding service. Because it is immutable, the
+// picker can read it without synchronization; a new SliceMap is built whenever
+// the assignment or any endpoint's connectivity state changes.
+//
+// The global fallback pool is simply all_endpoints(): a pick that falls back
+// selects (at random) from every endpoint, regardless of state.
+class SliceMap final : public RefCounted<SliceMap> {
+ public:
+  // Maps an endpoint's identity (its hostname) to its current state. Owned by
+  // the caller; used only during Make().
+  using EndpointMap = std::map<std::string, RefCountedPtr<EndpointState>>;
+
+  // A single key-range assignment from the sharding service: the endpoints
+  // (identified by the keys of the EndpointMap) that serve the range starting
+  // at start_key.
+  struct SliceAssignment {
+    std::string start_key;
+    std::vector<std::string> endpoint_names;
+  };
+
+  // The full assignment received from the sharding service.
+  struct LogicalAssignment {
+    std::vector<SliceAssignment> slices;
+    int64_t generation = 0;
+  };
+
+  // Builds a SliceMap from the resolver's endpoints and an assignment. If
+  // `assignment` is null (no assignment yet from the sharding service), the
+  // result is a "total fallback" map with no slices, whose every pick uses the
+  // fallback pool. Returns an error if any endpoint named by the assignment is
+  // absent from `endpoint_map`.
+  static absl::StatusOr<RefCountedPtr<SliceMap>> Make(
+      const EndpointMap& endpoint_map, const LogicalAssignment* assignment);
+
+  // Returns the slice whose key range contains `key` (the slice with the
+  // greatest start_key that is <= key), or null if there are no slices or `key`
+  // sorts before the first slice's start_key. A null result means the caller
+  // should use the fallback pool.
+  const SliceEntry* Lookup(absl::string_view key) const;
+
+  // The generation number of the assignment this map was built from (0 for a
+  // total-fallback map). Echoed back to the sharding service so it can skip
+  // resending an already-acknowledged assignment after a stream failure.
+  int64_t generation() const { return generation_; }
+
+  // All endpoints known to this map (assigned endpoints first, then any
+  // resolver endpoints not named by the assignment). This is also the global
+  // fallback pool.
+  const std::vector<RefCountedPtr<EndpointState>>& all_endpoints() const {
+    return all_endpoints_;
+  }
+
+  // The slices, sorted by start_key. Exposed primarily for testing.
+  const std::vector<SliceEntry>& slices() const { return slices_; }
+
+ private:
+  std::vector<RefCountedPtr<EndpointState>> all_endpoints_;
+  std::vector<SliceEntry> slices_;
+  int64_t generation_ = 0;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICE_MAP_H

--- a/src/core/load_balancing/slicer/slice_map.h
+++ b/src/core/load_balancing/slicer/slice_map.h
@@ -18,7 +18,6 @@
 #define GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICE_MAP_H
 
 #include <grpc/impl/connectivity_state.h>
-#include <grpc/support/port_platform.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -38,20 +37,11 @@
 
 namespace grpc_core {
 
-// The state of a single endpoint as seen by the slicer LB policy: its current
-// connectivity state and the picker used to route a pick to it. This mirrors
-// the RLS policy's ChildPolicyWrapper (which similarly bundles a connectivity
-// state and a picker); the child policy that produces these is owned by the LB
-// policy, not by this snapshot. The connectivity state and picker are
-// immutable: when either changes, a new SliceMap is built with a new
-// EndpointState. The one piece of mutable state is a latch recording whether a
-// connection attempt has been triggered for this generation (see ExitIdle()).
+// Snapshot of an endpoint's connectivity state and picker.
+// Holds an atomic latch tracking if ExitIdle() has been triggered.
 class EndpointState final : public RefCounted<EndpointState> {
  public:
-  // `exit_idle` is invoked (at most once, by the first ExitIdle() call) to ask
-  // the endpoint's child policy to leave IDLE and start connecting. The LB
-  // policy supplies a closure that hops to the control plane; it may be null
-  // (e.g. in tests), in which case ExitIdle() only flips the latch.
+  // `exit_idle` is invoked once when leaving IDLE state.
   EndpointState(grpc_connectivity_state connectivity_state,
                 RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> picker,
                 absl::AnyInvocable<void()> exit_idle = nullptr)
@@ -66,21 +56,21 @@ class EndpointState final : public RefCounted<EndpointState> {
     return picker_;
   }
 
-  // Asks this endpoint's child policy to leave IDLE and start connecting. The
-  // request is issued at most once for the life of this EndpointState (the
-  // first caller wins); later calls are no-ops. Returns true iff this call was
-  // the one that triggered the request. Safe to call concurrently from picks.
+  // Triggers exit-idle once. Returns true if this call triggered it.
+  // Thread-safe.
   bool ExitIdle() const {
     bool expected = false;
     if (!connect_triggered_.compare_exchange_strong(
             expected, true, std::memory_order_relaxed)) {
       return false;
     }
-    if (exit_idle_ != nullptr) exit_idle_();
+    if (exit_idle_ != nullptr) {
+      std::exchange(exit_idle_, nullptr)();
+    }
     return true;
   }
 
-  // True once a connection attempt has been triggered on this endpoint.
+  // True if exit-idle has been triggered.
   bool connect_triggered() const {
     return connect_triggered_.load(std::memory_order_relaxed);
   }
@@ -92,80 +82,43 @@ class EndpointState final : public RefCounted<EndpointState> {
   mutable std::atomic<bool> connect_triggered_{false};
 };
 
-// One key-range entry within a SliceMap. The range starts at start_key
-// (inclusive) and extends to the start_key of the next slice.
+// Represents a key-range slice and its assigned endpoints.
 struct SliceEntry {
-  // The (inclusive) lower bound of this slice's key range. Keys are opaque byte
-  // strings; std::string comparison gives the required lexicographic ordering.
   std::string start_key;
-  // Indices (into SliceMap::all_endpoints()) of all endpoints assigned to this
-  // slice. The picker selects a random endpoint from this list first, then
-  // consults the per-state lists below.
   std::vector<size_t> all_endpoints_in_slice;
-  // The same indices, bucketed by connectivity state. Indexed directly by
-  // grpc_connectivity_state (GRPC_CHANNEL_IDLE..GRPC_CHANNEL_SHUTDOWN == 0..4).
   std::array<std::vector<size_t>, 5> endpoints_by_state;
-  // Precomputed: true if this slice has no assigned endpoints or if all of its
-  // assigned endpoints are in TRANSIENT_FAILURE. When true, picks for this
-  // slice are routed to the global fallback pool.
   bool in_fallback = false;
 };
 
-// An immutable structure that maps a request key to the set of endpoints that
-// should serve it, produced by combining the resolver's endpoints with the
-// key-range assignment from the sharding service. Because it is immutable, the
-// picker can read it without synchronization; a new SliceMap is built whenever
-// the assignment or any endpoint's connectivity state changes.
-//
-// The global fallback pool is simply all_endpoints(): a pick that falls back
-// selects (at random) from every endpoint, regardless of state.
+// Immutable key-to-endpoint range map for slicer LB policy.
 class SliceMap final : public RefCounted<SliceMap> {
  public:
-  // Maps an endpoint's identity (its hostname) to its current state. Owned by
-  // the caller; used only during Make().
   using EndpointMap = std::map<std::string, RefCountedPtr<EndpointState>>;
 
-  // A single key-range assignment from the sharding service: the endpoints
-  // (identified by the keys of the EndpointMap) that serve the range starting
-  // at start_key.
   struct SliceAssignment {
     std::string start_key;
     std::vector<std::string> endpoint_names;
   };
 
-  // The full assignment received from the sharding service.
   struct LogicalAssignment {
     std::vector<SliceAssignment> slices;
     int64_t generation = 0;
   };
 
-  // Builds a SliceMap from the resolver's endpoints and an assignment. If
-  // `assignment` is null (no assignment yet from the sharding service), the
-  // result is a "total fallback" map with no slices, whose every pick uses the
-  // fallback pool. Returns an error if any endpoint named by the assignment is
-  // absent from `endpoint_map`.
+  // Builds a SliceMap. Missing endpoints in assignment are skipped.
   static absl::StatusOr<RefCountedPtr<SliceMap>> Make(
       const EndpointMap& endpoint_map, const LogicalAssignment* assignment);
 
-  // Returns the slice whose key range contains `key` (the slice with the
-  // greatest start_key that is <= key), or null if there are no slices or `key`
-  // sorts before the first slice's start_key. A null result means the caller
-  // should use the fallback pool.
+  // Returns slice matching key, or nullptr for fallback.
   const SliceEntry* Lookup(absl::string_view key) const;
 
-  // The generation number of the assignment this map was built from (0 for a
-  // total-fallback map). Echoed back to the sharding service so it can skip
-  // resending an already-acknowledged assignment after a stream failure.
   int64_t generation() const { return generation_; }
 
-  // All endpoints known to this map (assigned endpoints first, then any
-  // resolver endpoints not named by the assignment). This is also the global
-  // fallback pool.
+  // Global fallback pool of all endpoints.
   const std::vector<RefCountedPtr<EndpointState>>& all_endpoints() const {
     return all_endpoints_;
   }
 
-  // The slices, sorted by start_key. Exposed primarily for testing.
   const std::vector<SliceEntry>& slices() const { return slices_; }
 
  private:

--- a/src/core/load_balancing/slicer/slice_map.h
+++ b/src/core/load_balancing/slicer/slice_map.h
@@ -82,14 +82,6 @@ class EndpointState final : public RefCounted<EndpointState> {
   mutable std::atomic<bool> connect_triggered_{false};
 };
 
-// Represents a key-range slice and its assigned endpoints.
-struct SliceEntry {
-  std::string start_key;
-  std::vector<size_t> all_endpoints_in_slice;
-  std::array<std::vector<size_t>, 5> endpoints_by_state;
-  bool in_fallback = false;
-};
-
 // Immutable key-to-endpoint range map for slicer LB policy.
 class SliceMap final : public RefCounted<SliceMap> {
  public:
@@ -103,6 +95,14 @@ class SliceMap final : public RefCounted<SliceMap> {
   struct LogicalAssignment {
     std::vector<SliceAssignment> slices;
     int64_t generation = 0;
+  };
+
+  // Represents a key-range slice and its assigned endpoints.
+  struct SliceEntry {
+    std::string start_key;
+    std::vector<size_t> all_endpoints_in_slice;
+    std::array<std::vector<size_t>, 5> endpoints_by_state;
+    bool in_fallback = false;
   };
 
   // Builds a SliceMap. Missing endpoints in assignment are skipped.
@@ -126,6 +126,8 @@ class SliceMap final : public RefCounted<SliceMap> {
   std::vector<SliceEntry> slices_;
   int64_t generation_ = 0;
 };
+
+using SliceEntry = SliceMap::SliceEntry;
 
 }  // namespace grpc_core
 

--- a/src/core/load_balancing/slicer/slicer_picker.cc
+++ b/src/core/load_balancing/slicer/slicer_picker.cc
@@ -25,11 +25,11 @@
 #include <utility>
 #include <vector>
 
+#include "src/core/util/shared_bit_gen.h"
 #include "absl/random/distributions.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "src/core/util/shared_bit_gen.h"
 
 namespace grpc_core {
 
@@ -67,11 +67,12 @@ LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
   // been received from the sharding service).
   if (slice == nullptr) {
     if (fallback_enabled_) return PickFromFallbackPool(args);
-    return PickResult::Fail(absl::UnavailableError(
-        "slicer: no slice assignment for request key"));
+    return PickResult::Fail(
+        absl::UnavailableError("slicer: no slice assignment for request key"));
   }
   // The matching slice is in fallback mode.
-  if (slice->in_fallback && fallback_enabled_) return PickFromFallbackPool(args);
+  if (slice->in_fallback && fallback_enabled_)
+    return PickFromFallbackPool(args);
   return PickFromSlice(*slice, args);
 }
 
@@ -138,6 +139,9 @@ LoadBalancingPolicy::PickResult SlicerPicker::DelegateToRandom(
 
 LoadBalancingPolicy::PickResult SlicerPicker::Delegate(
     const EndpointState& endpoint, PickArgs args) {
+  if (endpoint.connectivity_state() == GRPC_CHANNEL_IDLE) {
+    endpoint.ExitIdle();
+  }
   if (endpoint.picker() == nullptr) return PickResult::Queue();
   return endpoint.picker()->Pick(args);
 }

--- a/src/core/load_balancing/slicer/slicer_picker.cc
+++ b/src/core/load_balancing/slicer/slicer_picker.cc
@@ -18,6 +18,7 @@
 
 #include <grpc/impl/connectivity_state.h>
 
+#include "src/core/util/grpc_check.h"
 #include "src/core/util/shared_bit_gen.h"
 #include "absl/random/distributions.h"
 
@@ -27,7 +28,25 @@ namespace {
 
 // Random index in [0, count).
 size_t RandomIndex(size_t count) {
+  GRPC_DCHECK_GT(count, 0);
   return absl::Uniform<size_t>(SharedBitGen(), 0, count);
+}
+
+LoadBalancingPolicy::PickResult Delegate(const EndpointState& endpoint,
+                                         LoadBalancingPolicy::PickArgs args) {
+  if (endpoint.connectivity_state() == GRPC_CHANNEL_IDLE) {
+    endpoint.ExitIdle();
+  }
+  if (endpoint.picker() == nullptr)
+    return LoadBalancingPolicy::PickResult::Queue();
+  return endpoint.picker()->Pick(args);
+}
+
+LoadBalancingPolicy::PickResult DelegateToRandom(
+    const std::vector<RefCountedPtr<EndpointState>>& all,
+    const std::vector<size_t>& indices, LoadBalancingPolicy::PickArgs args) {
+  if (indices.empty()) return LoadBalancingPolicy::PickResult::Queue();
+  return Delegate(*all[indices[RandomIndex(indices.size())]], args);
 }
 
 }  // namespace
@@ -43,13 +62,12 @@ LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
   std::string buffer;
   std::optional<absl::string_view> key =
       args.initial_metadata->Lookup(slice_key_header_, &buffer);
-
   if (!key.has_value()) {
     if (fallback_enabled_) return PickFromFallbackPool(args);
     return PickResult::Fail(absl::UnavailableError(absl::StrCat(
         "slicer: request has no \"", slice_key_header_, "\" header")));
   }
-  const SliceEntry* slice = slice_map_->Lookup(*key);
+  const SliceMap::SliceEntry* slice = slice_map_->Lookup(*key);
   // Unmapped key range.
   if (slice == nullptr) {
     if (fallback_enabled_) return PickFromFallbackPool(args);
@@ -57,13 +75,14 @@ LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
         absl::UnavailableError("slicer: no slice assignment for request key"));
   }
   // Slice in fallback mode.
-  if (slice->in_fallback && fallback_enabled_)
+  if (slice->in_fallback && fallback_enabled_) {
     return PickFromFallbackPool(args);
+  }
   return PickFromSlice(*slice, args);
 }
 
 LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
-    const SliceEntry& slice, PickArgs args) {
+    const SliceMap::SliceEntry& slice, PickArgs args) {
   const auto& all = slice_map_->all_endpoints();
   const std::vector<size_t>& flat = slice.all_endpoints_in_slice;
   // Queue if slice has no endpoints.
@@ -81,7 +100,7 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
     case GRPC_CHANNEL_IDLE:
       // Exit IDLE and delegate to READY endpoint if available, else queue.
       ep.ExitIdle();
-      if (!ready.empty()) return DelegateToRandom(ready, args);
+      if (!ready.empty()) return DelegateToRandom(all, ready, args);
       return PickResult::Queue();
     default:
       break;  // CONNECTING or TRANSIENT_FAILURE.
@@ -91,7 +110,7 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
     if (all[index]->ExitIdle()) break;
   }
   // Delegate to READY endpoint if available.
-  if (!ready.empty()) return DelegateToRandom(ready, args);
+  if (!ready.empty()) return DelegateToRandom(all, ready, args);
   // Queue if connection in progress.
   bool idle_in_progress = false;
   for (size_t index : idle) {
@@ -111,21 +130,6 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromFallbackPool(
   // Queue if no endpoints in fallback pool.
   if (all.empty()) return PickResult::Queue();
   return Delegate(*all[RandomIndex(all.size())], args);
-}
-
-LoadBalancingPolicy::PickResult SlicerPicker::DelegateToRandom(
-    const std::vector<size_t>& indices, PickArgs args) {
-  const auto& all = slice_map_->all_endpoints();
-  return Delegate(*all[indices[RandomIndex(indices.size())]], args);
-}
-
-LoadBalancingPolicy::PickResult SlicerPicker::Delegate(
-    const EndpointState& endpoint, PickArgs args) {
-  if (endpoint.connectivity_state() == GRPC_CHANNEL_IDLE) {
-    endpoint.ExitIdle();
-  }
-  if (endpoint.picker() == nullptr) return PickResult::Queue();
-  return endpoint.picker()->Pick(args);
 }
 
 }  // namespace grpc_core

--- a/src/core/load_balancing/slicer/slicer_picker.cc
+++ b/src/core/load_balancing/slicer/slicer_picker.cc
@@ -17,25 +17,15 @@
 #include "src/core/load_balancing/slicer/slicer_picker.h"
 
 #include <grpc/impl/connectivity_state.h>
-#include <grpc/support/port_platform.h>
-#include <stddef.h>
-
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include "src/core/util/shared_bit_gen.h"
 #include "absl/random/distributions.h"
-#include "absl/status/status.h"
-#include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
 
 namespace grpc_core {
 
 namespace {
 
-// Returns a uniformly random index in [0, count). `count` must be > 0.
+// Random index in [0, count).
 size_t RandomIndex(size_t count) {
   return absl::Uniform<size_t>(SharedBitGen(), 0, count);
 }
@@ -49,28 +39,24 @@ SlicerPicker::SlicerPicker(RefCountedPtr<SliceMap> slice_map,
       fallback_enabled_(fallback_enabled) {}
 
 LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
-  // Extract the slice key from the request header. A present-but-empty value is
-  // a valid key; an absent header means the request carries no key at all.
+  // Extract slice key from request header.
   std::string buffer;
   std::optional<absl::string_view> key =
       args.initial_metadata->Lookup(slice_key_header_, &buffer);
-  // Without a key we cannot route the request to a slice. Rather than silently
-  // treating it as some slice's key, serve it from the fallback pool if enabled
-  // and otherwise fail the pick.
+
   if (!key.has_value()) {
     if (fallback_enabled_) return PickFromFallbackPool(args);
     return PickResult::Fail(absl::UnavailableError(absl::StrCat(
         "slicer: request has no \"", slice_key_header_, "\" header")));
   }
   const SliceEntry* slice = slice_map_->Lookup(*key);
-  // No assignment covers this key (only happens before any good assignment has
-  // been received from the sharding service).
+  // Unmapped key range.
   if (slice == nullptr) {
     if (fallback_enabled_) return PickFromFallbackPool(args);
     return PickResult::Fail(
         absl::UnavailableError("slicer: no slice assignment for request key"));
   }
-  // The matching slice is in fallback mode.
+  // Slice in fallback mode.
   if (slice->in_fallback && fallback_enabled_)
     return PickFromFallbackPool(args);
   return PickFromSlice(*slice, args);
@@ -80,36 +66,33 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
     const SliceEntry& slice, PickArgs args) {
   const auto& all = slice_map_->all_endpoints();
   const std::vector<size_t>& flat = slice.all_endpoints_in_slice;
-  // Queue the pick when the slice has no endpoints. This happens when the name
-  // resolver update trails the assignment.
+  // Queue if slice has no endpoints.
   if (flat.empty()) return PickResult::Queue();
   const std::vector<size_t>& ready =
       slice.endpoints_by_state[GRPC_CHANNEL_READY];
   const std::vector<size_t>& idle = slice.endpoints_by_state[GRPC_CHANNEL_IDLE];
   const std::vector<size_t>& connecting =
       slice.endpoints_by_state[GRPC_CHANNEL_CONNECTING];
-  // Pick a random endpoint from the slice, then branch on its state.
+  // Select random endpoint in slice.
   EndpointState& ep = *all[flat[RandomIndex(flat.size())]];
   switch (ep.connectivity_state()) {
     case GRPC_CHANNEL_READY:
       return Delegate(ep, args);
     case GRPC_CHANNEL_IDLE:
-      // Trigger a connection attempt, then delegate to a READY endpoint if one
-      // exists, else queue.
+      // Exit IDLE and delegate to READY endpoint if available, else queue.
       ep.ExitIdle();
       if (!ready.empty()) return DelegateToRandom(ready, args);
       return PickResult::Queue();
     default:
       break;  // CONNECTING or TRANSIENT_FAILURE.
   }
-  // The randomly selected endpoint is CONNECTING or TRANSIENT_FAILURE. Wake up
-  // one not-yet-triggered IDLE endpoint, if any.
+  // Wake up one IDLE endpoint if any.
   for (size_t index : idle) {
     if (all[index]->ExitIdle()) break;
   }
-  // Prefer a READY endpoint if one exists.
+  // Delegate to READY endpoint if available.
   if (!ready.empty()) return DelegateToRandom(ready, args);
-  // Queue if anything is (or is now) making progress toward READY.
+  // Queue if connection in progress.
   bool idle_in_progress = false;
   for (size_t index : idle) {
     if (all[index]->connect_triggered()) {
@@ -118,15 +101,14 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
     }
   }
   if (!connecting.empty() || idle_in_progress) return PickResult::Queue();
-  // Nothing is connecting; delegate to the TRANSIENT_FAILURE endpoint's picker
-  // so the RPC fails with the underlying connection status.
+  // Delegate to TRANSIENT_FAILURE endpoint's picker.
   return Delegate(ep, args);
 }
 
 LoadBalancingPolicy::PickResult SlicerPicker::PickFromFallbackPool(
     PickArgs args) {
   const auto& all = slice_map_->all_endpoints();
-  // Queue if there are no endpoints at all.
+  // Queue if no endpoints in fallback pool.
   if (all.empty()) return PickResult::Queue();
   return Delegate(*all[RandomIndex(all.size())], args);
 }

--- a/src/core/load_balancing/slicer/slicer_picker.cc
+++ b/src/core/load_balancing/slicer/slicer_picker.cc
@@ -1,0 +1,144 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/load_balancing/slicer/slicer_picker.h"
+
+#include <grpc/impl/connectivity_state.h>
+#include <grpc/support/port_platform.h>
+#include <stddef.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/random/distributions.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "src/core/util/shared_bit_gen.h"
+
+namespace grpc_core {
+
+namespace {
+
+// Returns a uniformly random index in [0, count). `count` must be > 0.
+size_t RandomIndex(size_t count) {
+  return absl::Uniform<size_t>(SharedBitGen(), 0, count);
+}
+
+}  // namespace
+
+SlicerPicker::SlicerPicker(RefCountedPtr<SliceMap> slice_map,
+                           std::string slice_key_header, bool fallback_enabled)
+    : slice_map_(std::move(slice_map)),
+      slice_key_header_(std::move(slice_key_header)),
+      fallback_enabled_(fallback_enabled) {}
+
+LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
+  // Extract the slice key from the request header. A missing header yields an
+  // empty key, which Lookup() will map to the first slice (or to fallback if no
+  // slice starts at the empty key).
+  std::string buffer;
+  std::optional<absl::string_view> value =
+      args.initial_metadata->Lookup(slice_key_header_, &buffer);
+  const SliceEntry* slice =
+      slice_map_->Lookup(value.value_or(absl::string_view()));
+
+  // No assignment covers this key (only happens before any good assignment has
+  // been received from the sharding service).
+  if (slice == nullptr) {
+    if (fallback_enabled_) return PickFromFallbackPool(args);
+    return PickResult::Fail(absl::UnavailableError(
+        "slicer: no slice assignment for request key"));
+  }
+  // The matching slice is in fallback mode.
+  if (slice->in_fallback && fallback_enabled_) {
+    return PickFromFallbackPool(args);
+  }
+  return PickFromSlice(*slice, args);
+}
+
+LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
+    const SliceEntry& slice, PickArgs args) {
+  const auto& all = slice_map_->all_endpoints();
+  const std::vector<size_t>& flat = slice.all_endpoints_in_slice;
+  // Queue the pick when the slice has no endpoints. This happens when the name
+  // resolver update trails the assignment.
+  if (flat.empty()) return PickResult::Queue();
+
+  const std::vector<size_t>& ready =
+      slice.endpoints_by_state[GRPC_CHANNEL_READY];
+  const std::vector<size_t>& idle = slice.endpoints_by_state[GRPC_CHANNEL_IDLE];
+  const std::vector<size_t>& connecting =
+      slice.endpoints_by_state[GRPC_CHANNEL_CONNECTING];
+
+  // Pick a random endpoint from the slice, then branch on its state.
+  EndpointState& ep = *all[flat[RandomIndex(flat.size())]];
+  switch (ep.connectivity_state()) {
+    case GRPC_CHANNEL_READY:
+      return Delegate(ep, args);
+    case GRPC_CHANNEL_IDLE:
+      // Trigger a connection attempt, then delegate to a READY endpoint if one
+      // exists, else queue.
+      ep.ExitIdle();
+      if (!ready.empty()) return DelegateToRandom(ready, args);
+      return PickResult::Queue();
+    default:
+      break;  // CONNECTING or TRANSIENT_FAILURE.
+  }
+
+  // The randomly selected endpoint is CONNECTING or TRANSIENT_FAILURE. Wake up
+  // one not-yet-triggered IDLE endpoint, if any.
+  for (size_t index : idle) {
+    if (all[index]->ExitIdle()) break;
+  }
+  // Prefer a READY endpoint if one exists.
+  if (!ready.empty()) return DelegateToRandom(ready, args);
+  // Queue if anything is (or is now) making progress toward READY.
+  bool idle_in_progress = false;
+  for (size_t index : idle) {
+    if (all[index]->connect_triggered()) {
+      idle_in_progress = true;
+      break;
+    }
+  }
+  if (!connecting.empty() || idle_in_progress) return PickResult::Queue();
+  // Nothing is connecting; delegate to the TRANSIENT_FAILURE endpoint's picker
+  // so the RPC fails with the underlying connection status.
+  return Delegate(ep, args);
+}
+
+LoadBalancingPolicy::PickResult SlicerPicker::PickFromFallbackPool(
+    PickArgs args) {
+  const auto& all = slice_map_->all_endpoints();
+  // Queue if there are no endpoints at all.
+  if (all.empty()) return PickResult::Queue();
+  return Delegate(*all[RandomIndex(all.size())], args);
+}
+
+LoadBalancingPolicy::PickResult SlicerPicker::DelegateToRandom(
+    const std::vector<size_t>& indices, PickArgs args) {
+  const auto& all = slice_map_->all_endpoints();
+  return Delegate(*all[indices[RandomIndex(indices.size())]], args);
+}
+
+LoadBalancingPolicy::PickResult SlicerPicker::Delegate(
+    const EndpointState& endpoint, PickArgs args) {
+  if (endpoint.picker() == nullptr) return PickResult::Queue();
+  return endpoint.picker()->Pick(args);
+}
+
+}  // namespace grpc_core

--- a/src/core/load_balancing/slicer/slicer_picker.cc
+++ b/src/core/load_balancing/slicer/slicer_picker.cc
@@ -27,6 +27,7 @@
 
 #include "absl/random/distributions.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "src/core/util/shared_bit_gen.h"
 
@@ -48,15 +49,20 @@ SlicerPicker::SlicerPicker(RefCountedPtr<SliceMap> slice_map,
       fallback_enabled_(fallback_enabled) {}
 
 LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
-  // Extract the slice key from the request header. A missing header yields an
-  // empty key, which Lookup() will map to the first slice (or to fallback if no
-  // slice starts at the empty key).
+  // Extract the slice key from the request header. A present-but-empty value is
+  // a valid key; an absent header means the request carries no key at all.
   std::string buffer;
-  std::optional<absl::string_view> value =
+  std::optional<absl::string_view> key =
       args.initial_metadata->Lookup(slice_key_header_, &buffer);
-  const SliceEntry* slice =
-      slice_map_->Lookup(value.value_or(absl::string_view()));
-
+  // Without a key we cannot route the request to a slice. Rather than silently
+  // treating it as some slice's key, serve it from the fallback pool if enabled
+  // and otherwise fail the pick.
+  if (!key.has_value()) {
+    if (fallback_enabled_) return PickFromFallbackPool(args);
+    return PickResult::Fail(absl::UnavailableError(absl::StrCat(
+        "slicer: request has no \"", slice_key_header_, "\" header")));
+  }
+  const SliceEntry* slice = slice_map_->Lookup(*key);
   // No assignment covers this key (only happens before any good assignment has
   // been received from the sharding service).
   if (slice == nullptr) {
@@ -65,9 +71,7 @@ LoadBalancingPolicy::PickResult SlicerPicker::Pick(PickArgs args) {
         "slicer: no slice assignment for request key"));
   }
   // The matching slice is in fallback mode.
-  if (slice->in_fallback && fallback_enabled_) {
-    return PickFromFallbackPool(args);
-  }
+  if (slice->in_fallback && fallback_enabled_) return PickFromFallbackPool(args);
   return PickFromSlice(*slice, args);
 }
 
@@ -78,13 +82,11 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
   // Queue the pick when the slice has no endpoints. This happens when the name
   // resolver update trails the assignment.
   if (flat.empty()) return PickResult::Queue();
-
   const std::vector<size_t>& ready =
       slice.endpoints_by_state[GRPC_CHANNEL_READY];
   const std::vector<size_t>& idle = slice.endpoints_by_state[GRPC_CHANNEL_IDLE];
   const std::vector<size_t>& connecting =
       slice.endpoints_by_state[GRPC_CHANNEL_CONNECTING];
-
   // Pick a random endpoint from the slice, then branch on its state.
   EndpointState& ep = *all[flat[RandomIndex(flat.size())]];
   switch (ep.connectivity_state()) {
@@ -99,7 +101,6 @@ LoadBalancingPolicy::PickResult SlicerPicker::PickFromSlice(
     default:
       break;  // CONNECTING or TRANSIENT_FAILURE.
   }
-
   // The randomly selected endpoint is CONNECTING or TRANSIENT_FAILURE. Wake up
   // one not-yet-triggered IDLE endpoint, if any.
   for (size_t index : idle) {

--- a/src/core/load_balancing/slicer/slicer_picker.h
+++ b/src/core/load_balancing/slicer/slicer_picker.h
@@ -41,11 +41,8 @@ class SlicerPicker final : public LoadBalancingPolicy::SubchannelPicker {
   PickResult Pick(PickArgs args) override;
 
  private:
-  PickResult PickFromSlice(const SliceEntry& slice, PickArgs args);
+  PickResult PickFromSlice(const SliceMap::SliceEntry& slice, PickArgs args);
   PickResult PickFromFallbackPool(PickArgs args);
-  PickResult DelegateToRandom(const std::vector<size_t>& indices,
-                              PickArgs args);
-  PickResult Delegate(const EndpointState& endpoint, PickArgs args);
 
   RefCountedPtr<SliceMap> slice_map_;
   std::string slice_key_header_;

--- a/src/core/load_balancing/slicer/slicer_picker.h
+++ b/src/core/load_balancing/slicer/slicer_picker.h
@@ -1,0 +1,69 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICER_PICKER_H
+#define GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICER_PICKER_H
+
+#include <grpc/support/port_platform.h>
+#include <stddef.h>
+
+#include <string>
+#include <vector>
+
+#include "src/core/load_balancing/lb_policy.h"
+#include "src/core/load_balancing/slicer/slice_map.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+namespace grpc_core {
+
+// The data-plane picker for the slicer LB policy. It reads the request's
+// slice key from a header, looks up the matching slice in an immutable
+// SliceMap, and delegates the pick to one of the slice's endpoint pickers.
+// Because the SliceMap is immutable, the picker holds no locks.
+class SlicerPicker final : public LoadBalancingPolicy::SubchannelPicker {
+ public:
+  using PickArgs = LoadBalancingPolicy::PickArgs;
+  using PickResult = LoadBalancingPolicy::PickResult;
+
+  // `slice_key_header` is the name of the request header carrying the
+  // application-defined key. `fallback_enabled` mirrors the policy's
+  // enable_fallback config: when true, keys with no assignment (or slices in
+  // fallback mode) are served from the global fallback pool instead of failing.
+  SlicerPicker(RefCountedPtr<SliceMap> slice_map, std::string slice_key_header,
+               bool fallback_enabled);
+
+  PickResult Pick(PickArgs args) override;
+
+ private:
+  // Selects an endpoint from a non-fallback slice, applying the state-based
+  // preference (READY > wake IDLE / queue > fail via TRANSIENT_FAILURE picker).
+  PickResult PickFromSlice(const SliceEntry& slice, PickArgs args);
+  // Serves a pick from the global fallback pool (a random endpoint).
+  PickResult PickFromFallbackPool(PickArgs args);
+  // Delegates to a random endpoint from `indices` (indices into
+  // slice_map_->all_endpoints()).
+  PickResult DelegateToRandom(const std::vector<size_t>& indices, PickArgs args);
+  // Delegates the pick to `endpoint`'s picker, or queues if it has none.
+  PickResult Delegate(const EndpointState& endpoint, PickArgs args);
+
+  RefCountedPtr<SliceMap> slice_map_;
+  std::string slice_key_header_;
+  bool fallback_enabled_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_LOAD_BALANCING_SLICER_SLICER_PICKER_H

--- a/src/core/load_balancing/slicer/slicer_picker.h
+++ b/src/core/load_balancing/slicer/slicer_picker.h
@@ -55,7 +55,8 @@ class SlicerPicker final : public LoadBalancingPolicy::SubchannelPicker {
   PickResult PickFromFallbackPool(PickArgs args);
   // Delegates to a random endpoint from `indices` (indices into
   // slice_map_->all_endpoints()).
-  PickResult DelegateToRandom(const std::vector<size_t>& indices, PickArgs args);
+  PickResult DelegateToRandom(const std::vector<size_t>& indices,
+                              PickArgs args);
   // Delegates the pick to `endpoint`'s picker, or queues if it has none.
   PickResult Delegate(const EndpointState& endpoint, PickArgs args);
 

--- a/src/core/load_balancing/slicer/slicer_picker.h
+++ b/src/core/load_balancing/slicer/slicer_picker.h
@@ -29,35 +29,22 @@
 
 namespace grpc_core {
 
-// The data-plane picker for the slicer LB policy. It reads the request's
-// slice key from a header, looks up the matching slice in an immutable
-// SliceMap, and delegates the pick to one of the slice's endpoint pickers.
-// Because the SliceMap is immutable, the picker holds no locks.
+// Data-plane picker for slicer LB policy.
 class SlicerPicker final : public LoadBalancingPolicy::SubchannelPicker {
  public:
   using PickArgs = LoadBalancingPolicy::PickArgs;
   using PickResult = LoadBalancingPolicy::PickResult;
 
-  // `slice_key_header` is the name of the request header carrying the
-  // application-defined key. `fallback_enabled` mirrors the policy's
-  // enable_fallback config: when true, keys with no assignment (or slices in
-  // fallback mode) are served from the global fallback pool instead of failing.
   SlicerPicker(RefCountedPtr<SliceMap> slice_map, std::string slice_key_header,
                bool fallback_enabled);
 
   PickResult Pick(PickArgs args) override;
 
  private:
-  // Selects an endpoint from a non-fallback slice, applying the state-based
-  // preference (READY > wake IDLE / queue > fail via TRANSIENT_FAILURE picker).
   PickResult PickFromSlice(const SliceEntry& slice, PickArgs args);
-  // Serves a pick from the global fallback pool (a random endpoint).
   PickResult PickFromFallbackPool(PickArgs args);
-  // Delegates to a random endpoint from `indices` (indices into
-  // slice_map_->all_endpoints()).
   PickResult DelegateToRandom(const std::vector<size_t>& indices,
                               PickArgs args);
-  // Delegates the pick to `endpoint`'s picker, or queues if it has none.
   PickResult Delegate(const EndpointState& endpoint, PickArgs args);
 
   RefCountedPtr<SliceMap> slice_map_;

--- a/test/core/load_balancing/BUILD
+++ b/test/core/load_balancing/BUILD
@@ -400,6 +400,44 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "slice_map_test",
+    srcs = ["slice_map_test.cc"],
+    external_deps = [
+        "gtest",
+        "absl/status",
+        "absl/strings",
+    ],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//:grpc_base",
+        "//:ref_counted_ptr",
+        "//src/core:slice_map",
+        "//test/core/test_util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "slicer_picker_test",
+    srcs = ["slicer_picker_test.cc"],
+    external_deps = [
+        "gtest",
+        "absl/functional:any_invocable",
+        "absl/status",
+        "absl/strings",
+    ],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//:grpc_base",
+        "//:ref_counted_ptr",
+        "//src/core:slice_map",
+        "//src/core:slicer_picker",
+        "//test/core/test_util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "static_stride_scheduler_test",
     srcs = ["static_stride_scheduler_test.cc"],
     external_deps = [

--- a/test/core/load_balancing/slice_map_test.cc
+++ b/test/core/load_balancing/slice_map_test.cc
@@ -111,7 +111,6 @@ TEST(SliceMapTest, LookupFindsContainingSlice) {
       {/*start_key=*/"a", {"a"}},
       {/*start_key=*/"t", {"c"}},
   };
-
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
   ASSERT_EQ((*slice_map)->slices().size(), 3);
@@ -151,7 +150,6 @@ TEST(SliceMapTest, EndpointsBucketedByState) {
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
   ASSERT_EQ((*slice_map)->slices().size(), 1);
   const SliceEntry& slice = (*slice_map)->slices()[0];
-
   EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_READY),
               UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_READY));
   EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_CONNECTING),

--- a/test/core/load_balancing/slice_map_test.cc
+++ b/test/core/load_balancing/slice_map_test.cc
@@ -1,0 +1,249 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/load_balancing/slicer/slice_map.h"
+
+#include <grpc/impl/connectivity_state.h>
+
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+namespace grpc_core {
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+// EndpointState with the given connectivity state and a null picker (the picker
+// is not exercised by these tests).
+RefCountedPtr<EndpointState> Endpoint(grpc_connectivity_state state) {
+  return MakeRefCounted<EndpointState>(state, nullptr);
+}
+
+// Returns the connectivity states of the endpoints in `slice`'s bucket for
+// `state`, resolved via `slice_map.all_endpoints()`. Used to check that indices
+// land in the right bucket and point at the right endpoints.
+std::vector<grpc_connectivity_state> StatesInBucket(
+    const SliceMap& slice_map, const SliceEntry& slice,
+    grpc_connectivity_state state) {
+  std::vector<grpc_connectivity_state> result;
+  for (size_t index : slice.endpoints_by_state[state]) {
+    result.push_back(slice_map.all_endpoints()[index]->connectivity_state());
+  }
+  return result;
+}
+
+TEST(SliceMapTest, TotalFallbackWhenNoAssignment) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["b"] = Endpoint(GRPC_CHANNEL_CONNECTING);
+
+  auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  // No slices: every lookup falls back.
+  EXPECT_TRUE((*slice_map)->slices().empty());
+  EXPECT_EQ((*slice_map)->Lookup(""), nullptr);
+  EXPECT_EQ((*slice_map)->Lookup("anything"), nullptr);
+  // The fallback pool is every endpoint.
+  EXPECT_EQ((*slice_map)->all_endpoints().size(), 2);
+  EXPECT_EQ((*slice_map)->generation(), 0);
+}
+
+TEST(SliceMapTest, EmptyAssignmentSlicesIsTotalFallback) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.generation = 7;  // No slices.
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  EXPECT_TRUE((*slice_map)->slices().empty());
+  EXPECT_EQ((*slice_map)->all_endpoints().size(), 1);
+  // A total-fallback map has no assignment, so generation is 0.
+  EXPECT_EQ((*slice_map)->generation(), 0);
+}
+
+TEST(SliceMapTest, LookupFindsContainingSlice) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["b"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["c"] = Endpoint(GRPC_CHANNEL_READY);
+
+  // Deliberately out of order to exercise the sort in Make().
+  SliceMap::LogicalAssignment assignment;
+  assignment.generation = 42;
+  assignment.slices = {
+      {/*start_key=*/"m", {"b"}},
+      {/*start_key=*/"a", {"a"}},
+      {/*start_key=*/"t", {"c"}},
+  };
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 3);
+
+  // Slices are sorted by start_key.
+  EXPECT_EQ((*slice_map)->slices()[0].start_key, "a");
+  EXPECT_EQ((*slice_map)->slices()[1].start_key, "m");
+  EXPECT_EQ((*slice_map)->slices()[2].start_key, "t");
+
+  // Below the first start_key => no slice => fallback.
+  EXPECT_EQ((*slice_map)->Lookup("0"), nullptr);
+  // Exactly on a start_key => that slice.
+  EXPECT_EQ((*slice_map)->Lookup("a"), &(*slice_map)->slices()[0]);
+  EXPECT_EQ((*slice_map)->Lookup("m"), &(*slice_map)->slices()[1]);
+  // Inside a range => the slice with the greatest start_key <= key.
+  EXPECT_EQ((*slice_map)->Lookup("f"), &(*slice_map)->slices()[0]);
+  EXPECT_EQ((*slice_map)->Lookup("s"), &(*slice_map)->slices()[1]);
+  // Above all start_keys => the last slice.
+  EXPECT_EQ((*slice_map)->Lookup("z"), &(*slice_map)->slices()[2]);
+
+  EXPECT_EQ((*slice_map)->generation(), 42);
+}
+
+TEST(SliceMapTest, EndpointsBucketedByState) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["ready1"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["ready2"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["connecting"] = Endpoint(GRPC_CHANNEL_CONNECTING);
+  endpoints["tf"] = Endpoint(GRPC_CHANNEL_TRANSIENT_FAILURE);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {
+      {/*start_key=*/"", {"ready1", "connecting", "ready2", "tf"}},
+  };
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  const SliceEntry& slice = (*slice_map)->slices()[0];
+
+  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_READY),
+              UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_READY));
+  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_CONNECTING),
+              UnorderedElementsAre(GRPC_CHANNEL_CONNECTING));
+  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_TRANSIENT_FAILURE),
+              UnorderedElementsAre(GRPC_CHANNEL_TRANSIENT_FAILURE));
+  EXPECT_TRUE(slice.endpoints_by_state[GRPC_CHANNEL_IDLE].empty());
+  EXPECT_FALSE(slice.in_fallback);
+}
+
+TEST(SliceMapTest, UnmappedEndpointsAppendedToFallbackPoolOnly) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["assigned"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["unmapped1"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["unmapped2"] = Endpoint(GRPC_CHANNEL_IDLE);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", {"assigned"}}};
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  // All three endpoints are in the fallback pool.
+  EXPECT_EQ((*slice_map)->all_endpoints().size(), 3);
+  // But the single slice contains only the assigned endpoint.
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  const SliceEntry& slice = (*slice_map)->slices()[0];
+  size_t total = 0;
+  for (const auto& bucket : slice.endpoints_by_state) total += bucket.size();
+  EXPECT_EQ(total, 1);
+}
+
+TEST(SliceMapTest, InFallbackWhenSliceHasNoEndpoints) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", /*endpoint_names=*/{}}};
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  EXPECT_TRUE((*slice_map)->slices()[0].in_fallback);
+}
+
+TEST(SliceMapTest, InFallbackWhenAllEndpointsInTransientFailure) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["tf1"] = Endpoint(GRPC_CHANNEL_TRANSIENT_FAILURE);
+  endpoints["tf2"] = Endpoint(GRPC_CHANNEL_TRANSIENT_FAILURE);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", {"tf1", "tf2"}}};
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  EXPECT_TRUE((*slice_map)->slices()[0].in_fallback);
+}
+
+TEST(SliceMapTest, NotInFallbackWithOneNonTransientFailureEndpoint) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["tf"] = Endpoint(GRPC_CHANNEL_TRANSIENT_FAILURE);
+  endpoints["ready"] = Endpoint(GRPC_CHANNEL_READY);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", {"tf", "ready"}}};
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  EXPECT_FALSE((*slice_map)->slices()[0].in_fallback);
+}
+
+TEST(SliceMapTest, MissingAssignedEndpointIsError) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", {"a", "does-not-exist"}}};
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_FALSE(slice_map.ok());
+  EXPECT_EQ(slice_map.status().code(), absl::StatusCode::kNotFound);
+}
+
+TEST(SliceMapTest, EndpointSharedAcrossSlicesIsDeduplicated) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["shared"] = Endpoint(GRPC_CHANNEL_READY);
+  endpoints["other"] = Endpoint(GRPC_CHANNEL_READY);
+
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {
+      {/*start_key=*/"a", {"shared", "other"}},
+      {/*start_key=*/"b", {"shared"}},
+  };
+
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  // "shared" appears in both slices but is stored once in all_endpoints().
+  EXPECT_EQ((*slice_map)->all_endpoints().size(), 2);
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/core/load_balancing/slice_map_test.cc
+++ b/test/core/load_balancing/slice_map_test.cc
@@ -21,11 +21,11 @@
 #include <string>
 #include <vector>
 
-#include "absl/status/status.h"
-#include "absl/strings/string_view.h"
+#include "src/core/util/ref_counted_ptr.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "src/core/util/ref_counted_ptr.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 
 namespace grpc_core {
 namespace {
@@ -76,8 +76,9 @@ TEST(SliceMapTest, TotalFallbackWhenNoAssignment) {
   EXPECT_EQ((*slice_map)->Lookup(""), nullptr);
   EXPECT_EQ((*slice_map)->Lookup("anything"), nullptr);
   // The fallback pool is every endpoint.
-  EXPECT_THAT(AllStates(**slice_map),
-              UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_CONNECTING));
+  EXPECT_THAT(
+      AllStates(**slice_map),
+      UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_CONNECTING));
   EXPECT_EQ((*slice_map)->generation(), 0);
 }
 
@@ -155,8 +156,9 @@ TEST(SliceMapTest, EndpointsBucketedByState) {
               UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_READY));
   EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_CONNECTING),
               UnorderedElementsAre(GRPC_CHANNEL_CONNECTING));
-  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_TRANSIENT_FAILURE),
-              UnorderedElementsAre(GRPC_CHANNEL_TRANSIENT_FAILURE));
+  EXPECT_THAT(
+      StatesInBucket(**slice_map, slice, GRPC_CHANNEL_TRANSIENT_FAILURE),
+      UnorderedElementsAre(GRPC_CHANNEL_TRANSIENT_FAILURE));
   EXPECT_TRUE(slice.endpoints_by_state[GRPC_CHANNEL_IDLE].empty());
   EXPECT_FALSE(slice.in_fallback);
 }
@@ -228,7 +230,7 @@ TEST(SliceMapTest, NotInFallbackWithOneNonTransientFailureEndpoint) {
   EXPECT_FALSE((*slice_map)->slices()[0].in_fallback);
 }
 
-TEST(SliceMapTest, MissingAssignedEndpointIsError) {
+TEST(SliceMapTest, MissingAssignedEndpointIsSkipped) {
   SliceMap::EndpointMap endpoints;
   endpoints["a"] = Endpoint(GRPC_CHANNEL_READY);
 
@@ -236,8 +238,12 @@ TEST(SliceMapTest, MissingAssignedEndpointIsError) {
   assignment.slices = {{/*start_key=*/"", {"a", "does-not-exist"}}};
 
   auto slice_map = SliceMap::Make(endpoints, &assignment);
-  ASSERT_FALSE(slice_map.ok());
-  EXPECT_EQ(slice_map.status().code(), absl::StatusCode::kNotFound);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+  ASSERT_EQ((*slice_map)->slices().size(), 1);
+  const SliceEntry& slice = (*slice_map)->slices()[0];
+  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_READY),
+              ElementsAre(GRPC_CHANNEL_READY));
+  EXPECT_FALSE(slice.in_fallback);
 }
 
 TEST(SliceMapTest, EndpointSharedAcrossSlicesIsDeduplicated) {

--- a/test/core/load_balancing/slice_map_test.cc
+++ b/test/core/load_balancing/slice_map_test.cc
@@ -30,12 +30,24 @@
 namespace grpc_core {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
 // EndpointState with the given connectivity state and a null picker (the picker
 // is not exercised by these tests).
 RefCountedPtr<EndpointState> Endpoint(grpc_connectivity_state state) {
   return MakeRefCounted<EndpointState>(state, nullptr);
+}
+
+// The connectivity states of every endpoint in the map (i.e. the fallback
+// pool). Endpoints carry no identity of their own, so tests assert on the
+// multiset of states rather than on endpoint names.
+std::vector<grpc_connectivity_state> AllStates(const SliceMap& slice_map) {
+  std::vector<grpc_connectivity_state> result;
+  for (const auto& endpoint : slice_map.all_endpoints()) {
+    result.push_back(endpoint->connectivity_state());
+  }
+  return result;
 }
 
 // Returns the connectivity states of the endpoints in `slice`'s bucket for
@@ -64,7 +76,8 @@ TEST(SliceMapTest, TotalFallbackWhenNoAssignment) {
   EXPECT_EQ((*slice_map)->Lookup(""), nullptr);
   EXPECT_EQ((*slice_map)->Lookup("anything"), nullptr);
   // The fallback pool is every endpoint.
-  EXPECT_EQ((*slice_map)->all_endpoints().size(), 2);
+  EXPECT_THAT(AllStates(**slice_map),
+              UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_CONNECTING));
   EXPECT_EQ((*slice_map)->generation(), 0);
 }
 
@@ -78,7 +91,7 @@ TEST(SliceMapTest, EmptyAssignmentSlicesIsTotalFallback) {
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
   EXPECT_TRUE((*slice_map)->slices().empty());
-  EXPECT_EQ((*slice_map)->all_endpoints().size(), 1);
+  EXPECT_THAT(AllStates(**slice_map), ElementsAre(GRPC_CHANNEL_READY));
   // A total-fallback map has no assignment, so generation is 0.
   EXPECT_EQ((*slice_map)->generation(), 0);
 }
@@ -161,13 +174,17 @@ TEST(SliceMapTest, UnmappedEndpointsAppendedToFallbackPoolOnly) {
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
 
   // All three endpoints are in the fallback pool.
-  EXPECT_EQ((*slice_map)->all_endpoints().size(), 3);
-  // But the single slice contains only the assigned endpoint.
+  EXPECT_THAT(AllStates(**slice_map),
+              UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_READY,
+                                   GRPC_CHANNEL_IDLE));
+  // But the single slice contains only the assigned (READY) endpoint.
   ASSERT_EQ((*slice_map)->slices().size(), 1);
   const SliceEntry& slice = (*slice_map)->slices()[0];
-  size_t total = 0;
-  for (const auto& bucket : slice.endpoints_by_state) total += bucket.size();
-  EXPECT_EQ(total, 1);
+  EXPECT_THAT(StatesInBucket(**slice_map, slice, GRPC_CHANNEL_READY),
+              ElementsAre(GRPC_CHANNEL_READY));
+  // The slice's only endpoint is that READY one (flat list == READY bucket).
+  EXPECT_EQ(slice.all_endpoints_in_slice,
+            slice.endpoints_by_state[GRPC_CHANNEL_READY]);
 }
 
 TEST(SliceMapTest, InFallbackWhenSliceHasNoEndpoints) {
@@ -237,7 +254,15 @@ TEST(SliceMapTest, EndpointSharedAcrossSlicesIsDeduplicated) {
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
   // "shared" appears in both slices but is stored once in all_endpoints().
-  EXPECT_EQ((*slice_map)->all_endpoints().size(), 2);
+  EXPECT_THAT(AllStates(**slice_map),
+              UnorderedElementsAre(GRPC_CHANNEL_READY, GRPC_CHANNEL_READY));
+  // ...and slice "b" reuses the very index that slice "a" assigned to "shared"
+  // (its first endpoint), rather than a duplicate entry.
+  ASSERT_EQ((*slice_map)->slices().size(), 2);
+  const SliceEntry& slice_a = (*slice_map)->slices()[0];  // start_key "a"
+  const SliceEntry& slice_b = (*slice_map)->slices()[1];  // start_key "b"
+  EXPECT_THAT(slice_b.all_endpoints_in_slice,
+              ElementsAre(slice_a.all_endpoints_in_slice[0]));
 }
 
 }  // namespace

--- a/test/core/load_balancing/slicer_picker_test.cc
+++ b/test/core/load_balancing/slicer_picker_test.cc
@@ -1,0 +1,267 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/load_balancing/slicer/slicer_picker.h"
+
+#include <grpc/impl/connectivity_state.h>
+
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/core/load_balancing/lb_policy.h"
+#include "src/core/load_balancing/slicer/slice_map.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+namespace grpc_core {
+namespace {
+
+using ::testing::AnyOf;
+
+constexpr absl::string_view kHeader = "slice-key";
+
+using PickArgs = LoadBalancingPolicy::PickArgs;
+using PickResult = LoadBalancingPolicy::PickResult;
+using SubchannelPicker = LoadBalancingPolicy::SubchannelPicker;
+
+// A child picker that identifies itself by failing with its tag as the status
+// message. Delegating to an endpoint therefore produces a Fail whose message
+// tells us which endpoint's picker was invoked.
+class TaggedPicker final : public SubchannelPicker {
+ public:
+  explicit TaggedPicker(std::string tag) : tag_(std::move(tag)) {}
+  PickResult Pick(PickArgs /*args*/) override {
+    return PickResult::Fail(absl::UnavailableError(tag_));
+  }
+
+ private:
+  std::string tag_;
+};
+
+// Metadata carrying (at most) a single header value.
+class FakeMetadata final : public LoadBalancingPolicy::MetadataInterface {
+ public:
+  explicit FakeMetadata(std::optional<std::string> value)
+      : value_(std::move(value)) {}
+  std::optional<absl::string_view> Lookup(absl::string_view key,
+                                          std::string* /*buffer*/) const override {
+    if (value_.has_value() && key == kHeader) return absl::string_view(*value_);
+    return std::nullopt;
+  }
+
+ private:
+  std::optional<std::string> value_;
+};
+
+RefCountedPtr<EndpointState> MakeEndpoint(grpc_connectivity_state state,
+                                          std::string tag,
+                                          int* exit_idle_count = nullptr) {
+  absl::AnyInvocable<void()> on_exit_idle = nullptr;
+  if (exit_idle_count != nullptr) {
+    on_exit_idle = [exit_idle_count]() { ++*exit_idle_count; };
+  }
+  return MakeRefCounted<EndpointState>(
+      state, MakeRefCounted<TaggedPicker>(std::move(tag)),
+      std::move(on_exit_idle));
+}
+
+// If the pick delegated to a TaggedPicker (or otherwise failed), returns the
+// status message; std::nullopt for a non-Fail result.
+std::optional<std::string> FailMessage(const PickResult& result) {
+  if (const auto* fail = std::get_if<PickResult::Fail>(&result.result)) {
+    return std::string(fail->status.message());
+  }
+  return std::nullopt;
+}
+
+bool IsQueue(const PickResult& result) {
+  return std::holds_alternative<PickResult::Queue>(result.result);
+}
+
+PickResult DoPick(SlicerPicker& picker, std::optional<std::string> header_value) {
+  FakeMetadata metadata(std::move(header_value));
+  PickArgs args{/*path=*/"", &metadata, /*call_state=*/nullptr};
+  return picker.Pick(args);
+}
+
+// Builds a single-slice assignment starting at "" with the given endpoint names.
+SliceMap::LogicalAssignment OneSlice(std::vector<std::string> endpoint_names) {
+  SliceMap::LogicalAssignment assignment;
+  assignment.slices = {{/*start_key=*/"", std::move(endpoint_names)}};
+  return assignment;
+}
+
+TEST(SlicerPickerTest, NoAssignmentFallbackDisabledFails) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = MakeEndpoint(GRPC_CHANNEL_READY, "a");
+  auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  auto result = DoPick(picker, "anything");
+  ASSERT_TRUE(FailMessage(result).has_value());
+  EXPECT_THAT(*FailMessage(result), ::testing::HasSubstr("no slice assignment"));
+}
+
+TEST(SlicerPickerTest, NoAssignmentFallbackEnabledUsesFallbackPool) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = MakeEndpoint(GRPC_CHANNEL_READY, "a");
+  auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/true);
+  // Single endpoint in the fallback pool => deterministic delegation to "a".
+  EXPECT_EQ(FailMessage(DoPick(picker, "anything")), "a");
+}
+
+TEST(SlicerPickerTest, ReadySliceDelegatesToReadyEndpoint) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["r"] = MakeEndpoint(GRPC_CHANNEL_READY, "r");
+  auto assignment = OneSlice({"r"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  EXPECT_EQ(FailMessage(DoPick(picker, "k")), "r");
+}
+
+TEST(SlicerPickerTest, MissingHeaderUsesEmptyKey) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["r"] = MakeEndpoint(GRPC_CHANNEL_READY, "r");
+  auto assignment = OneSlice({"r"});  // slice starts at "".
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  // No header => empty key => matches the slice starting at "".
+  EXPECT_EQ(FailMessage(DoPick(picker, std::nullopt)), "r");
+}
+
+TEST(SlicerPickerTest, IdleWithNoReadyTriggersExitIdleAndQueues) {
+  int exit_idle_count = 0;
+  SliceMap::EndpointMap endpoints;
+  endpoints["i"] = MakeEndpoint(GRPC_CHANNEL_IDLE, "i", &exit_idle_count);
+  auto assignment = OneSlice({"i"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
+  // A second pick must not re-trigger the connection attempt.
+  EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
+  EXPECT_EQ(exit_idle_count, 1);
+}
+
+TEST(SlicerPickerTest, IdleWithReadyDelegatesToReady) {
+  int exit_idle_count = 0;
+  SliceMap::EndpointMap endpoints;
+  endpoints["i"] = MakeEndpoint(GRPC_CHANNEL_IDLE, "i", &exit_idle_count);
+  endpoints["r"] = MakeEndpoint(GRPC_CHANNEL_READY, "r");
+  auto assignment = OneSlice({"i", "r"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  // Whether the random endpoint is "i" or "r", the pick resolves to "r": either
+  // by direct delegation, or by falling through from IDLE to the READY list.
+  EXPECT_EQ(FailMessage(DoPick(picker, "k")), "r");
+}
+
+TEST(SlicerPickerTest, ConnectingQueues) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["c"] = MakeEndpoint(GRPC_CHANNEL_CONNECTING, "c");
+  auto assignment = OneSlice({"c"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
+}
+
+TEST(SlicerPickerTest, AllTransientFailureFallbackDisabledFailsViaEndpointPicker) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["tf1"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf1");
+  endpoints["tf2"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf2");
+  auto assignment = OneSlice({"tf1", "tf2"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  // Slice is in_fallback (all TF), but fallback is disabled, so the pick is
+  // served from the slice and fails via the selected endpoint's picker.
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  auto msg = FailMessage(DoPick(picker, "k"));
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_THAT(*msg, AnyOf("tf1", "tf2"));
+}
+
+TEST(SlicerPickerTest, EmptySliceQueues) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["a"] = MakeEndpoint(GRPC_CHANNEL_READY, "a");
+  auto assignment = OneSlice({});  // Slice with no endpoints.
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/false);
+  EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
+}
+
+TEST(SlicerPickerTest, SliceInFallbackUsesGlobalFallbackPool) {
+  // The slice contains only a TRANSIENT_FAILURE endpoint (=> in_fallback), while
+  // the resolver also has an unassigned READY endpoint "fb". With fallback
+  // enabled, picks must be served from the global pool (which includes "fb"),
+  // not from the slice alone.
+  SliceMap::EndpointMap endpoints;
+  endpoints["tf"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf");
+  endpoints["fb"] = MakeEndpoint(GRPC_CHANNEL_READY, "fb");
+  auto assignment = OneSlice({"tf"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/true);
+  // Over many picks the random fallback selection must include "fb", which is
+  // not part of the slice -- proving the global pool is used.
+  bool saw_fb = false;
+  for (int i = 0; i < 200; ++i) {
+    auto msg = FailMessage(DoPick(picker, "k"));
+    ASSERT_TRUE(msg.has_value());
+    EXPECT_THAT(*msg, AnyOf("tf", "fb"));
+    if (*msg == "fb") saw_fb = true;
+  }
+  EXPECT_TRUE(saw_fb);
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/core/load_balancing/slicer_picker_test.cc
+++ b/test/core/load_balancing/slicer_picker_test.cc
@@ -116,7 +116,6 @@ TEST(SlicerPickerTest, NoAssignmentFallbackDisabledFails) {
   endpoints["a"] = MakeEndpoint(GRPC_CHANNEL_READY, "a");
   auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   auto result = DoPick(picker, "anything");
@@ -143,7 +142,6 @@ TEST(SlicerPickerTest, ReadySliceDelegatesToReadyEndpoint) {
   auto assignment = OneSlice({"r"});
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   EXPECT_EQ(FailMessage(DoPick(picker, "k")), "r");
@@ -155,7 +153,6 @@ TEST(SlicerPickerTest, MissingHeaderFailsWhenFallbackDisabled) {
   auto assignment = OneSlice({"r"});  // Slice starts at "".
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   // A request with no slice-key header cannot be routed; it must not be
@@ -172,7 +169,6 @@ TEST(SlicerPickerTest, MissingHeaderUsesFallbackPoolWhenEnabled) {
   auto assignment = OneSlice({"r"});
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/true);
   // No key => fallback pool (single endpoint => deterministic "r").
@@ -186,7 +182,6 @@ TEST(SlicerPickerTest, IdleWithNoReadyTriggersExitIdleAndQueues) {
   auto assignment = OneSlice({"i"});
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
@@ -203,7 +198,6 @@ TEST(SlicerPickerTest, IdleWithReadyDelegatesToReady) {
   auto assignment = OneSlice({"i", "r"});
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   // Whether the random endpoint is "i" or "r", the pick resolves to "r": either
@@ -247,7 +241,6 @@ TEST(SlicerPickerTest, EmptySliceQueues) {
   auto assignment = OneSlice({});  // Slice with no endpoints.
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
   EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
@@ -264,7 +257,6 @@ TEST(SlicerPickerTest, SliceInFallbackUsesGlobalFallbackPool) {
   auto assignment = OneSlice({"tf"});
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/true);
   // Over many picks the random fallback selection must include "fb", which is
@@ -285,7 +277,6 @@ TEST(SlicerPickerTest, FallbackPoolTriggersExitIdleOnIdleEndpoint) {
   endpoints["i"] = MakeEndpoint(GRPC_CHANNEL_IDLE, "i", &exit_idle_count);
   auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
-
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/true);
   (void)DoPick(picker, "anything");

--- a/test/core/load_balancing/slicer_picker_test.cc
+++ b/test/core/load_balancing/slicer_picker_test.cc
@@ -146,16 +146,32 @@ TEST(SlicerPickerTest, ReadySliceDelegatesToReadyEndpoint) {
   EXPECT_EQ(FailMessage(DoPick(picker, "k")), "r");
 }
 
-TEST(SlicerPickerTest, MissingHeaderUsesEmptyKey) {
+TEST(SlicerPickerTest, MissingHeaderFailsWhenFallbackDisabled) {
   SliceMap::EndpointMap endpoints;
   endpoints["r"] = MakeEndpoint(GRPC_CHANNEL_READY, "r");
-  auto assignment = OneSlice({"r"});  // slice starts at "".
+  auto assignment = OneSlice({"r"});  // Slice starts at "".
   auto slice_map = SliceMap::Make(endpoints, &assignment);
   ASSERT_TRUE(slice_map.ok()) << slice_map.status();
 
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
-  // No header => empty key => matches the slice starting at "".
+  // A request with no slice-key header cannot be routed; it must not be silently
+  // treated as the empty key (which would match the slice starting at "").
+  auto msg = FailMessage(DoPick(picker, std::nullopt));
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_THAT(*msg, ::testing::HasSubstr("no \"slice-key\" header"));
+}
+
+TEST(SlicerPickerTest, MissingHeaderUsesFallbackPoolWhenEnabled) {
+  SliceMap::EndpointMap endpoints;
+  endpoints["r"] = MakeEndpoint(GRPC_CHANNEL_READY, "r");
+  auto assignment = OneSlice({"r"});
+  auto slice_map = SliceMap::Make(endpoints, &assignment);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/true);
+  // No key => fallback pool (single endpoint => deterministic "r").
   EXPECT_EQ(FailMessage(DoPick(picker, std::nullopt)), "r");
 }
 

--- a/test/core/load_balancing/slicer_picker_test.cc
+++ b/test/core/load_balancing/slicer_picker_test.cc
@@ -22,14 +22,14 @@
 #include <string>
 #include <variant>
 
-#include "absl/functional/any_invocable.h"
-#include "absl/status/status.h"
-#include "absl/strings/string_view.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "src/core/load_balancing/lb_policy.h"
 #include "src/core/load_balancing/slicer/slice_map.h"
 #include "src/core/util/ref_counted_ptr.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 
 namespace grpc_core {
 namespace {
@@ -61,8 +61,8 @@ class FakeMetadata final : public LoadBalancingPolicy::MetadataInterface {
  public:
   explicit FakeMetadata(std::optional<std::string> value)
       : value_(std::move(value)) {}
-  std::optional<absl::string_view> Lookup(absl::string_view key,
-                                          std::string* /*buffer*/) const override {
+  std::optional<absl::string_view> Lookup(
+      absl::string_view key, std::string* /*buffer*/) const override {
     if (value_.has_value() && key == kHeader) return absl::string_view(*value_);
     return std::nullopt;
   }
@@ -96,13 +96,15 @@ bool IsQueue(const PickResult& result) {
   return std::holds_alternative<PickResult::Queue>(result.result);
 }
 
-PickResult DoPick(SlicerPicker& picker, std::optional<std::string> header_value) {
+PickResult DoPick(SlicerPicker& picker,
+                  std::optional<std::string> header_value) {
   FakeMetadata metadata(std::move(header_value));
   PickArgs args{/*path=*/"", &metadata, /*call_state=*/nullptr};
   return picker.Pick(args);
 }
 
-// Builds a single-slice assignment starting at "" with the given endpoint names.
+// Builds a single-slice assignment starting at "" with the given endpoint
+// names.
 SliceMap::LogicalAssignment OneSlice(std::vector<std::string> endpoint_names) {
   SliceMap::LogicalAssignment assignment;
   assignment.slices = {{/*start_key=*/"", std::move(endpoint_names)}};
@@ -119,7 +121,8 @@ TEST(SlicerPickerTest, NoAssignmentFallbackDisabledFails) {
                       /*fallback_enabled=*/false);
   auto result = DoPick(picker, "anything");
   ASSERT_TRUE(FailMessage(result).has_value());
-  EXPECT_THAT(*FailMessage(result), ::testing::HasSubstr("no slice assignment"));
+  EXPECT_THAT(*FailMessage(result),
+              ::testing::HasSubstr("no slice assignment"));
 }
 
 TEST(SlicerPickerTest, NoAssignmentFallbackEnabledUsesFallbackPool) {
@@ -155,8 +158,9 @@ TEST(SlicerPickerTest, MissingHeaderFailsWhenFallbackDisabled) {
 
   SlicerPicker picker(*slice_map, std::string(kHeader),
                       /*fallback_enabled=*/false);
-  // A request with no slice-key header cannot be routed; it must not be silently
-  // treated as the empty key (which would match the slice starting at "").
+  // A request with no slice-key header cannot be routed; it must not be
+  // silently treated as the empty key (which would match the slice starting at
+  // "").
   auto msg = FailMessage(DoPick(picker, std::nullopt));
   ASSERT_TRUE(msg.has_value());
   EXPECT_THAT(*msg, ::testing::HasSubstr("no \"slice-key\" header"));
@@ -219,7 +223,8 @@ TEST(SlicerPickerTest, ConnectingQueues) {
   EXPECT_TRUE(IsQueue(DoPick(picker, "k")));
 }
 
-TEST(SlicerPickerTest, AllTransientFailureFallbackDisabledFailsViaEndpointPicker) {
+TEST(SlicerPickerTest,
+     AllTransientFailureFallbackDisabledFailsViaEndpointPicker) {
   SliceMap::EndpointMap endpoints;
   endpoints["tf1"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf1");
   endpoints["tf2"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf2");
@@ -249,10 +254,10 @@ TEST(SlicerPickerTest, EmptySliceQueues) {
 }
 
 TEST(SlicerPickerTest, SliceInFallbackUsesGlobalFallbackPool) {
-  // The slice contains only a TRANSIENT_FAILURE endpoint (=> in_fallback), while
-  // the resolver also has an unassigned READY endpoint "fb". With fallback
-  // enabled, picks must be served from the global pool (which includes "fb"),
-  // not from the slice alone.
+  // The slice contains only a TRANSIENT_FAILURE endpoint (=> in_fallback),
+  // while the resolver also has an unassigned READY endpoint "fb". With
+  // fallback enabled, picks must be served from the global pool (which includes
+  // "fb"), not from the slice alone.
   SliceMap::EndpointMap endpoints;
   endpoints["tf"] = MakeEndpoint(GRPC_CHANNEL_TRANSIENT_FAILURE, "tf");
   endpoints["fb"] = MakeEndpoint(GRPC_CHANNEL_READY, "fb");
@@ -272,6 +277,19 @@ TEST(SlicerPickerTest, SliceInFallbackUsesGlobalFallbackPool) {
     if (*msg == "fb") saw_fb = true;
   }
   EXPECT_TRUE(saw_fb);
+}
+
+TEST(SlicerPickerTest, FallbackPoolTriggersExitIdleOnIdleEndpoint) {
+  int exit_idle_count = 0;
+  SliceMap::EndpointMap endpoints;
+  endpoints["i"] = MakeEndpoint(GRPC_CHANNEL_IDLE, "i", &exit_idle_count);
+  auto slice_map = SliceMap::Make(endpoints, /*assignment=*/nullptr);
+  ASSERT_TRUE(slice_map.ok()) << slice_map.status();
+
+  SlicerPicker picker(*slice_map, std::string(kHeader),
+                      /*fallback_enabled=*/true);
+  (void)DoPick(picker, "anything");
+  EXPECT_EQ(exit_idle_count, 1);
 }
 
 }  // namespace

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -8936,7 +8936,55 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "slice_map_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "slice_string_helpers_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
+    "name": "slicer_picker_test",
     "platforms": [
       "linux",
       "mac",


### PR DESCRIPTION
This PR implements SliceMap and SlicerPicker, introducing the core data structures and data-plane routing logic for the Slicer Load Balancing Policy specified in gRFC A119: Slicer LB Policy       
  https://github.com/grpc/proposal/blob/master/A119-slicer-lb-policy.md