### PR TITLE
[xDS e2e tests] server bind to local IP instead of "localhost"

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -208,7 +208,7 @@ void XdsEnd2endTest::ServerThread::Serve(grpc_core::Mutex* mu,
   // We need to acquire the lock here in order to prevent the notify_one
   // below from firing before its corresponding wait is executed.
   grpc_core::MutexLock lock(mu);
-  std::string server_address = absl::StrCat("localhost:", port_);
+  std::string server_address = grpc_core::LocalIpAndPort(port_);
   if (use_xds_enabled_server_) {
     XdsServerBuilder builder;
     if (GetParam().bootstrap_source() ==

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -253,7 +253,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
     void Start();
     void Shutdown();
 
-    std::string target() const { return absl::StrCat("localhost:", port_); }
+    std::string target() const { return grpc_core::LocalIpAndPort(port_); }
 
     int port() const { return port_; }
 

--- a/test/cpp/end2end/xds/xds_fallback_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_fallback_end2end_test.cc
@@ -148,11 +148,11 @@ TEST_P(XdsFallbackTest, PrimarySecondaryNotAvailable) {
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
       absl::StrFormat(
           "empty address list \\(LDS resource server.example.com: "
-          "xDS channel for server localhost:%d: "
+          "xDS channel for server %s: "
           "xDS call failed with no responses received; "
           "status: RESOURCE_EXHAUSTED: test forced ADS stream failure "
           "\\(node ID:xds_end2end_test\\)\\)",
-          fallback_balancer_->port()));
+          fallback_balancer_->target()));
 }
 
 TEST_P(XdsFallbackTest, UsesCachedResourcesAfterFailure) {


### PR DESCRIPTION
When running on a machine that supports both IPv4 and IPv6, binding to "localhost" causes the server to listen on both IPv4 and IPv6 ports, even though the test will only ever use one of the two.  This causes unnecessary work and unnecessary noise in the logs that make it harder to debug the tests -- especially since xDS-enabled servers wind up trying to fetch a separate LDS resource for each address.

This PR changes the test framework to bind to a specific IP instead of "localhost", which avoids this unnecessary overhead.