### PR TITLE
Add gRPC Rust to performance CI

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -221,7 +221,6 @@ if [[ -v "useLanguage[rust]" ]]; then
   runnerLangArgs+=(-l "rust:${GRPC_RUST_REPO}:${GRPC_RUST_COMMIT}")
 fi
 
-
 # Disable broken tests by regex.
 # The test disabled here hangs on 8 cores. The result of this test is not
 # displayed on the public dashboard. The test runs and passes on the 30-core

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=grpc/test-infra
-TEST_INFRA_GITREF=master
+TEST_INFRA_REPO=arjan-bal/test-infra
+TEST_INFRA_GITREF=rust-worker
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -145,13 +145,13 @@ disableTestsRegex() {
 
 # List all languages.
 declare -A useLanguage=(
-  [c++]=1
-  [dotnet]=1
-  [go]=1
-  [java]=1
-  [node]=1
-  [python]=1
-  [ruby]=1
+  # [c++]=1
+  # [dotnet]=1
+  # [go]=1
+  # [java]=1
+  # [node]=1
+  # [python]=1
+  # [ruby]=1
   [rust]=1
 )
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=arjan-bal/test-infra
-TEST_INFRA_GITREF=rust-worker
+TEST_INFRA_REPO=grpc/test-infra
+TEST_INFRA_GITREF=master
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -146,12 +146,12 @@ disableTestsRegex() {
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
-  # [dotnet]=1
+  [dotnet]=1
   [go]=1
   [java]=1
-  # [node]=1
-  # [python]=1
-  # [ruby]=1
+  [node]=1
+  [python]=1
+  [ruby]=1
   [rust]=1
 )
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=grpc/test-infra
-TEST_INFRA_GITREF=master
+TEST_INFRA_REPO=arjan-bal/test-infra
+TEST_INFRA_GITREF=rust-worker
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -146,12 +146,12 @@ disableTestsRegex() {
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
-  [dotnet]=1
+  # [dotnet]=1
   [go]=1
   [java]=1
-  [node]=1
-  [python]=1
-  [ruby]=1
+  # [node]=1
+  # [python]=1
+  # [ruby]=1
   [rust]=1
 )
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -31,6 +31,8 @@ GRPC_JAVA_REPO=grpc/grpc-java
 GRPC_JAVA_GITREF=master
 GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
+GRPC_RUST_REPO=grpc/grpc-rust
+GRPC_RUST_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
@@ -65,6 +67,7 @@ GRPC_DOTNET_COMMIT="$(git ls-remote "https://github.com/${GRPC_DOTNET_REPO}.git"
 GRPC_GO_COMMIT="$(git ls-remote "https://github.com/${GRPC_GO_REPO}.git" "${GRPC_GO_GITREF}" | cut -f1)"
 GRPC_JAVA_COMMIT="$(git ls-remote "https://github.com/${GRPC_JAVA_REPO}.git" "${GRPC_JAVA_GITREF}" | cut -f1)"
 GRPC_NODE_COMMIT="$(git ls-remote "https://github.com/${GRPC_NODE_REPO}.git" "${GRPC_NODE_GITREF}" | cut -f1)"
+GRPC_RUST_COMMIT="$(git ls-remote "https://github.com/${GRPC_RUST_REPO}.git" "${GRPC_RUST_GITREF}" | cut -f1)"
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
@@ -112,6 +115,7 @@ buildConfigs() {
     -a ci_gitCommit_dotnet="${GRPC_DOTNET_COMMIT}" \
     -a ci_gitCommit_go="${GRPC_GO_COMMIT}" \
     -a ci_gitCommit_java="${GRPC_JAVA_COMMIT}" \
+    -a ci_gitCommit_rust="${GRPC_RUST_COMMIT}" \
     -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
     --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
     -a pool="${pool}" --category=scalable \
@@ -148,6 +152,7 @@ declare -A useLanguage=(
   [node]=1
   [python]=1
   [ruby]=1
+  [rust]=1
 )
 
 # Disable specific languages.
@@ -208,6 +213,14 @@ if [[ -v "useLanguage[ruby]" ]]; then
   configLangArgs8core+=(-l ruby) # 8-core only.
   runnerLangArgs+=(-l "ruby:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
+
+# rust
+if [[ -v "useLanguage[rust]" ]]; then
+  configLangArgs8core+=(-l rust)
+  configLangArgs32core+=(-l rust)
+  runnerLangArgs+=(-l "rust:${GRPC_RUST_REPO}:${GRPC_RUST_COMMIT}")
+fi
+
 
 # Disable broken tests by regex.
 # The test disabled here hangs on 8 cores. The result of this test is not

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=arjan-bal/test-infra
-TEST_INFRA_GITREF=rust-worker
+TEST_INFRA_REPO=grpc/test-infra
+TEST_INFRA_GITREF=master
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -145,13 +145,13 @@ disableTestsRegex() {
 
 # List all languages.
 declare -A useLanguage=(
-  # [c++]=1
-  # [dotnet]=1
-  # [go]=1
-  # [java]=1
-  # [node]=1
-  # [python]=1
-  # [ruby]=1
+  [c++]=1
+  [dotnet]=1
+  [go]=1
+  [java]=1
+  [node]=1
+  [python]=1
+  [ruby]=1
   [rust]=1
 )
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -31,6 +31,8 @@ GRPC_JAVA_REPO=grpc/grpc-java
 GRPC_JAVA_GITREF=master
 GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
+GRPC_RUST_REPO=grpc/grpc-rust
+GRPC_RUST_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
@@ -60,6 +62,7 @@ GRPC_DOTNET_COMMIT="$(git ls-remote "https://github.com/${GRPC_DOTNET_REPO}.git"
 GRPC_GO_COMMIT="$(git ls-remote "https://github.com/${GRPC_GO_REPO}.git" "${GRPC_GO_GITREF}" | cut -f1)"
 GRPC_JAVA_COMMIT="$(git ls-remote "https://github.com/${GRPC_JAVA_REPO}.git" "${GRPC_JAVA_GITREF}" | cut -f1)"
 GRPC_NODE_COMMIT="$(git ls-remote "https://github.com/${GRPC_NODE_REPO}.git" "${GRPC_NODE_GITREF}" | cut -f1)"
+GRPC_RUST_COMMIT="$(git ls-remote "https://github.com/${GRPC_RUST_REPO}.git" "${GRPC_RUST_GITREF}" | cut -f1)"
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
@@ -107,6 +110,7 @@ buildConfigs() {
     -a ci_gitCommit_dotnet="${GRPC_DOTNET_COMMIT}" \
     -a ci_gitCommit_go="${GRPC_GO_COMMIT}" \
     -a ci_gitCommit_java="${GRPC_JAVA_COMMIT}" \
+    -a ci_gitCommit_rust="${GRPC_RUST_COMMIT}" \
     -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
     --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
     -a pool="${pool}" --category=scalable \
@@ -143,6 +147,7 @@ declare -A useLanguage=(
   [node]=1
   [python]=1
   [ruby]=1
+  [rust]=1
 )
 
 # Disable specific languages.
@@ -202,6 +207,13 @@ fi
 if [[ -v "useLanguage[ruby]" ]]; then
   configLangArgs8core+=(-l ruby) # 8-core only.
   runnerLangArgs+=(-l "ruby:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
+fi
+
+# rust
+if [[ -v "useLanguage[rust]" ]]; then
+  configLangArgs8core+=(-l rust)
+  configLangArgs32core+=(-l rust)
+  runnerLangArgs+=(-l "rust:${GRPC_RUST_REPO}:${GRPC_RUST_COMMIT}")
 fi
 
 # Disable broken tests by regex.

--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -52,6 +52,9 @@ do
   "go")
     tools/run_tests/performance/build_performance_go.sh
     ;;
+  "rust")
+    tools/run_tests/performance/build_performance_rust.sh
+    ;;
   "php7"|"php7_protobuf_c")
     if [ -n "$PHP_ALREADY_BUILT" ]; then
       echo "Skipping PHP build as already built by $PHP_ALREADY_BUILT"

--- a/tools/run_tests/performance/build_performance_rust.sh
+++ b/tools/run_tests/performance/build_performance_rust.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+# Set up workspace for grpc-rust.
+RUST_WORKSPACE=$(pwd)/../rust_workspace
+rm -rf "$RUST_WORKSPACE"
+
+# Clone the sibling grpc-rust repo to avoid dirtying it.
+git clone ../grpc-rust "$RUST_WORKSPACE"
+
+# Build the worker.
+(cd "$RUST_WORKSPACE" && cargo build -p grpc-benchmark --release --bin worker)
+
+# Copy the binary to a clean location.
+mkdir -p ../rust_bin
+cp "$RUST_WORKSPACE/target/release/worker" ../rust_bin/worker

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -78,6 +78,7 @@ scenarios=(
     "python_generic_sync_streaming_ping_pong"
     "python_asyncio_generic_async_streaming_ping_pong"
     "ruby_protobuf_sync_streaming_ping_pong"
+    "rust_protobuf_sync_streaming_ping_pong_secure"
 )
 
 psm_scenarios=(

--- a/tools/run_tests/performance/run_worker_rust.sh
+++ b/tools/run_tests/performance/run_worker_rust.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+exec ../rust_bin/worker "$@"

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1567,6 +1567,60 @@ class JavaLanguage(Language):
     def __str__(self):
         return "java"
 
+class RustLanguage(Language):
+    def worker_cmdline(self):
+        return ["tools/run_tests/performance/run_worker_rust.sh"]
+
+    def worker_port_offset(self):
+        return 951
+
+    def scenarios(self):
+        secstr = "secure"
+
+        yield _ping_pong_scenario(
+            "rust_protobuf_sync_streaming_ping_pong_%s" % secstr,
+            rpc_type="STREAMING",
+            client_type="SYNC_CLIENT",
+            server_type="SYNC_SERVER",
+            async_server_threads=1,
+            secure=True,
+        )
+
+        yield _ping_pong_scenario(
+            "rust_protobuf_sync_unary_ping_pong_%s" % secstr,
+            rpc_type="UNARY",
+            client_type="SYNC_CLIENT",
+            server_type="SYNC_SERVER",
+            async_server_threads=1,
+            secure=True,
+            categories=[SCALABLE, SMOKETEST],
+        )
+
+        # unconstrained_client='async' is intended (client uses tokio tasks)
+        yield _ping_pong_scenario(
+            "rust_protobuf_sync_unary_qps_unconstrained_%s" % secstr,
+            rpc_type="UNARY",
+            client_type="SYNC_CLIENT",
+            server_type="SYNC_SERVER",
+            unconstrained_client="async",
+            secure=True,
+            categories=[SCALABLE],
+        )
+
+        # unconstrained_client='async' is intended (client uses tokio tasks)
+        yield _ping_pong_scenario(
+            "rust_protobuf_sync_streaming_qps_unconstrained_%s" % secstr,
+            rpc_type="STREAMING",
+            client_type="SYNC_CLIENT",
+            server_type="SYNC_SERVER",
+            unconstrained_client="async",
+            secure=True,
+            categories=[SCALABLE],
+        )
+
+    def __str__(self):
+        return "rust"
+
 
 class GoLanguage(Language):
     def worker_cmdline(self):
@@ -1783,4 +1837,5 @@ LANGUAGES = {
     "python_asyncio": PythonAsyncIOLanguage(),
     "go": GoLanguage(),
     "node": NodeLanguage(),  # 'node' means 'node_purejs'.
+    "rust": RustLanguage(),
 }

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1567,6 +1567,7 @@ class JavaLanguage(Language):
     def __str__(self):
         return "java"
 
+
 class RustLanguage(Language):
     def worker_cmdline(self):
         return ["tools/run_tests/performance/run_worker_rust.sh"]

--- a/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
@@ -236,6 +236,30 @@ spec:
       command:
       - bash
       name: main
+  - build:
+      args:
+      - build
+      - -p
+      - grpc-benchmark
+      - --release
+      - --bin
+      - worker
+      command:
+      - cargo
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-rust.git
+    language: rust
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/target/release/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
   driver:
     language: cxx
     run: []
@@ -425,6 +449,30 @@ spec:
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
             src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - -p
+      - grpc-benchmark
+      - --release
+      - --bin
+      - worker
+      command:
+      - cargo
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-rust.git
+    language: rust
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/target/release/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
       name: main

--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -154,6 +154,19 @@ spec:
       - bash
       image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
       name: main
+  - language: rust
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/rust:${prebuilt_image_tag}
+      name: main
   driver:
     language: cxx
     pool: ${driver_pool}
@@ -277,6 +290,19 @@ spec:
       command:
       - bash
       image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
+      name: main
+  - language: rust
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/rust:${prebuilt_image_tag}
       name: main
   timeoutSeconds: ${timeout_seconds}
   ttlSeconds: 86400


### PR DESCRIPTION
Contributes to: https://github.com/grpc/grpc-rust/issues/2666

## Tested
* Passing kokoro run with other languages skipped: https://source.cloud.google.com/results/invocations/f24699be-b24d-4668-a7e9-67625ceef296
* Full run with node and dotnet failures: https://source.cloud.google.com/results/invocations/52671545-0c24-4993-acae-f91c19d37819
* `python3 tools/run_tests/run_performance_tests.py -l rust --category smoketest` passes.