### PR TITLE
[core] Refactor DoSplitHostPort to write to output parameters only on…

### DIFF
--- a/src/core/util/host_port.cc
+++ b/src/core/util/host_port.cc
@@ -39,7 +39,9 @@ std::string JoinHostPort(absl::string_view host, int port) {
 namespace {
 bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
                      absl::string_view* port, bool* has_port) {
-  *has_port = false;
+  absl::string_view local_host;
+  absl::string_view local_port;
+  bool local_has_port = false;
   if (!name.empty() && name[0] == '[') {
     // Parse a bracketed host, typically an IPv6 literal.
     const size_t rbracket = name.find(']', 1);
@@ -49,20 +51,19 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
     }
     if (rbracket == name.size() - 1) {
       // ]<end>
-      *port = absl::string_view();
+      local_port = absl::string_view();
     } else if (name[rbracket + 1] == ':') {
       // ]:<port?>
-      *port = name.substr(rbracket + 2, name.size() - rbracket - 2);
-      *has_port = true;
+      local_port = name.substr(rbracket + 2, name.size() - rbracket - 2);
+      local_has_port = true;
     } else {
       // ]<invalid>
       return false;
     }
-    *host = name.substr(1, rbracket - 1);
-    if (host->find(':') == absl::string_view::npos) {
+    local_host = name.substr(1, rbracket - 1);
+    if (local_host.find(':') == absl::string_view::npos) {
       // Require all bracketed hosts to contain a colon, because a hostname or
       // IPv4 address should never use brackets.
-      *host = absl::string_view();
       return false;
     }
   } else {
@@ -70,15 +71,18 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
     if (colon != absl::string_view::npos &&
         name.find(':', colon + 1) == absl::string_view::npos) {
       // Exactly 1 colon.  Split into host:port.
-      *host = name.substr(0, colon);
-      *port = name.substr(colon + 1, name.size() - colon - 1);
-      *has_port = true;
+      local_host = name.substr(0, colon);
+      local_port = name.substr(colon + 1, name.size() - colon - 1);
+      local_has_port = true;
     } else {
-      // 0 or 2+ colons.  Bare hostname or IPv6 litearal.
-      *host = name;
-      *port = absl::string_view();
+      // 0 or 2+ colons.  Bare hostname or IPv6 literal.
+      local_host = name;
+      local_port = absl::string_view();
     }
   }
+  if (host != nullptr) *host = local_host;
+  if (port != nullptr) *port = local_port;
+  if (has_port != nullptr) *has_port = local_has_port;
   return true;
 }
 }  // namespace
@@ -86,7 +90,12 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
 bool SplitHostPort(absl::string_view name, absl::string_view* host,
                    absl::string_view* port) {
   bool unused;
-  return DoSplitHostPort(name, host, port, &unused);
+  const bool ret = DoSplitHostPort(name, host, port, &unused);
+  if (!ret) {
+    if (host != nullptr) *host = absl::string_view();
+    if (port != nullptr) *port = absl::string_view();
+  }
+  return ret;
 }
 
 bool SplitHostPort(absl::string_view name, std::string* host,

--- a/test/core/util/host_port_test.cc
+++ b/test/core/util/host_port_test.cc
@@ -69,6 +69,33 @@ TEST(HostPortTest, SplitHostPortInvalid) {
   split_host_port_expect("[a:b]30", nullptr, nullptr, false);
 }
 
+TEST(HostPortTest, SplitHostPortStringView) {
+  absl::string_view host = "initial_host";
+  absl::string_view port = "initial_port";
+
+  // Valid inputs
+  EXPECT_TRUE(grpc_core::SplitHostPort("[a:b]:30", &host, &port));
+  EXPECT_EQ(host, "a:b");
+  EXPECT_EQ(port, "30");
+
+  EXPECT_TRUE(grpc_core::SplitHostPort("1.2.3.4:30", &host, &port));
+  EXPECT_EQ(host, "1.2.3.4");
+  EXPECT_EQ(port, "30");
+
+  // Invalid inputs should guarantee host and port are cleared
+  host = "initial_host";
+  port = "initial_port";
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b", &host, &port));
+  EXPECT_TRUE(host.empty());
+  EXPECT_TRUE(port.empty());
+
+  host = "initial_host";
+  port = "initial_port";
+  EXPECT_FALSE(grpc_core::SplitHostPort("[ab]:30", &host, &port));
+  EXPECT_TRUE(host.empty());
+  EXPECT_TRUE(port.empty());
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
I was looking through host_port.cc and noticed that the string_view overload of SplitHostPort didn't clear the output pointers when parsing failed—even though the header explicitly says it should. 

Tracing back, the real problem was inside DoSplitHostPort: it was writing partial results to the caller's pointers and then bailing out, so any failure leaked garbage. 

I refactored DoSplitHostPort to work entirely on local variables and only write to the outputs at the very end when we know everything is valid. Now both overloads naturally respect the contract without extra defensive tricks. Added a test to lock in the cleared-on-failure behavior for the string_view path.

