### PR TITLE
chore: rename php-ext

### DIFF
--- a/src/php/ext/grpc/README.md
+++ b/src/php/ext/grpc/README.md
@@ -9,7 +9,7 @@ Development of the gRPC PHP extension takes place inside the main monorepo at [g
 You can install this extension using PIE:
 
 ```bash
-pie install grpc/grpc-php-ext
+pie install grpc/grpc-ext
 ```
 
 Ensure your system has the required build tools (like `make`, `gcc`, `autoconf`, `phpize`) installed prior to running the installation command.

--- a/src/php/ext/grpc/composer.json
+++ b/src/php/ext/grpc/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "grpc/grpc-php-ext",
+    "name": "grpc/grpc-ext",
     "description": "gRPC PHP Extension",
     "type": "php-ext",
     "require": {


### PR DESCRIPTION
Renames `grpc/grpc-php-ext` to `grpc/grpc-ext` to be consistent and idiomatic

fixes https://github.com/grpc/grpc/issues/43051