### PR TITLE
bazel/python: provide direct python source info for static analysis aspects

### DIFF
--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -42,8 +42,13 @@ PyProtoInfo = provider(
     },
 )
 
-def _merge_pyinfos(pyinfos):
+def _merge_pyinfos(direct_pyinfo, transitive_pyinfos):
+    pyinfos = [direct_pyinfo] + transitive_pyinfos
     return PyInfo(
+        direct_original_sources = direct_pyinfo.direct_original_sources,
+        direct_pyi_files = direct_pyinfo.direct_pyi_files,
+        transitive_original_sources = depset(transitive = [p.transitive_original_sources for p in pyinfos]),
+        transitive_pyi_files = depset(transitive = [p.transitive_pyi_files for p in pyinfos]),
         transitive_sources = depset(transitive = [p.transitive_sources for p in pyinfos]),
         imports = depset(transitive = [p.imports for p in pyinfos]),
     )
@@ -99,8 +104,8 @@ def _gen_py_aspect_impl(target, context):
     py_info = PyInfo(transitive_sources = depset(direct = out_files), imports = depset(direct = imports))
     return PyProtoInfo(
         py_info = _merge_pyinfos(
+            py_info,
             [
-                py_info,
                 context.attr._protobuf_library[PyInfo],
             ] + [dep[PyProtoInfo].py_info for dep in context.rule.attr.deps],
         ),
@@ -148,7 +153,7 @@ def _generate_py_impl(context):
     # Collect output PyInfo provider.
     imports = [context.label.package + "/" + i for i in context.attr.imports]
     py_info = PyInfo(transitive_sources = depset(direct = py_sources), imports = depset(direct = imports))
-    out_pyinfo = _merge_pyinfos([py_info, context.attr.deps[0][PyProtoInfo].py_info])
+    out_pyinfo = _merge_pyinfos(py_info, [context.attr.deps[0][PyProtoInfo].py_info])
 
     runfiles = context.runfiles(files = out_pyinfo.transitive_sources.to_list()).merge(context.attr._protobuf_library[DefaultInfo].data_runfiles)
     return [
@@ -252,10 +257,15 @@ def _generate_pb2_grpc_src_impl(context):
         import_path = "{}/{}".format(context.workspace_name, import_path)
         imports.append(import_path)
 
-    p = PyInfo(transitive_sources = depset(direct = out_files), imports = depset(direct = imports))
+    p = PyInfo(
+        direct_original_sources = depset(direct = out_files),
+        transitive_original_sources = depset(direct = out_files),
+        transitive_sources = depset(direct = out_files),
+        imports = depset(direct = imports),
+    )
     py_info = _merge_pyinfos(
+        p,
         [
-            p,
             context.attr.grpc_library[PyInfo],
         ] + [dep[PyInfo] for dep in context.attr.py_deps],
     )
@@ -299,6 +309,7 @@ _generate_pb2_grpc_src = rule(
         ),
     },
     implementation = _generate_pb2_grpc_src_impl,
+    provides = [PyInfo],
 )
 
 def py_grpc_library(

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -42,13 +42,18 @@ PyProtoInfo = provider(
     },
 )
 
+def _get_pyinfo_depset(py_info, field):
+    """Gets a PyInfo depset field with backwards compatibility."""
+    value = getattr(py_info, field, None)
+    return depset() if value == None else value
+
 def _merge_pyinfos(direct_pyinfo, transitive_pyinfos):
     pyinfos = [direct_pyinfo] + transitive_pyinfos
     return PyInfo(
-        direct_original_sources = direct_pyinfo.direct_original_sources,
-        direct_pyi_files = direct_pyinfo.direct_pyi_files,
-        transitive_original_sources = depset(transitive = [p.transitive_original_sources for p in pyinfos]),
-        transitive_pyi_files = depset(transitive = [p.transitive_pyi_files for p in pyinfos]),
+        direct_original_sources = _get_pyinfo_depset(direct_pyinfo, "direct_original_sources"),
+        direct_pyi_files = _get_pyinfo_depset(direct_pyinfo, "direct_pyi_files"),
+        transitive_original_sources = depset(transitive = [_get_pyinfo_depset(p, "transitive_original_sources") for p in pyinfos]),
+        transitive_pyi_files = depset(transitive = [_get_pyinfo_depset(p, "transitive_pyi_files") for p in pyinfos]),
         transitive_sources = depset(transitive = [p.transitive_sources for p in pyinfos]),
         imports = depset(transitive = [p.imports for p in pyinfos]),
     )

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -42,18 +42,18 @@ PyProtoInfo = provider(
     },
 )
 
