### PR TITLE
[Python] Removed `UsageError` exception from registered method

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -976,7 +976,10 @@ cdef class AioServer:
     def add_registered_method_handlers(self, dict method_handlers):
         # Cannot register method once server started.
         if self._status != AIO_SERVER_STATUS_READY:
-            raise UsageError('Cannot register method handlers once server has started')
+            _LOGGER.warning(
+                'Cannot register method handlers once server has started'
+            )
+            return
 
         for fully_qualified_method in method_handlers:
             self._server.register_method(fully_qualified_method)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -54,7 +54,6 @@ from grpc._typing import ResponseType
 from grpc._typing import SerializingFunction
 from grpc._typing import ServerCallbackTag
 from grpc._typing import ServerTagCallbackType
-import grpc.experimental
 from typing_extensions import override
 
 _LOGGER = logging.getLogger(__name__)
@@ -1449,7 +1448,8 @@ class _Server(grpc.Server):
                 error_msg = (
                     "Cannot register method handlers once server has started"
                 )
-                raise grpc.experimental.UsageError(error_msg)
+                _LOGGER.warning(error_msg)
+                return
 
         # TODO(xuanwn): We should validate method_handlers first.
         method_to_handlers = {

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -239,19 +239,13 @@ class ServerHandlerTest(unittest.TestCase):
         self._server = test_common.test_server()
         port = self._server.add_insecure_port("[::]:0")
         self._server.start()
-        with self.assertRaises(grpc.experimental.UsageError) as exception_ctx:
-            self._server.add_registered_method_handlers(
-                _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
-            )
-        self.assertIn(
-            "Cannot register method handlers once server has started",
-            str(exception_ctx.exception),
+        self._server.add_registered_method_handlers(
+            _SERVICE_NAME, _REGISTERED_METHOD_HANDLERS
         )
 
-        # The failed registration must not have exposed the method
         self._channel = grpc.insecure_channel("localhost:%d" % port)
 
-        with self.assertRaises(grpc.RpcError) as rpc_exception_ctx:
+        with self.assertRaises(grpc.RpcError) as exception_context:
             self._channel.unary_unary(
                 grpc._common.fully_qualified_method(
                     _SERVICE_NAME, _UNARY_UNARY_REGISTERED
@@ -259,7 +253,7 @@ class ServerHandlerTest(unittest.TestCase):
                 _registered_method=True,
             )(_REQUEST)
 
-        self.assertIn("Method not found", str(rpc_exception_ctx.exception))
+        self.assertIn("Method not found", str(exception_context.exception))
 
     def test_server_with_both_registered_and_generic_handlers(self):
         self._server = test_common.test_server()

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -735,9 +735,7 @@ class TestServer(AioTestBase):
                 registered_unary_unary_handler
             ),
         }
-        self._server.add_registered_method_handlers(
-            "test", registered_handlers
-        )
+        self._server.add_registered_method_handlers("test", registered_handlers)
 
         call = self._channel.unary_unary(
             "/test/AddedAfterServerStart",

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -735,26 +735,20 @@ class TestServer(AioTestBase):
                 registered_unary_unary_handler
             ),
         }
-        with self.assertRaises(aio.UsageError) as exception_ctx:
-            self._server.add_registered_method_handlers(
-                "test", registered_handlers
-            )
-        self.assertIn(
-            "Cannot register method handlers once server has started",
-            str(exception_ctx.exception),
+        self._server.add_registered_method_handlers(
+            "test", registered_handlers
         )
 
-        # The failed registration must not have exposed the method
         call = self._channel.unary_unary(
             "/test/AddedAfterServerStart",
             _registered_method=True,
         )(_REQUEST)
-        with self.assertRaises(grpc.RpcError) as rpc_exception_ctx:
+        with self.assertRaises(grpc.RpcError) as exception_ctx:
             await call
 
         self.assertIn(
             "Method not found",
-            str(rpc_exception_ctx.exception.details()),
+            str(exception_ctx.exception.details()),
         )
 
 


### PR DESCRIPTION
Follow-up after https://github.com/grpc/grpc/pull/41796. It seems like no-op is the right choice for method registration while server is already started.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

