### PR TITLE
[xDS e2e tests] don't set xds_resource_does_not_exist_timeout_ms unnecessarily

### DIFF
--- a/test/cpp/end2end/xds/xds_enabled_server_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_enabled_server_end2end_test.cc
@@ -57,13 +57,13 @@ class XdsEnabledServerTest : public XdsEnd2endTest {
  protected:
   void SetUp() override {}  // No-op -- individual tests do this themselves.
 
-  void DoSetUp(
-      const std::optional<XdsBootstrapBuilder>& builder = std::nullopt) {
+  void DoSetUp(const std::optional<XdsBootstrapBuilder>& builder = std::nullopt,
+               int xds_resource_does_not_exist_timeout_ms = 0) {
     // We use insecure creds here as a convenience to be able to easily
     // create new channels in some of the tests below.  None of the
     // tests here actually depend on the channel creds anyway.
     InitClient(builder, /*lb_expected_authority=*/"",
-               /*xds_resource_does_not_exist_timeout_ms=*/0,
+               xds_resource_does_not_exist_timeout_ms,
                /*balancer_authority_override=*/"", /*args=*/nullptr,
                InsecureChannelCredentials());
     CreateBackends(1, /*xds_enabled=*/true, InsecureServerCredentials());
@@ -868,10 +868,7 @@ TEST_P(XdsServerFilterChainMatchTest,
 // server-side RDS tests
 //
 
-class XdsServerRdsTest : public XdsEnabledServerTest {
- public:
-  void SetUp() override { DoSetUp(); }
-};
+using XdsServerRdsTest = XdsEnabledServerTest;
 
 // Test both with and without RDS.
 // Run with bootstrap from env var so that we use one XdsClient.
@@ -885,12 +882,14 @@ INSTANTIATE_TEST_SUITE_P(
     &XdsTestType::Name);
 
 TEST_P(XdsServerRdsTest, Basic) {
+  DoSetUp();
   StartBackend(0);
   ASSERT_EQ(backends_[0]->GetNextStatus(), absl::OkStatus());
   CheckRpcSendOk(DEBUG_LOCATION, 1, RpcOptions().set_wait_for_ready(true));
 }
 
 TEST_P(XdsServerRdsTest, FailsRouteMatchesOtherThanNonForwardingAction) {
+  DoSetUp();
   SetServerListenerNameAndRouteConfiguration(
       balancer_.get(), default_server_listener_, backends_[0]->port(),
       default_route_config_ /* inappropriate route config for servers */);
@@ -906,6 +905,7 @@ TEST_P(XdsServerRdsTest, FailsRouteMatchesOtherThanNonForwardingAction) {
 // chains
 TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNonDefaultFilterChain) {
   if (!GetParam().enable_rds_testing()) return;
+  DoSetUp();
   Listener listener = default_server_listener_;
   auto* filter_chain = listener.add_filter_chains();
   HttpConnectionManager http_connection_manager =
@@ -925,6 +925,8 @@ TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNonDefaultFilterChain) {
 
 TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNotAvailable) {
   if (!GetParam().enable_rds_testing()) return;
+  DoSetUp(/*builder=*/std::nullopt,
+          /*xds_resource_does_not_exist_timeout_ms=*/500);
   Listener listener = default_server_listener_;
   HttpConnectionManager http_connection_manager =
       ServerHcmAccessor().Unpack(listener);
@@ -937,7 +939,14 @@ TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNotAvailable) {
                                              backends_[0]->port(),
                                              default_server_route_config_);
   StartBackend(0);
-  ASSERT_EQ(backends_[0]->GetNextStatus(), absl::OkStatus());
+  const absl::Time deadline =
+      absl::Now() + (absl::Seconds(10) * grpc_test_slowdown_factor());
+  while (true) {
+    auto status = backends_[0]->GetNextStatus(deadline);
+    ASSERT_TRUE(status.has_value()) << "timed out waiting for server status";
+    if (status->ok()) break;
+    LOG(INFO) << "waiting for OK server status, got: " << *status;
+  }
   CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE,
                       "RDS resource unknown_server_route_config: "
                       "does not exist \\(node ID:xds_end2end_test\\)",
@@ -948,6 +957,7 @@ TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNotAvailable) {
 // should add tests that make sure that different route configs are used for
 // incoming connections with a different match.
 TEST_P(XdsServerRdsTest, MultipleRouteConfigurations) {
+  DoSetUp();
   Listener listener = default_server_listener_;
   // Set a filter chain with a new route config name
   auto new_route_config = default_server_route_config_;

--- a/test/cpp/end2end/xds/xds_enabled_server_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_enabled_server_end2end_test.cc
@@ -63,11 +63,7 @@ class XdsEnabledServerTest : public XdsEnd2endTest {
     // create new channels in some of the tests below.  None of the
     // tests here actually depend on the channel creds anyway.
     InitClient(builder, /*lb_expected_authority=*/"",
-               // Using a low timeout to quickly end negative tests.
-               // Prefer using GetNextStatus() or a similar loop on the
-               // client side to wait on status changes instead of
-               // increasing this timeout.
-               /*xds_resource_does_not_exist_timeout_ms=*/500,
+               /*xds_resource_does_not_exist_timeout_ms=*/0,
                /*balancer_authority_override=*/"", /*args=*/nullptr,
                InsecureChannelCredentials());
     CreateBackends(1, /*xds_enabled=*/true, InsecureServerCredentials());

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -74,15 +74,14 @@ void XdsEnd2endTest::ServerThread::XdsServingStatusNotifier::
 
 std::optional<absl::Status>
 XdsEnd2endTest::ServerThread::XdsServingStatusNotifier::GetNextStatus(
-    const std::string& uri, absl::Duration timeout) {
-  timeout *= grpc_test_slowdown_factor();
+    const std::string& uri, absl::Time deadline) {
   grpc_core::MutexLock lock(&mu_);
   auto& queue = status_map_[uri];
   if (queue.empty()) {
     grpc_core::CondVar cv;
     cond_ = &cv;
     while (queue.empty()) {
-      if (cv.WaitWithTimeout(&mu_, timeout)) {
+      if (cv.WaitWithDeadline(&mu_, deadline)) {
         LOG(ERROR) << "timed out waiting for server status notification";
         cond_ = nullptr;
         return std::nullopt;

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -228,8 +228,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
       void OnServingStatusUpdate(std::string uri,
                                  ServingStatusUpdate update) override;
 
-      std::optional<absl::Status> GetNextStatus(
-          const std::string& uri, absl::Duration timeout = absl::Seconds(10));
+      std::optional<absl::Status> GetNextStatus(const std::string& uri,
+                                                absl::Time deadline);
 
      private:
       grpc_core::Mutex mu_;
@@ -257,9 +257,15 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
 
     int port() const { return port_; }
 
+    std::optional<absl::Status> GetNextStatus(absl::Time deadline) {
+      return notifier_.GetNextStatus(grpc_core::LocalIpAndPort(port_),
+                                     deadline);
+    }
+
     std::optional<absl::Status> GetNextStatus(
         absl::Duration timeout = absl::Seconds(10)) {
-      return notifier_.GetNextStatus(grpc_core::LocalIpAndPort(port_), timeout);
+      return GetNextStatus(absl::Now() +
+                           (timeout * grpc_test_slowdown_factor()));
     }
 
     void set_allow_put_requests(bool allow_put_requests) {

--- a/test/cpp/end2end/xds/xds_security_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_security_end2end_test.cc
@@ -1170,11 +1170,7 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
     builder.AddCertificateProviderPlugin("file_plugin", "file_watcher",
                                          absl::StrJoin(fields, ",\n"));
     InitClient(builder, /*lb_expected_authority=*/"",
-               /*xds_resource_does_not_exist_timeout_ms=*/
-               500,  // using a low timeout to quickly end negative tests.
-                     // Prefer using GetNextStatus() or a similar loop on
-                     // the client side to wait on status changes instead
-                     // of increasing this timeout.
+               /*xds_resource_does_not_exist_timeout_ms=*/0,
                /*balancer_authority_override=*/"", /*args=*/nullptr,
                CreateXdsChannelCredentials());
     CreateBackends(1, /*xds_enabled=*/true,


### PR DESCRIPTION
Change xDS e2e tests to stop lowering the does-not-exist timeout unnecessarily.  The low timeout was causing flakiness in the wake of #43052, since that PR changed the code to fetch the next server status notifier update instead of waiting for a particular desired status update.  If we time out fetching the initial resource, then the initial server status notifier update would be NOT_FOUND, followed by an OK notification once the resource actually is received.

There seems to be only one test that actually needs the lower timeout.  I have retained the lower timeout for that test and added a retry loop with deadline to avoid potential flakiness.