-def _get_pyinfo_depset(py_info, field):
-    """Gets a PyInfo depset field with backwards compatibility."""
-    value = getattr(py_info, field, None)
+def _get_optional_depset_field(obj, field):
+    """Get a field from an object, returning an empty depset if the field is unset or None."""
+    value = getattr(obj, field, None)
     return depset() if value == None else value
 
 def _merge_pyinfos(direct_pyinfo, transitive_pyinfos):
     pyinfos = [direct_pyinfo] + transitive_pyinfos
     return PyInfo(
-        direct_original_sources = _get_pyinfo_depset(direct_pyinfo, "direct_original_sources"),
-        direct_pyi_files = _get_pyinfo_depset(direct_pyinfo, "direct_pyi_files"),
-        transitive_original_sources = depset(transitive = [_get_pyinfo_depset(p, "transitive_original_sources") for p in pyinfos]),
-        transitive_pyi_files = depset(transitive = [_get_pyinfo_depset(p, "transitive_pyi_files") for p in pyinfos]),
+        direct_original_sources = _get_optional_depset_field(direct_pyinfo, "direct_original_sources"),
+        direct_pyi_files = _get_optional_depset_field(direct_pyinfo, "direct_pyi_files"),
+        transitive_original_sources = depset(transitive = [_get_optional_depset_field(p, "transitive_original_sources") for p in pyinfos]),
+        transitive_pyi_files = depset(transitive = [_get_optional_depset_field(p, "transitive_pyi_files") for p in pyinfos]),
         transitive_sources = depset(transitive = [p.transitive_sources for p in pyinfos]),
         imports = depset(transitive = [p.imports for p in pyinfos]),
     )

--- a/test/distrib/bazel/python/BUILD
+++ b/test/distrib/bazel/python/BUILD
@@ -187,6 +187,14 @@ py_grpc_library(
     deps = [":helloworld_py_pb2"],
 )
 
