### PR TITLE
[Python] Migrate SSL server credentials to TLS credentials

### DIFF
--- a/doc/python/sphinx/grpc.rst
+++ b/doc/python/sphinx/grpc.rst
@@ -54,6 +54,12 @@ Local Connection Type
 .. autoclass:: LocalConnectionType
 
 
+TLS Version
+^^^^^^^^^^^
+
+.. autoclass:: TLSVersion
+
+
 RPC Method Handlers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -293,6 +293,19 @@ class StatusCode(enum.Enum):
     UNAUTHENTICATED = (_cygrpc.StatusCode.unauthenticated, "unauthenticated")
 
 
+@enum.unique
+class TLSVersion(enum.Enum):
+    """TLS protocol versions supported by gRPC.
+
+    Attributes:
+      TLS1_2: TLS 1.2.
+      TLS1_3: TLS 1.3.
+    """
+
+    TLS1_2 = _cygrpc.TLSVersion.tls1_2
+    TLS1_3 = _cygrpc.TLSVersion.tls1_3
+
+
 #############################  gRPC Status  ################################
 
 
@@ -1706,8 +1719,29 @@ def method_handlers_generic_handler(service, method_handlers):
     return _utilities.DictionaryGenericHandler(service, method_handlers)
 
 
+def _validate_tls_versions(minimum_tls_version, maximum_tls_version):
+    for name, version in (
+        ("minimum_tls_version", minimum_tls_version),
+        ("maximum_tls_version", maximum_tls_version),
+    ):
+        if version is not None and not isinstance(version, TLSVersion):
+            raise TypeError("{} must be a grpc.TLSVersion or None".format(name))
+    if (
+        minimum_tls_version is not None
+        and maximum_tls_version is not None
+        and minimum_tls_version.value > maximum_tls_version.value
+    ):
+        raise ValueError(
+            "minimum_tls_version cannot be greater than maximum_tls_version"
+        )
+
+
 def ssl_channel_credentials(
-    root_certificates=None, private_key=None, certificate_chain=None
+    root_certificates=None,
+    private_key=None,
+    certificate_chain=None,
+    minimum_tls_version=None,
+    maximum_tls_version=None,
 ):
     """Creates a ChannelCredentials for use with an SSL-enabled Channel.
 
@@ -1719,13 +1753,31 @@ def ssl_channel_credentials(
         private key should be used.
       certificate_chain: The PEM-encoded certificate chain as a byte string
         to use or None if no certificate chain should be used.
+      minimum_tls_version: The minimum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.2.
+      maximum_tls_version: The maximum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.3.
 
     Returns:
       A ChannelCredentials for use with an SSL-enabled Channel.
     """
+    _validate_tls_versions(minimum_tls_version, maximum_tls_version)
     return ChannelCredentials(
         _cygrpc.SSLChannelCredentials(
-            root_certificates, private_key, certificate_chain
+            root_certificates,
+            private_key,
+            certificate_chain,
+            None,
+            (
+                minimum_tls_version.value
+                if minimum_tls_version is not None
+                else None
+            ),
+            (
+                maximum_tls_version.value
+                if maximum_tls_version is not None
+                else None
+            ),
         )
     )
 
