### PR TITLE
[core][filters] Rename exiting test as v2 filter test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1488,7 +1488,7 @@ if(gRPC_BUILD_TESTS)
   endif()
   add_dependencies(buildtests_cxx file_watcher_certificate_provider_factory_test)
   add_dependencies(buildtests_cxx filter_fusion_test)
-  add_dependencies(buildtests_cxx filter_test_test)
+  add_dependencies(buildtests_cxx filter_test_v2_test)
   add_dependencies(buildtests_cxx flaky_network_test)
   add_dependencies(buildtests_cxx flow_control_manager_test)
   add_dependencies(buildtests_cxx flow_control_test)
@@ -12495,7 +12495,7 @@ add_executable(client_auth_filter_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/filters/client_auth_filter_test.cc
-  test/core/filters/filter_test.cc
+  test/core/filters/filter_test_v2.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -12545,7 +12545,7 @@ add_executable(client_authority_filter_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/filters/client_authority_filter_test.cc
-  test/core/filters/filter_test.cc
+  test/core/filters/filter_test_v2.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -18201,27 +18201,27 @@ target_link_libraries(filter_fusion_test
 endif()
 if(gRPC_BUILD_TESTS)
 
-add_executable(filter_test_test
+add_executable(filter_test_v2_test
   ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h
   ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.h
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  test/core/filters/filter_test.cc
-  test/core/filters/filter_test_test.cc
+  test/core/filters/filter_test_v2.cc
+  test/core/filters/filter_test_v2_test.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(filter_test_test
+    target_compile_definitions(filter_test_v2_test
     PRIVATE
       "GPR_DLL_IMPORTS"
       "GRPC_DLL_IMPORTS"
     )
   endif()
 endif()
-target_compile_features(filter_test_test PUBLIC cxx_std_17)
-target_include_directories(filter_test_test
+target_compile_features(filter_test_v2_test PUBLIC cxx_std_17)
+target_include_directories(filter_test_v2_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -18240,7 +18240,7 @@ target_include_directories(filter_test_test
     ${_gRPC_PROTO_GENS_DIR}
 )
 
-target_link_libraries(filter_test_test
+target_link_libraries(filter_test_v2_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
   grpc_unsecure
@@ -19121,7 +19121,7 @@ add_executable(gcp_authentication_filter_test
   ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.h
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  test/core/filters/filter_test.cc
+  test/core/filters/filter_test_v2.cc
   test/core/filters/gcp_authentication_filter_test.cc
 )
 if(WIN32 AND MSVC)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -9393,13 +9393,13 @@ targets:
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/filters/filter_test.h
+  - test/core/filters/filter_test_v2.h
   src:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.proto
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   - test/core/filters/client_auth_filter_test.cc
-  - test/core/filters/filter_test.cc
+  - test/core/filters/filter_test_v2.cc
   deps:
   - gtest
   - protobuf
@@ -9411,13 +9411,13 @@ targets:
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/filters/filter_test.h
+  - test/core/filters/filter_test_v2.h
   src:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.proto
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   - test/core/filters/client_authority_filter_test.cc
-  - test/core/filters/filter_test.cc
+  - test/core/filters/filter_test_v2.cc
   deps:
   - gtest
   - protobuf
@@ -13787,20 +13787,20 @@ targets:
   - cares
   - gpr
   - address_sorting
-- name: filter_test_test
+- name: filter_test_v2_test
   gtest: true
   build: test
   language: c++
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/filters/filter_test.h
+  - test/core/filters/filter_test_v2.h
   src:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.proto
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/filters/filter_test.cc
-  - test/core/filters/filter_test_test.cc
+  - test/core/filters/filter_test_v2.cc
+  - test/core/filters/filter_test_v2_test.cc
   deps:
   - gtest
   - grpc_unsecure
@@ -14842,12 +14842,12 @@ targets:
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/filters/filter_test.h
+  - test/core/filters/filter_test_v2.h
   src:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.proto
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/filters/filter_test.cc
+  - test/core/filters/filter_test_v2.cc
   - test/core/filters/gcp_authentication_filter_test.cc
   deps:
   - gtest

--- a/test/core/filters/BUILD
+++ b/test/core/filters/BUILD
@@ -26,10 +26,10 @@ grpc_package(
 )
 
 grpc_cc_library(
-    name = "filter_test",
+    name = "filter_test_v2",
     testonly = 1,
-    srcs = ["filter_test.cc"],
-    hdrs = ["filter_test.h"],
+    srcs = ["filter_test_v2.cc"],
+    hdrs = ["filter_test_v2.h"],
     external_deps = [
         "absl/memory",
         "absl/status",
@@ -68,8 +68,8 @@ grpc_cc_library(
 )
 
 grpc_cc_test(
-    name = "filter_test_test",
-    srcs = ["filter_test_test.cc"],
+    name = "filter_test_v2_test",
+    srcs = ["filter_test_v2_test.cc"],
     external_deps = [
         "absl/status:statusor",
         "gtest",
@@ -77,7 +77,7 @@ grpc_cc_test(
     uses_event_engine = False,
     uses_polling = False,
     deps = [
-        "filter_test",
+        "filter_test_v2",
         "//:grpc_base",
         "//:grpc_unsecure",
         "//src/core:activity",
@@ -104,7 +104,7 @@ grpc_cc_test(
     uses_event_engine = False,
     uses_polling = False,
     deps = [
-        "filter_test",
+        "filter_test_v2",
         "//:grpc",
         "//:grpc_base",
         "//:grpc_core_credentials_header",
@@ -132,7 +132,7 @@ grpc_cc_test(
     uses_event_engine = False,
     uses_polling = False,
     deps = [
-        "filter_test",
+        "filter_test_v2",
         "//:channel_arg_names",
         "//src/core:grpc_client_authority_filter",
     ],
@@ -151,7 +151,7 @@ grpc_cc_test(
     uses_event_engine = False,
     uses_polling = False,
     deps = [
-        "filter_test",
+        "filter_test_v2",
         "//:grpc",
         "//:grpc_base",
         "//:grpc_security_base",

--- a/test/core/filters/client_auth_filter_test.cc
+++ b/test/core/filters/client_auth_filter_test.cc
@@ -35,7 +35,7 @@
 #include "src/core/util/ref_counted_ptr.h"
 #include "src/core/util/unique_type_name.h"
 #include "src/core/util/useful.h"
-#include "test/core/filters/filter_test.h"
+#include "test/core/filters/filter_test_v2.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/status/status.h"
@@ -50,7 +50,7 @@
 namespace grpc_core {
 namespace {
 
-class ClientAuthFilterTest : public FilterTest<ClientAuthFilter> {
+class ClientAuthFilterTest : public FilterTestV2<ClientAuthFilter> {
  protected:
   class FailCallCreds : public grpc_call_credentials {
    public:

--- a/test/core/filters/client_authority_filter_test.cc
+++ b/test/core/filters/client_authority_filter_test.cc
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-#include "test/core/filters/filter_test.h"
+#include "test/core/filters/filter_test_v2.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/status/status.h"
@@ -29,7 +29,7 @@ using ::testing::StrictMock;
 namespace grpc_core {
 namespace {
 
-using ClientAuthorityFilterTest = FilterTest<ClientAuthorityFilter>;
+using ClientAuthorityFilterTest = FilterTestV2<ClientAuthorityFilter>;
 
 ChannelArgs TestChannelArgs(absl::string_view default_authority) {
   return ChannelArgs().Set(GRPC_ARG_DEFAULT_AUTHORITY, default_authority);
@@ -50,7 +50,7 @@ TEST_F(ClientAuthorityFilterTest, NonStringArgFails) {
 }
 
 TEST_F(ClientAuthorityFilterTest, PromiseCompletesImmediatelyAndSetsAuthority) {
-  StrictMock<FilterTest::Call> call(
+  StrictMock<FilterTestV2::Call> call(
       MakeChannel(TestChannelArgs("foo.test.google.au")).value());
   EXPECT_EVENT(
       Started(&call, HasMetadataKeyValue(":authority", "foo.test.google.au")));
@@ -59,7 +59,7 @@ TEST_F(ClientAuthorityFilterTest, PromiseCompletesImmediatelyAndSetsAuthority) {
 
 TEST_F(ClientAuthorityFilterTest,
        PromiseCompletesImmediatelyAndDoesNotSetAuthority) {
-  StrictMock<FilterTest::Call> call(
+  StrictMock<FilterTestV2::Call> call(
       MakeChannel(TestChannelArgs("foo.test.google.au")).value());
   EXPECT_EVENT(
       Started(&call, HasMetadataKeyValue(":authority", "bar.test.google.au")));

--- a/test/core/filters/filter_test_v2.cc
+++ b/test/core/filters/filter_test_v2.cc
@@ -371,7 +371,7 @@ ServerMetadataHandle FilterTestV2Base::Call::NewServerMetadata(
 }
 
 MessageHandle FilterTestV2Base::Call::NewMessage(absl::string_view payload,
-                                               uint32_t flags) {
+                                                 uint32_t flags) {
   SliceBuffer buffer;
   if (!payload.empty()) buffer.Append(Slice::FromCopiedString(payload));
   return impl_->arena()->MakePooled<Message>(std::move(buffer), flags);

--- a/test/core/filters/filter_test_v2.cc
+++ b/test/core/filters/filter_test_v2.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test/core/filters/filter_test.h"
+#include "test/core/filters/filter_test_v2.h"
 
 #include <grpc/grpc.h>
 
@@ -45,10 +45,10 @@ using grpc_event_engine::experimental::FuzzingEventEngine;
 namespace grpc_core {
 
 ///////////////////////////////////////////////////////////////////////////////
-// FilterTestBase::Call::Impl
+// FilterTestV2Base::Call::Impl
 
-class FilterTestBase::Call::Impl
-    : public std::enable_shared_from_this<FilterTestBase::Call::Impl> {
+class FilterTestV2Base::Call::Impl
+    : public std::enable_shared_from_this<FilterTestV2Base::Call::Impl> {
  public:
   Impl(Call* call, std::shared_ptr<Channel::Impl> channel)
       : call_(call), channel_(std::move(channel)) {}
@@ -107,13 +107,13 @@ class FilterTestBase::Call::Impl
   std::queue<MessageHandle> forward_server_to_client_messages_;
 };
 
-FilterTestBase::Call::Impl::~Impl() {
+FilterTestV2Base::Call::Impl::~Impl() {
   if (!run_call_finalization_) {
     call_finalization_.Run(nullptr);
   }
 }
 
-void FilterTestBase::Call::Impl::Start(ClientMetadataHandle md) {
+void FilterTestV2Base::Call::Impl::Start(ClientMetadataHandle md) {
   EXPECT_EQ(promise_, std::nullopt);
   promise_ = channel_->filter->MakeCallPromise(
       CallArgs{std::move(md), ClientInitialMetadataOutstandingToken::Empty(),
@@ -133,35 +133,35 @@ void FilterTestBase::Call::Impl::Start(ClientMetadataHandle md) {
   ForceWakeup();
 }
 
-Poll<ServerMetadataHandle> FilterTestBase::Call::Impl::PollNextFilter() {
+Poll<ServerMetadataHandle> FilterTestV2Base::Call::Impl::PollNextFilter() {
   return std::exchange(poll_next_filter_result_, Pending());
 }
 
-void FilterTestBase::Call::Impl::ForwardServerInitialMetadata(
+void FilterTestV2Base::Call::Impl::ForwardServerInitialMetadata(
     ServerMetadataHandle md) {
   EXPECT_FALSE(forward_server_initial_metadata_.has_value());
   forward_server_initial_metadata_ = std::move(md);
   ForceWakeup();
 }
 
-void FilterTestBase::Call::Impl::ForwardMessageClientToServer(
+void FilterTestV2Base::Call::Impl::ForwardMessageClientToServer(
     MessageHandle msg) {
   forward_client_to_server_messages_.push(std::move(msg));
   ForceWakeup();
 }
 
-void FilterTestBase::Call::Impl::ForwardMessageServerToClient(
+void FilterTestV2Base::Call::Impl::ForwardMessageServerToClient(
     MessageHandle msg) {
   forward_server_to_client_messages_.push(std::move(msg));
   ForceWakeup();
 }
 
-void FilterTestBase::Call::Impl::FinishNextFilter(ServerMetadataHandle md) {
+void FilterTestV2Base::Call::Impl::FinishNextFilter(ServerMetadataHandle md) {
   poll_next_filter_result_ = std::move(md);
   ForceWakeup();
 }
 
-bool FilterTestBase::Call::Impl::StepOnce() {
+bool FilterTestV2Base::Call::Impl::StepOnce() {
   if (!promise_.has_value()) return true;
 
   if (forward_server_initial_metadata_.has_value() &&
@@ -261,9 +261,9 @@ bool FilterTestBase::Call::Impl::StepOnce() {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// FilterTestBase::Call::ScopedContext
+// FilterTestV2Base::Call::ScopedContext
 
-class FilterTestBase::Call::ScopedContext final
+class FilterTestV2Base::Call::ScopedContext final
     : public Activity,
       public promise_detail::Context<Arena>,
       public promise_detail::Context<CallFinalization> {
@@ -314,7 +314,7 @@ class FilterTestBase::Call::ScopedContext final
   bool repoll_ = false;
 };
 
-void FilterTestBase::Call::Impl::StepLoop() {
+void FilterTestV2Base::Call::Impl::StepLoop() {
   for (;;) {
     ScopedContext ctx(shared_from_this());
     if (!StepOnce() && ctx.repoll()) continue;
@@ -322,21 +322,21 @@ void FilterTestBase::Call::Impl::StepLoop() {
   }
 }
 
-void FilterTestBase::Call::Impl::ForceWakeup() {
+void FilterTestV2Base::Call::Impl::ForceWakeup() {
   ScopedContext(shared_from_this()).MakeOwningWaker().Wakeup();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// FilterTestBase::Call
+// FilterTestV2Base::Call
 
-FilterTestBase::Call::Call(const Channel& channel)
+FilterTestV2Base::Call::Call(const Channel& channel)
     : impl_(std::make_unique<Impl>(this, channel.impl_)) {}
 
-FilterTestBase::Call::~Call() { ScopedContext x(std::move(impl_)); }
+FilterTestV2Base::Call::~Call() { ScopedContext x(std::move(impl_)); }
 
-Arena* FilterTestBase::Call::arena() const { return impl_->arena(); }
+Arena* FilterTestV2Base::Call::arena() const { return impl_->arena(); }
 
-ClientMetadataHandle FilterTestBase::Call::NewClientMetadata(
+ClientMetadataHandle FilterTestV2Base::Call::NewClientMetadata(
     std::initializer_list<std::pair<absl::string_view, absl::string_view>>
         init) {
   auto md = impl_->arena()->MakePooled<ClientMetadata>();
@@ -353,7 +353,7 @@ ClientMetadataHandle FilterTestBase::Call::NewClientMetadata(
   return md;
 }
 
-ServerMetadataHandle FilterTestBase::Call::NewServerMetadata(
+ServerMetadataHandle FilterTestV2Base::Call::NewServerMetadata(
     std::initializer_list<std::pair<absl::string_view, absl::string_view>>
         init) {
   auto md = impl_->arena()->MakePooled<ClientMetadata>();
@@ -370,44 +370,44 @@ ServerMetadataHandle FilterTestBase::Call::NewServerMetadata(
   return md;
 }
 
-MessageHandle FilterTestBase::Call::NewMessage(absl::string_view payload,
+MessageHandle FilterTestV2Base::Call::NewMessage(absl::string_view payload,
                                                uint32_t flags) {
   SliceBuffer buffer;
   if (!payload.empty()) buffer.Append(Slice::FromCopiedString(payload));
   return impl_->arena()->MakePooled<Message>(std::move(buffer), flags);
 }
 
-void FilterTestBase::Call::Start(ClientMetadataHandle md) {
+void FilterTestV2Base::Call::Start(ClientMetadataHandle md) {
   ScopedContext ctx(impl_);
   impl_->Start(std::move(md));
 }
 
-void FilterTestBase::Call::Cancel() {
+void FilterTestV2Base::Call::Cancel() {
   ScopedContext ctx(impl_);
   impl_ = absl::make_unique<Impl>(this, impl_->channel());
 }
 
-void FilterTestBase::Call::ForwardServerInitialMetadata(
+void FilterTestV2Base::Call::ForwardServerInitialMetadata(
     ServerMetadataHandle md) {
   impl_->ForwardServerInitialMetadata(std::move(md));
 }
 
-void FilterTestBase::Call::ForwardMessageClientToServer(MessageHandle msg) {
+void FilterTestV2Base::Call::ForwardMessageClientToServer(MessageHandle msg) {
   impl_->ForwardMessageClientToServer(std::move(msg));
 }
 
-void FilterTestBase::Call::ForwardMessageServerToClient(MessageHandle msg) {
+void FilterTestV2Base::Call::ForwardMessageServerToClient(MessageHandle msg) {
   impl_->ForwardMessageServerToClient(std::move(msg));
 }
 
-void FilterTestBase::Call::FinishNextFilter(ServerMetadataHandle md) {
+void FilterTestV2Base::Call::FinishNextFilter(ServerMetadataHandle md) {
   impl_->FinishNextFilter(std::move(md));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// FilterTestBase
+// FilterTestV2Base
 
-FilterTestBase::FilterTestBase() {
+FilterTestV2Base::FilterTestV2Base() {
   FuzzingEventEngine::Options options;
   options.max_delay_run_after = std::chrono::milliseconds(500);
   options.max_delay_write = std::chrono::milliseconds(50);
@@ -418,14 +418,14 @@ FilterTestBase::FilterTestBase() {
   grpc_init();
 }
 
-FilterTestBase::~FilterTestBase() {
+FilterTestV2Base::~FilterTestV2Base() {
   grpc_shutdown();
   event_engine_->UnsetGlobalHooks();
   event_engine_.reset();
   grpc_event_engine::experimental::ShutdownDefaultEventEngine();
 }
 
-void FilterTestBase::Step() {
+void FilterTestV2Base::Step() {
   event_engine_->TickUntilIdle();
   ::testing::Mock::VerifyAndClearExpectations(&events);
 }

--- a/test/core/filters/filter_test_v2.h
+++ b/test/core/filters/filter_test_v2.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GRPC_TEST_CORE_FILTERS_FILTER_TEST_H
-#define GRPC_TEST_CORE_FILTERS_FILTER_TEST_H
+#ifndef GRPC_TEST_CORE_FILTERS_FILTER_TEST_V2_H
+#define GRPC_TEST_CORE_FILTERS_FILTER_TEST_V2_H
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/event_engine/memory_allocator.h>
@@ -37,7 +37,6 @@
 #include "src/core/lib/transport/transport.h"
 #include "src/core/util/ref_counted_ptr.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
-#include "test/core/filters/filter_test.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/status/status.h"
@@ -89,18 +88,18 @@ inline std::ostream& operator<<(std::ostream& os, const Message& msg) {
             << " payload:" << absl::CEscape(msg.payload()->JoinIntoString());
 }
 
-class FilterTestBase : public ::testing::Test {
+class FilterTestV2Base : public ::testing::Test {
  public:
   class Call;
 
   class Channel {
    private:
     struct Impl {
-      Impl(std::unique_ptr<ChannelFilter> filter, FilterTestBase* test)
+      Impl(std::unique_ptr<ChannelFilter> filter, FilterTestV2Base* test)
           : filter(std::move(filter)), test(test) {}
       RefCountedPtr<ArenaFactory> arena_factory = SimpleArenaAllocator();
       std::unique_ptr<ChannelFilter> filter;
-      FilterTestBase* const test;
+      FilterTestV2Base* const test;
     };
 
    public:
@@ -108,13 +107,13 @@ class FilterTestBase : public ::testing::Test {
 
    protected:
     explicit Channel(std::unique_ptr<ChannelFilter> filter,
-                     FilterTestBase* test)
+                     FilterTestV2Base* test)
         : impl_(std::make_shared<Impl>(std::move(filter), test)) {}
 
     ChannelFilter* filter_ptr() { return impl_->filter.get(); }
 
    private:
-    friend class FilterTestBase;
+    friend class FilterTestV2Base;
     friend class Call;
 
     std::shared_ptr<Impl> impl_;
@@ -192,8 +191,8 @@ class FilterTestBase : public ::testing::Test {
   ::testing::StrictMock<Events> events;
 
  protected:
-  FilterTestBase();
-  ~FilterTestBase() override;
+  FilterTestV2Base();
+  ~FilterTestV2Base() override;
 
   grpc_event_engine::experimental::EventEngine* event_engine() {
     return event_engine_.get();
@@ -207,15 +206,15 @@ class FilterTestBase : public ::testing::Test {
 };
 
 template <typename Filter>
-class FilterTest : public FilterTestBase {
+class FilterTestV2 : public FilterTestV2Base {
  public:
-  class Channel : public FilterTestBase::Channel {
+  class Channel : public FilterTestV2Base::Channel {
    public:
     Filter* filter() { return static_cast<Filter*>(filter_ptr()); }
 
    private:
-    friend class FilterTest<Filter>;
-    using FilterTestBase::Channel::Channel;
+    friend class FilterTestV2<Filter>;
+    using FilterTestV2Base::Channel::Channel;
   };
 
   absl::StatusOr<Channel> MakeChannel(
@@ -230,7 +229,8 @@ class FilterTest : public FilterTestBase {
 
 }  // namespace grpc_core
 
-// Expect one of the events corresponding to the methods in FilterTest::Events.
+// Expect one of the events corresponding to the methods in
+// FilterTestV2::Events.
 #define EXPECT_EVENT(event) EXPECT_CALL(events, event)
 
-#endif  // GRPC_TEST_CORE_FILTERS_FILTER_TEST_H
+#endif  // GRPC_TEST_CORE_FILTERS_FILTER_TEST_V2_H

--- a/test/core/filters/filter_test_v2_test.cc
+++ b/test/core/filters/filter_test_v2_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test/core/filters/filter_test.h"
+#include "test/core/filters/filter_test_v2.h"
 
 #include <grpc/compression.h>
 
@@ -53,7 +53,7 @@ class NoOpFilter final : public ChannelFilter {
     return std::make_unique<NoOpFilter>();
   }
 };
-using NoOpFilterTest = FilterTest<NoOpFilter>;
+using NoOpFilterTest = FilterTestV2<NoOpFilter>;
 
 class DelayStartFilter final : public ChannelFilter {
  public:
@@ -74,7 +74,7 @@ class DelayStartFilter final : public ChannelFilter {
     return std::make_unique<DelayStartFilter>();
   }
 };
-using DelayStartFilterTest = FilterTest<DelayStartFilter>;
+using DelayStartFilterTest = FilterTestV2<DelayStartFilter>;
 
 class AddClientInitialMetadataFilter final : public ChannelFilter {
  public:
@@ -91,7 +91,7 @@ class AddClientInitialMetadataFilter final : public ChannelFilter {
   }
 };
 using AddClientInitialMetadataFilterTest =
-    FilterTest<AddClientInitialMetadataFilter>;
+    FilterTestV2<AddClientInitialMetadataFilter>;
 
 class AddServerTrailingMetadataFilter final : public ChannelFilter {
  public:
@@ -109,7 +109,7 @@ class AddServerTrailingMetadataFilter final : public ChannelFilter {
   }
 };
 using AddServerTrailingMetadataFilterTest =
-    FilterTest<AddServerTrailingMetadataFilter>;
+    FilterTestV2<AddServerTrailingMetadataFilter>;
 
 class AddServerInitialMetadataFilter final : public ChannelFilter {
  public:
@@ -127,7 +127,7 @@ class AddServerInitialMetadataFilter final : public ChannelFilter {
   }
 };
 using AddServerInitialMetadataFilterTest =
-    FilterTest<AddServerInitialMetadataFilter>;
+    FilterTestV2<AddServerInitialMetadataFilter>;
 
 TEST_F(NoOpFilterTest, NoOp) {}
 

--- a/test/core/filters/gcp_authentication_filter_test.cc
+++ b/test/core/filters/gcp_authentication_filter_test.cc
@@ -28,7 +28,7 @@
 #include "src/core/service_config/service_config_impl.h"
 #include "src/core/util/ref_counted_ptr.h"
 #include "src/core/util/unique_type_name.h"
-#include "test/core/filters/filter_test.h"
+#include "test/core/filters/filter_test_v2.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/status/status.h"
@@ -38,7 +38,8 @@
 namespace grpc_core {
 namespace {
 
-class GcpAuthenticationFilterTest : public FilterTest<GcpAuthenticationFilter> {
+class GcpAuthenticationFilterTest
+    : public FilterTestV2<GcpAuthenticationFilter> {
  protected:
   static RefCountedPtr<const FilterConfig> MakeFilterConfig(
       absl::string_view filter_instance_name) {

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3538,7 +3538,7 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
-    "name": "filter_test_test",
+    "name": "filter_test_v2_test",
     "platforms": [
       "linux",
       "mac",


### PR DESCRIPTION
As per https://github.com/grpc/grpc/pull/42969#discussion_r3648838586.