+py_library(
+    name = "helloworld_grpc_consumer",
+    deps = [
+        ":helloworld_py_pb2",
+        ":helloworld_py_pb2_grpc_library_changed",
+    ],
+)
+
 py_test(
     name = "grpc_library_replacement_test",
     srcs = ["grpc_library_replacement_test.py"],

--- a/test/distrib/bazel/python/python_rules_test.bzl
+++ b/test/distrib/bazel/python/python_rules_test.bzl
@@ -16,12 +16,42 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_python//python:py_info.bzl", "PyInfo")
 
+_StaticAnalysisInfo = provider(
+    fields = {
+        "direct_files_by_target": "The preferred direct static-analysis inputs keyed by target name.",
+    },
+)
+
 def _assert_in(env, item, container):
     asserts.true(
         env,
         item in container,
         "Expected " + str(item) + " to be in " + str(container),
     )
+
+def _short_paths(files):
+    return sorted([file.short_path for file in files.to_list()])
+
+def _static_analysis_aspect_impl(target, ctx):
+    py_info = target[PyInfo]
+    direct_files = py_info.direct_pyi_files
+    if not direct_files.to_list():
+        direct_files = py_info.direct_original_sources
+
+    direct_files_by_target = {}
+    for dep in getattr(ctx.rule.attr, "deps", []):
+        if _StaticAnalysisInfo in dep:
+            direct_files_by_target.update(dep[_StaticAnalysisInfo].direct_files_by_target)
+    direct_files_by_target[target.label.name] = _short_paths(direct_files)
+
+    return [_StaticAnalysisInfo(direct_files_by_target = direct_files_by_target)]
+
+_static_analysis_aspect = aspect(
+    implementation = _static_analysis_aspect_impl,
+    attr_aspects = ["deps"],
+    required_providers = [PyInfo],
+    provides = [_StaticAnalysisInfo],
+)
 
 # Tests the declared outputs of the 'py_proto_library' rule and, indirectly, also  tests that
 # these outputs are actually generated (building ":helloworld_py_pb2" will fail if not all of
@@ -30,13 +60,15 @@ def _py_proto_library_provider_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
 
     target = analysistest.target_under_test(env)
+    py_info = target[PyInfo]
 
     files = [file.short_path for file in target.files.to_list()]
     runfiles = [file.short_path for file in target.default_runfiles.files.to_list()]
-    py_info_transitive_sources = [
-        file.short_path
-        for file in target[PyInfo].transitive_sources.to_list()
-    ]
+    direct_original_sources = _short_paths(py_info.direct_original_sources)
+    direct_pyi_files = _short_paths(py_info.direct_pyi_files)
+    transitive_original_sources = _short_paths(py_info.transitive_original_sources)
+    transitive_pyi_files = _short_paths(py_info.transitive_pyi_files)
+    transitive_sources = _short_paths(py_info.transitive_sources)
 
     _assert_in(env, "helloworld_pb2.py", files)
     _assert_in(env, "subdir/hello_dep_pb2.py", files)
@@ -44,20 +76,87 @@ def _py_proto_library_provider_contents_test_impl(ctx):
     _assert_in(env, "helloworld_pb2.py", runfiles)
     _assert_in(env, "subdir/hello_dep_pb2.py", runfiles)
 
-    _assert_in(env, "helloworld_pb2.py", py_info_transitive_sources)
-    _assert_in(env, "subdir/hello_dep_pb2.py", py_info_transitive_sources)
+    asserts.equals(env, [], direct_original_sources)
+    asserts.equals(env, ["helloworld_pb2.pyi"], direct_pyi_files)
 
-    # TODO: Enable after py_proto_library supports outputting .pyi files.
-    # _assert_in(env, "helloworld_pb2.pyi", files)
-    # _assert_in(env, "subdir/hello_dep_pb2.pyi", files)
-    # _assert_in(env, "helloworld_pb2.pyi", runfiles)
-    # _assert_in(env, "subdir/hello_dep_pb2.pyi", runfiles)
-    # _assert_in(env, "helloworld_pb2.pyi", py_info_transitive_sources)
-    # _assert_in(env, "subdir/hello_dep_pb2.pyi", py_info_transitive_sources)
+    asserts.equals(env, [], transitive_original_sources)
+    _assert_in(env, "helloworld_pb2.pyi", transitive_pyi_files)
+    _assert_in(env, "subdir/hello_dep_pb2.pyi", transitive_pyi_files)
+    _assert_in(env, "helloworld_pb2.py", transitive_sources)
+    _assert_in(env, "subdir/hello_dep_pb2.py", transitive_sources)
 
     return analysistest.end(env)
 
 _py_proto_library_provider_contents_test = analysistest.make(_py_proto_library_provider_contents_test_impl)
+
+def _py_grpc_library_provider_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    py_info = target[PyInfo]
+
+    direct_original_sources = _short_paths(py_info.direct_original_sources)
+    direct_pyi_files = _short_paths(py_info.direct_pyi_files)
+    transitive_original_sources = _short_paths(py_info.transitive_original_sources)
+    transitive_pyi_files = _short_paths(py_info.transitive_pyi_files)
+    transitive_sources = _short_paths(py_info.transitive_sources)
+
+    asserts.equals(env, ["helloworld_pb2_grpc.py"], direct_original_sources)
+    asserts.equals(env, [], direct_pyi_files)
+
+    _assert_in(env, "helloworld_pb2_grpc.py", transitive_original_sources)
+    _assert_in(env, "grpc_library_replacement.py", transitive_original_sources)
+    _assert_in(env, "helloworld_pb2.pyi", transitive_pyi_files)
+    _assert_in(env, "subdir/hello_dep_pb2.pyi", transitive_pyi_files)
+    _assert_in(env, "helloworld_pb2_grpc.py", transitive_sources)
+    _assert_in(env, "helloworld_pb2.py", transitive_sources)
+    _assert_in(env, "grpc_library_replacement.py", transitive_sources)
+
+    asserts.false(env, "helloworld_pb2.py" in direct_original_sources)
+    asserts.false(env, "grpc_library_replacement.py" in direct_original_sources)
+
+    return analysistest.end(env)
+
+_py_grpc_library_provider_contents_test = analysistest.make(_py_grpc_library_provider_contents_test_impl)
+
+def _pyinfo_aspect_applicability_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    analyzed_targets = target[_StaticAnalysisInfo].direct_files_by_target
+
+    _assert_in(env, "helloworld_py_pb2_grpc_library_changed", analyzed_targets)
+
+    return analysistest.end(env)
+
+_pyinfo_aspect_applicability_test = analysistest.make(
+    _pyinfo_aspect_applicability_test_impl,
+    extra_target_under_test_aspects = [_static_analysis_aspect],
+)
+
+def _pyinfo_aspect_direct_input_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    direct_files_by_target = target[_StaticAnalysisInfo].direct_files_by_target
+
+    asserts.equals(
+        env,
+        ["helloworld_pb2.pyi"],
+        direct_files_by_target["helloworld_py_pb2"],
+    )
+    asserts.equals(
+        env,
+        ["helloworld_pb2_grpc.py"],
+        direct_files_by_target["helloworld_py_pb2_grpc_library_changed"],
+    )
+
+    return analysistest.end(env)
+
+_pyinfo_aspect_direct_input_test = analysistest.make(
+    _pyinfo_aspect_direct_input_test_impl,
+    extra_target_under_test_aspects = [_static_analysis_aspect],
+)
 
 def python_rules_test_suite(name):
     _py_proto_library_provider_contents_test(
@@ -65,9 +164,27 @@ def python_rules_test_suite(name):
         target_under_test = ":helloworld_py_pb2",
     )
 
+    _py_grpc_library_provider_contents_test(
+        name = "py_grpc_library_provider_contents_test",
+        target_under_test = ":helloworld_py_pb2_grpc_library_changed",
+    )
+
+    _pyinfo_aspect_applicability_test(
+        name = "pyinfo_aspect_applicability_test",
+        target_under_test = ":helloworld_grpc_consumer",
+    )
+
+    _pyinfo_aspect_direct_input_test(
+        name = "pyinfo_aspect_direct_input_test",
+        target_under_test = ":helloworld_grpc_consumer",
+    )
+
     native.test_suite(
         name = name,
         tests = [
             "py_proto_library_provider_contents_test",
+            "py_grpc_library_provider_contents_test",
+            "pyinfo_aspect_applicability_test",
+            "pyinfo_aspect_direct_input_test",
         ],
     )

--- a/test/distrib/bazel/python/python_rules_test.bzl
+++ b/test/distrib/bazel/python/python_rules_test.bzl
@@ -30,13 +30,15 @@ def _assert_in(env, item, container):
     )
 
 def _short_paths(files):