@@ -2287,6 +2339,7 @@ __all__ = (
     "ServicerContext",
     "Status",
     "StatusCode",
+    "TLSVersion",
     "StreamStreamClientInterceptor",
     "StreamStreamMultiCallable",
     "StreamUnaryClientInterceptor",

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1882,6 +1882,8 @@ def ssl_server_credentials(
     private_key_certificate_chain_pairs,
     root_certificates=None,
     require_client_auth=False,
+    minimum_tls_version=None,
+    maximum_tls_version=None,
 ):
     """Creates a ServerCredentials for use with an SSL-enabled Server.
 
@@ -1894,6 +1896,10 @@ def ssl_server_credentials(
       require_client_auth: A boolean indicating whether or not to require
         clients to be authenticated. May only be True if root_certificates
         is not None.
+      minimum_tls_version: The minimum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.2.
+      maximum_tls_version: The maximum TLS version that may be negotiated, or
+        None to use gRPC's default of TLS 1.3.
 
     Returns:
       A ServerCredentials for use with an SSL-enabled Server. Typically, this
@@ -1907,6 +1913,7 @@ def ssl_server_credentials(
     if require_client_auth and root_certificates is None:
         error_msg = "Illegal to require client auth without providing root certificates!"
         raise ValueError(error_msg)
+    _validate_tls_versions(minimum_tls_version, maximum_tls_version)
     return ServerCredentials(
         _cygrpc.server_credentials_ssl(
             root_certificates,
@@ -1915,6 +1922,16 @@ def ssl_server_credentials(
                 for key, pem in private_key_certificate_chain_pairs
             ],
             require_client_auth,
+            (
+                minimum_tls_version.value
+                if minimum_tls_version is not None
+                else None
+            ),
+            (
+                maximum_tls_version.value
+                if maximum_tls_version is not None
+                else None
+            ),
         )
     )
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -64,6 +64,8 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   cdef readonly object _private_key
   cdef readonly object _certificate_chain
   cdef readonly object _private_key_signer
+  cdef readonly object _minimum_tls_version
+  cdef readonly object _maximum_tls_version
 
   cdef grpc_channel_credentials *c(self) except *
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -186,15 +186,24 @@ cdef class SSLSessionCacheLRU:
     grpc_shutdown()
 
 
+class TLSVersion:
+  tls1_2 = TLS1_2
+  tls1_3 = TLS1_3
+
+
 cdef class SSLChannelCredentials(ChannelCredentials):
 
-  def __cinit__(self, pem_root_certificates, private_key, certificate_chain, private_key_signer=None):
+  def __cinit__(self, pem_root_certificates, private_key, certificate_chain,
+                private_key_signer=None, minimum_tls_version=None,
+                maximum_tls_version=None):
     if pem_root_certificates is not None and not isinstance(pem_root_certificates, bytes):
       raise TypeError('expected certificate to be bytes, got %s' % (type(pem_root_certificates)))
     self._pem_root_certificates = pem_root_certificates
     self._private_key = private_key
     self._certificate_chain = certificate_chain
     self._private_key_signer = private_key_signer
+    self._minimum_tls_version = minimum_tls_version
+    self._maximum_tls_version = maximum_tls_version
     # This gets passed around C++, make sure it stays
     if self._private_key_signer is not None:
       Py_INCREF(self._private_key_signer)
@@ -215,6 +224,14 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     cdef Status private_key_status
 
     c_tls_credentials_options = grpc_tls_credentials_options_create()
+    if self._minimum_tls_version is not None:
+      grpc_tls_credentials_options_set_min_tls_version(
+        c_tls_credentials_options,
+        <grpc_tls_version>self._minimum_tls_version)
+    if self._maximum_tls_version is not None:
+      grpc_tls_credentials_options_set_max_tls_version(
+        c_tls_credentials_options,
+        <grpc_tls_version>self._maximum_tls_version)
     c_pem_root_certificates = self._pem_root_certificates or <const char*>NULL
     if self._private_key or self._certificate_chain or self._private_key_signer:
       c_tls_identity_pairs = grpc_tls_identity_pairs_create()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -350,28 +350,56 @@ cdef grpc_ssl_pem_key_cert_pair* _create_c_ssl_pem_key_cert_pairs(pem_key_cert_p
   return c_ssl_pem_key_cert_pairs
 
 def server_credentials_ssl(pem_root_certs, pem_key_cert_pairs,
-                           bint force_client_auth):
+                           bint force_client_auth,
+                           minimum_tls_version=None,
+                           maximum_tls_version=None):
   pem_root_certs = str_to_bytes(pem_root_certs)
   pem_key_cert_pairs = list(pem_key_cert_pairs)
   cdef ServerCredentials credentials = ServerCredentials()
-  credentials.references.append(pem_root_certs)
-  credentials.references.append(pem_key_cert_pairs)
-  cdef const char * c_pem_root_certs = _get_c_pem_root_certs(pem_root_certs)
-  credentials.c_ssl_pem_key_cert_pairs_count = len(pem_key_cert_pairs)
-  credentials.c_ssl_pem_key_cert_pairs = _create_c_ssl_pem_key_cert_pairs(pem_key_cert_pairs)
-  cdef grpc_ssl_server_certificate_config *c_cert_config = NULL
-  c_cert_config = grpc_ssl_server_certificate_config_create(
-    c_pem_root_certs, credentials.c_ssl_pem_key_cert_pairs,
-    credentials.c_ssl_pem_key_cert_pairs_count)
-  cdef grpc_ssl_server_credentials_options* c_options = NULL
-  # C-core assumes ownership of c_cert_config
-  c_options = grpc_ssl_server_credentials_create_options_using_config(
+  cdef const char *c_pem_root_certs = _get_c_pem_root_certs(pem_root_certs)
+  cdef grpc_tls_credentials_options* c_options
+  cdef grpc_tls_identity_pairs* c_identity_pairs
+  cdef grpc_tls_certificate_provider* c_certificate_provider
+
+  c_options = grpc_tls_credentials_options_create()
+  if minimum_tls_version is not None:
+    grpc_tls_credentials_options_set_min_tls_version(
+      c_options, <grpc_tls_version>minimum_tls_version)
+  if maximum_tls_version is not None:
+    grpc_tls_credentials_options_set_max_tls_version(
+      c_options, <grpc_tls_version>maximum_tls_version)
+  grpc_tls_credentials_options_set_cert_request_type(
+    c_options,
     GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
     if force_client_auth else
-    GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE,
-    c_cert_config)
+    GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE)
+
+  c_identity_pairs = grpc_tls_identity_pairs_create()
+  for pem_key_cert_pair in pem_key_cert_pairs:
+    if not isinstance(pem_key_cert_pair, SslPemKeyCertPair):
+      grpc_tls_identity_pairs_destroy(c_identity_pairs)
+      grpc_tls_credentials_options_destroy(c_options)
+      raise TypeError("expected pem_key_cert_pairs to be sequence of "
+                      "SslPemKeyCertPair")
+    grpc_tls_identity_pairs_add_pair(
+      c_identity_pairs,
+      (<SslPemKeyCertPair>pem_key_cert_pair).c_pair.private_key,
+      (<SslPemKeyCertPair>pem_key_cert_pair).c_pair.certificate_chain)
+
+  c_certificate_provider = grpc_tls_certificate_provider_in_memory_create()
+  if c_pem_root_certs != NULL:
+    grpc_tls_certificate_provider_in_memory_set_root_certificate(
+      c_certificate_provider, c_pem_root_certs)
+    grpc_tls_credentials_options_set_root_certificate_provider(
+      c_options, c_certificate_provider)
+  grpc_tls_certificate_provider_in_memory_set_identity_certificate(
+    c_certificate_provider, c_identity_pairs)
+  grpc_tls_credentials_options_set_identity_certificate_provider(
+    c_options, c_certificate_provider)
+  grpc_tls_certificate_provider_release(c_certificate_provider)
+
   # C-core assumes ownership of c_options
-  credentials.c_credentials = grpc_ssl_server_credentials_create_with_options(c_options)
+  credentials.c_credentials = grpc_tls_server_credentials_create(c_options)
   return credentials
 
 def server_certificate_config_ssl(pem_root_certs, pem_key_cert_pairs):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -607,6 +607,10 @@ cdef extern from "grpc/credentials.h":
     grpc_tls_credentials_options *options,
     grpc_tls_version version) nogil
 
+  void grpc_tls_credentials_options_set_cert_request_type(
+    grpc_tls_credentials_options *options,
+    grpc_ssl_client_certificate_request_type type) nogil
+
   ctypedef struct grpc_tls_certificate_provider:
     # We don't care about the internals (and in fact don't know them)
     pass
@@ -664,6 +668,9 @@ cdef extern from "grpc/credentials.h":
       verify_peer_options *verify_options, void *reserved) nogil
 
   grpc_channel_credentials *grpc_tls_credentials_create(
+    grpc_tls_credentials_options *options) nogil
+
+  grpc_server_credentials *grpc_tls_server_credentials_create(
     grpc_tls_credentials_options *options) nogil
 
   grpc_channel_credentials *grpc_composite_channel_credentials_create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -542,6 +542,10 @@ cdef extern from "grpc/grpc_security_constants.h":
     GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_NEW
     GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL
 
+  ctypedef enum grpc_tls_version:
+    TLS1_2
+    TLS1_3
+
   ctypedef grpc_ssl_certificate_config_reload_status (*grpc_ssl_server_certificate_config_callback)(
     void *user_data,
     grpc_ssl_server_certificate_config **config)
@@ -594,6 +598,14 @@ cdef extern from "grpc/credentials.h":
 
   grpc_tls_credentials_options *grpc_tls_credentials_options_create() nogil
   void grpc_tls_credentials_options_destroy(grpc_tls_credentials_options* options) nogil
+
+  void grpc_tls_credentials_options_set_min_tls_version(
+    grpc_tls_credentials_options *options,
+    grpc_tls_version version) nogil
+
+  void grpc_tls_credentials_options_set_max_tls_version(
+    grpc_tls_credentials_options *options,
+    grpc_tls_version version) nogil
 
   ctypedef struct grpc_tls_certificate_provider:
     # We don't care about the internals (and in fact don't know them)

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -60,6 +60,7 @@ class AllTest(unittest.TestCase):
             "Server",
             "ServerInterceptor",
             "LocalConnectionType",
+            "TLSVersion",
             "local_channel_credentials",
             "local_server_credentials",
             "alts_channel_credentials",

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -123,7 +123,7 @@ class AuthContextTest(unittest.TestCase):
         self.assertDictEqual(
             {
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
-                "transport_security_type": [b"ssl"],
+                "transport_security_type": [b"tls"],
                 "ssl_session_reused": [b"false"],
             },
             auth_data[_AUTH_CTX],
@@ -162,7 +162,7 @@ class AuthContextTest(unittest.TestCase):
         auth_ctx = auth_data[_AUTH_CTX]
         self.assertCountEqual(_CLIENT_IDS, auth_data[_ID])
         self.assertEqual("x509_subject_alternative_name", auth_data[_ID_KEY])
-        self.assertSequenceEqual([b"ssl"], auth_ctx["transport_security_type"])
+        self.assertSequenceEqual([b"tls"], auth_ctx["transport_security_type"])
         self.assertSequenceEqual(
             [b"*.test.google.com"], auth_ctx["x509_common_name"]
         )

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -67,6 +67,32 @@ class CredentialsTest(unittest.TestCase):
             certificate_chain=None,
         )
 
+    def test_tls_version_values(self):
+        self.assertSequenceEqual(
+            (grpc.TLSVersion.TLS1_2, grpc.TLSVersion.TLS1_3),
+            tuple(grpc.TLSVersion),
+        )
+
+    def test_tls_versions_create_channel_credentials(self):
+        credentials = grpc.ssl_channel_credentials(
+            minimum_tls_version=grpc.TLSVersion.TLS1_2,
+            maximum_tls_version=grpc.TLSVersion.TLS1_3,
+        )
+        self.assertIsInstance(credentials, grpc.ChannelCredentials)
+
+    def test_invalid_tls_version_types(self):
+        for argument in ("minimum_tls_version", "maximum_tls_version"):
+            with self.subTest(argument=argument):
+                with self.assertRaises(TypeError):
+                    grpc.ssl_channel_credentials(**{argument: "TLS1_2"})
+
+    def test_minimum_tls_version_greater_than_maximum(self):
+        with self.assertRaises(ValueError):
+            grpc.ssl_channel_credentials(
+                minimum_tls_version=grpc.TLSVersion.TLS1_3,
+                maximum_tls_version=grpc.TLSVersion.TLS1_2,
+            )
+
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -14,9 +14,32 @@
 """Tests of credentials."""
 
 import logging
+import pickle
 import unittest
 
 import grpc
+
+from tests.unit import resources
+from tests.unit import test_common
+
+
+_SERVER_HOST_OVERRIDE = "foo.test.google.fr"
+_SERVER_CERTS = ((resources.private_key(), resources.certificate_chain()),)
+_TEST_ROOT_CERTIFICATES = resources.test_root_certificates()
+_CHANNEL_OPTIONS = (("grpc.ssl_target_name_override", _SERVER_HOST_OVERRIDE),)
+_SERVICE_NAME = "test"
+_METHOD_NAME = "UnaryUnary"
+_REQUEST = b"request"
+
+
+def _handle_unary_unary(request, servicer_context):
+    del request
+    return pickle.dumps(servicer_context.auth_context())
+
+
+_METHOD_HANDLERS = {
+    _METHOD_NAME: grpc.unary_unary_rpc_method_handler(_handle_unary_unary)
+}
 
 
 class CredentialsTest(unittest.TestCase):
@@ -80,18 +103,175 @@ class CredentialsTest(unittest.TestCase):
         )
         self.assertIsInstance(credentials, grpc.ChannelCredentials)
 
+    def test_tls_versions_create_server_credentials(self):
+        for versions in (
+            {"minimum_tls_version": grpc.TLSVersion.TLS1_3},
+            {"maximum_tls_version": grpc.TLSVersion.TLS1_2},
+            {
+                "minimum_tls_version": grpc.TLSVersion.TLS1_2,
+                "maximum_tls_version": grpc.TLSVersion.TLS1_3,
+            },
+        ):
+            with self.subTest(versions=versions):
+                credentials = grpc.ssl_server_credentials(
+                    _SERVER_CERTS, **versions
+                )
+                self.assertIsInstance(credentials, grpc.ServerCredentials)
+
+    def test_tls_versions_create_server_credentials_with_multiple_certificates(
+        self,
+    ):
+        credentials = grpc.ssl_server_credentials(
+            _SERVER_CERTS + _SERVER_CERTS,
+            minimum_tls_version=grpc.TLSVersion.TLS1_2,
+            maximum_tls_version=grpc.TLSVersion.TLS1_3,
+        )
+        self.assertIsInstance(credentials, grpc.ServerCredentials)
+
     def test_invalid_tls_version_types(self):
-        for argument in ("minimum_tls_version", "maximum_tls_version"):
-            with self.subTest(argument=argument):
-                with self.assertRaises(TypeError):
-                    grpc.ssl_channel_credentials(**{argument: "TLS1_2"})
+        for credential_factory in (
+            grpc.ssl_channel_credentials,
+            lambda **kwargs: grpc.ssl_server_credentials(
+                _SERVER_CERTS, **kwargs
+            ),
+        ):
+            for argument in ("minimum_tls_version", "maximum_tls_version"):
+                with self.subTest(
+                    credential_factory=credential_factory, argument=argument
+                ):
+                    with self.assertRaises(TypeError):
+                        credential_factory(**{argument: "TLS1_2"})
 
     def test_minimum_tls_version_greater_than_maximum(self):
-        with self.assertRaises(ValueError):
-            grpc.ssl_channel_credentials(
-                minimum_tls_version=grpc.TLSVersion.TLS1_3,
-                maximum_tls_version=grpc.TLSVersion.TLS1_2,
+        for credential_factory in (
+            grpc.ssl_channel_credentials,
+            lambda **kwargs: grpc.ssl_server_credentials(
+                _SERVER_CERTS, **kwargs
+            ),
+        ):
+            with self.subTest(credential_factory=credential_factory):
+                with self.assertRaises(ValueError):
+                    credential_factory(
+                        minimum_tls_version=grpc.TLSVersion.TLS1_3,
+                        maximum_tls_version=grpc.TLSVersion.TLS1_2,
+                    )
+
+    def _perform_tls_rpc(
+        self,
+        client_minimum,
+        client_maximum,
+        server_minimum,
+        server_maximum,
+        require_client_auth=False,
+    ):
+        server = test_common.test_server()
+        server.add_registered_method_handlers(_SERVICE_NAME, _METHOD_HANDLERS)
+        server_credentials = grpc.ssl_server_credentials(
+            _SERVER_CERTS,
+            root_certificates=(
+                _TEST_ROOT_CERTIFICATES if require_client_auth else None
+            ),
+            require_client_auth=require_client_auth,
+            minimum_tls_version=server_minimum,
+            maximum_tls_version=server_maximum,
+        )
+        port = server.add_secure_port("[::]:0", server_credentials)
+        server.start()
+        channel_credentials = grpc.ssl_channel_credentials(
+            root_certificates=_TEST_ROOT_CERTIFICATES,
+            private_key=(
+                resources.private_key() if require_client_auth else None
+            ),
+            certificate_chain=(
+                resources.certificate_chain() if require_client_auth else None
+            ),
+            minimum_tls_version=client_minimum,
+            maximum_tls_version=client_maximum,
+        )
+        channel = grpc.secure_channel(
+            "localhost:{}".format(port),
+            channel_credentials,
+            options=_CHANNEL_OPTIONS,
+        )
+        try:
+            response = channel.unary_unary(
+                grpc._common.fully_qualified_method(
+                    _SERVICE_NAME, _METHOD_NAME
+                ),
+                _registered_method=True,
+            )(_REQUEST, timeout=5)
+            return pickle.loads(response)
+        finally:
+            channel.close()
+            server.stop(None)
+
+    def _assert_tls_handshake_succeeds(
+        self,
+        client_minimum,
+        client_maximum,
+        server_minimum,
+        server_maximum,
+        require_client_auth=False,
+    ):
+        auth_context = self._perform_tls_rpc(
+            client_minimum,
+            client_maximum,
+            server_minimum,
+            server_maximum,
+            require_client_auth=require_client_auth,
+        )
+        self.assertSequenceEqual(
+            [b"tls"], auth_context["transport_security_type"]
+        )
+        return auth_context
+
+    def test_tls_1_2_only_handshake_succeeds(self):
+        self._assert_tls_handshake_succeeds(
+            grpc.TLSVersion.TLS1_2,
+            grpc.TLSVersion.TLS1_2,
+            grpc.TLSVersion.TLS1_2,
+            grpc.TLSVersion.TLS1_2,
+        )
+
+    def test_tls_1_3_only_handshake_succeeds(self):
+        self._assert_tls_handshake_succeeds(
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+        )
+
+    def test_one_sided_tls_version_bounds_succeed(self):
+        self._assert_tls_handshake_succeeds(
+            None,
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            None,
+        )
+
+    def test_non_overlapping_tls_versions_fail(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._perform_tls_rpc(
+                grpc.TLSVersion.TLS1_3,
+                grpc.TLSVersion.TLS1_3,
+                grpc.TLSVersion.TLS1_2,
+                grpc.TLSVersion.TLS1_2,
             )
+        self.assertEqual(
+            grpc.StatusCode.UNAVAILABLE, exception_context.exception.code()
+        )
+
+    def test_tls_version_bounds_preserve_mutual_tls(self):
+        auth_context = self._assert_tls_handshake_succeeds(
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            grpc.TLSVersion.TLS1_3,
+            require_client_auth=True,
+        )
+        self.assertSequenceEqual(
+            [b"*.test.google.com"], auth_context["x509_common_name"]
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -127,7 +127,7 @@ class TestAuthContext(AioTestBase):
         self.assertDictEqual(
             {
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
-                "transport_security_type": [b"ssl"],
+                "transport_security_type": [b"tls"],
                 "ssl_session_reused": [b"false"],
             },
             auth_data[_AUTH_CTX],
@@ -171,7 +171,7 @@ class TestAuthContext(AioTestBase):
         auth_ctx = auth_data[_AUTH_CTX]
         self.assertCountEqual(_CLIENT_IDS, auth_data[_ID])
         self.assertEqual("x509_subject_alternative_name", auth_data[_ID_KEY])
-        self.assertSequenceEqual([b"ssl"], auth_ctx["transport_security_type"])
+        self.assertSequenceEqual([b"tls"], auth_ctx["transport_security_type"])
         self.assertSequenceEqual(
             [b"*.test.google.com"], auth_ctx["x509_common_name"]
         )


### PR DESCRIPTION
## Summary

Migrates `grpc.ssl_server_credentials()` from the legacy SSL server credentials implementation to Core's generic TLS credentials API, following the approach already used by Python channel credentials in [grpc/grpc#40878](https://github.com/grpc/grpc/pull/40878).

Also adds optional `minimum_tls_version` and `maximum_tls_version` arguments using `grpc.TLSVersion` from the stacked channel work in [grpc/grpc#43045](https://github.com/grpc/grpc/pull/43045).

## Motivation

This follows the maintainer-suggested alternative to [grpc/grpc#43074](https://github.com/grpc/grpc/pull/43074): use the existing `grpc_tls_credentials_options` setters instead of adding new public setters to the legacy `grpc_ssl_server_credentials_options` API.

## Implementation

- constructs an in-memory TLS certificate provider for roots and identity key/cert pairs
- preserves multiple identity pairs and optional mTLS client verification
- applies Core's existing minimum and maximum TLS version options
- creates credentials with `grpc_tls_server_credentials_create()`
- updates synchronous and AsyncIO auth-context expectations from `ssl` to `tls`

## Compatibility

- default version bounds remain TLS 1.2 through TLS 1.3
- `transport_security_type` changes from `ssl` to `tls`, matching the generic Core TLS implementation
- `dynamic_ssl_server_credentials()` remains on the legacy path because it promises to invoke the Python fetch callback on every new connection, while generic certificate providers use an update-driven model

## Testing

- Cython generation and generated C++ syntax check
- native extension compile and link
- 25 focused credentials, API, auth-context, and session-cache tests
- 4 AsyncIO auth-context tests
- pinned TLS 1.2 and TLS 1.3 handshakes
- incompatible-version handshake failure and one-sided bounds
- multiple identity pairs and mTLS identity/auth context
