### PR TITLE
[xDS composite filter e2e test] fix flakes

### DIFF
--- a/test/cpp/end2end/xds/xds_composite_filter_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_composite_filter_end2end_test.cc
@@ -224,6 +224,14 @@ class XdsCompositeFilterEnd2endTest : public XdsEnd2endTest {
                                        *route_config);
     }
   }
+
+  void StartBackendServer() {
+    StartBackend(0);
+    if (GetParam().filter_on_server()) {
+      EXPECT_THAT(backends_[0]->GetNextStatus(),
+                  ::testing::Optional(absl::OkStatus()));
+    }
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -241,7 +249,7 @@ TEST_P(XdsCompositeFilterEnd2endTest, TopLevelConfig) {
   matcher_data["hornet"] = std::nullopt;  // SkipFilter
   SetListenerAndRouteConfig(BuildListenerWithCompositeFilter(
       BuildMatcher("name", std::move(matcher_data))));
-  StartBackend(0);
+  StartBackendServer();
   // Send RPC with name=enterprise.
   LOG(INFO) << "Sending RPC with name=enterprise...";
   std::multimap<std::string, std::string> server_initial_metadata;
@@ -291,7 +299,7 @@ TEST_P(XdsCompositeFilterEnd2endTest, OnNoMatch) {
   ActionData::value_type on_no_match = MakeAction("status", "unknown");
   SetListenerAndRouteConfig(BuildListenerWithCompositeFilter(
       BuildMatcher("name", std::move(matcher_data), std::move(on_no_match))));
-  StartBackend(0);
+  StartBackendServer();
   // Send RPC with name=enterprise.
   LOG(INFO) << "Sending RPC with name=enterprise...";
   std::multimap<std::string, std::string> server_initial_metadata;
@@ -318,7 +326,7 @@ TEST_P(XdsCompositeFilterEnd2endTest, TopLevelConfigEmptyMatcher) {
   grpc_core::testing::ScopedExperimentalEnvVar env(
       "GRPC_EXPERIMENTAL_XDS_COMPOSITE_FILTER");
   SetListenerAndRouteConfig(BuildListenerWithCompositeFilter(std::nullopt));
-  StartBackend(0);
+  StartBackendServer();
   CheckRpcSendOk(DEBUG_LOCATION);
 }
 
@@ -334,7 +342,7 @@ TEST_P(XdsCompositeFilterEnd2endTest, OverrideConfig) {
   RouteConfiguration route_config = BuildRouteConfigWithOverrideConfig(
       BuildMatcher("name", std::move(matcher_data)));
   SetListenerAndRouteConfig(listener, route_config);
-  StartBackend(0);
+  StartBackendServer();
   // Send RPC with name=enterprise.
   LOG(INFO) << "Sending RPC with name=enterprise...";
   std::multimap<std::string, std::string> server_initial_metadata;
@@ -362,7 +370,7 @@ TEST_P(XdsCompositeFilterEnd2endTest,
   RouteConfiguration route_config = BuildRouteConfigWithOverrideConfig(
       BuildMatcher("name", std::move(matcher_data)));
   SetListenerAndRouteConfig(listener, route_config);
-  StartBackend(0);
+  StartBackendServer();
   // Send RPC with name=enterprise.
   LOG(INFO) << "Sending RPC with name=enterprise...";
   std::multimap<std::string, std::string> server_initial_metadata;


### PR DESCRIPTION
This fixes flakes introduced in #43019 where the RPCs time out before the server starts up.