+    if files == None:
+        return []
     return sorted([file.short_path for file in files.to_list()])
 
 def _static_analysis_aspect_impl(target, ctx):
     py_info = target[PyInfo]
-    direct_files = py_info.direct_pyi_files
-    if not direct_files.to_list():
-        direct_files = py_info.direct_original_sources
+    direct_files = getattr(py_info, "direct_pyi_files", None)
+    if direct_files == None or not direct_files.to_list():
+        direct_files = getattr(py_info, "direct_original_sources", None)
 
     direct_files_by_target = {}
     for dep in getattr(ctx.rule.attr, "deps", []):


### PR DESCRIPTION
## Problems

1. Static-analysis aspects (e.g. for type-checking or IDEs) cannot recognise that generated `*_pb2_grpc.py` files belong to `py_grpc_library` targets because the Bazel rule does not populate `PyInfo.direct_original_sources`.
2. The `PyInfo` produced by `py_grpc_library` drops transitive source and stub information from dependencies.
3. The `py_grpc_library` rule doesn't advertise the `PyInfo` provider, meaning Python-specific aspects won't attach to it.

## Changes

- Publish generated `*_pb2_grpc.py` files through `direct_original_sources` and `transitive_original_sources`.
- Preserve dependencies’ transitive original sources and `.pyi` files.
- Declare that the generating rule provides `PyInfo`.
- Add focused analysis tests for these fields and aspect applicability.

## Notes
In a follow-up, it could be worth generating a `.pyi` stub to accompany generated `*_pb2_grpc.py` files and then populate `PyInfo.direct_pyi_files`, which would further improve integration with type-checking / IDE aspects. 

This has already been done for protobuf in https://github.com/grpc/grpc/pull/32872.