### PR TITLE
php: allow lcov 1.14 and bump protobuf version in benchmark worker

### DIFF
--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -94,7 +94,7 @@ if test "$PHP_COVERAGE" = "yes"; then
     AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
   fi
 
-  lcov_version_list="1.5 1.6 1.7 1.9 1.10 1.11 1.12 1.13"
+  lcov_version_list="1.5 1.6 1.7 1.9 1.10 1.11 1.12 1.13 1.14"
 
   AC_CHECK_PROG(LCOV, lcov, lcov)
   AC_CHECK_PROG(GENHTML, genhtml, genhtml)

--- a/src/php/tests/qps/composer.json
+++ b/src/php/tests/qps/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "grpc/grpc": "dev-master",
-    "google/protobuf": "^v3.3.0"
+    "google/protobuf": "^v4.33.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
`apt` has stopped working in debian 10 images. Debian 11 ships with lcov 1.14, so this version has been added to the allowed versions validation list.

Protobuf 3.x stopped receiving security patches, so the minimum version is bumped to 4.x.

## Tested

Verified that the example load test runs with [unmerged changes](https://github.com/grpc/test-infra/commit/f3de54813c963f46f8307c96a7b1573158bbe21f) in the test-infra repo.