### PR TITLE
Enforce clear-on-failure guarantee in SplitHostPort by making DoSplit…

### DIFF
--- a/src/core/util/host_port.cc
+++ b/src/core/util/host_port.cc
@@ -39,7 +39,9 @@ std::string JoinHostPort(absl::string_view host, int port) {
 namespace {
 bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
                      absl::string_view* port, bool* has_port) {
-  *has_port = false;
+  absl::string_view result_host;
+  absl::string_view result_port;
+  bool result_has_port = false;
   if (!name.empty() && name[0] == '[') {
     // Parse a bracketed host, typically an IPv6 literal.
     const size_t rbracket = name.find(']', 1);
@@ -49,20 +51,19 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
     }
     if (rbracket == name.size() - 1) {
       // ]<end>
-      *port = absl::string_view();
+      result_port = absl::string_view();
     } else if (name[rbracket + 1] == ':') {
       // ]:<port?>
-      *port = name.substr(rbracket + 2, name.size() - rbracket - 2);
-      *has_port = true;
+      result_port = name.substr(rbracket + 2, name.size() - rbracket - 2);
+      result_has_port = true;
     } else {
       // ]<invalid>
       return false;
     }
-    *host = name.substr(1, rbracket - 1);
-    if (host->find(':') == absl::string_view::npos) {
+    result_host = name.substr(1, rbracket - 1);
+    if (result_host.find(':') == absl::string_view::npos) {
       // Require all bracketed hosts to contain a colon, because a hostname or
       // IPv4 address should never use brackets.
-      *host = absl::string_view();
       return false;
     }
   } else {
@@ -70,15 +71,18 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
     if (colon != absl::string_view::npos &&
         name.find(':', colon + 1) == absl::string_view::npos) {
       // Exactly 1 colon.  Split into host:port.
-      *host = name.substr(0, colon);
-      *port = name.substr(colon + 1, name.size() - colon - 1);
-      *has_port = true;
+      result_host = name.substr(0, colon);
+      result_port = name.substr(colon + 1, name.size() - colon - 1);
+      result_has_port = true;
     } else {
-      // 0 or 2+ colons.  Bare hostname or IPv6 litearal.
-      *host = name;
-      *port = absl::string_view();
+      // 0 or 2+ colons.  Bare hostname or IPv6 literal.
+      result_host = name;
+      result_port = absl::string_view();
     }
   }
+  *host = result_host;
+  *port = result_port;
+  *has_port = result_has_port;
   return true;
 }
 }  // namespace
@@ -86,7 +90,12 @@ bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
 bool SplitHostPort(absl::string_view name, absl::string_view* host,
                    absl::string_view* port) {
   bool unused;
-  return DoSplitHostPort(name, host, port, &unused);
+  if (!DoSplitHostPort(name, host, port, &unused)) {
+    *host = absl::string_view();
+    *port = absl::string_view();
+    return false;
+  }
+  return true;
 }
 
 bool SplitHostPort(absl::string_view name, std::string* host,
@@ -107,6 +116,9 @@ bool SplitHostPort(absl::string_view name, std::string* host,
     if (has_port) {
       *port = std::string(port_view);
     }
+  } else {
+    host->clear();
+    port->clear();
   }
   return ret;
 }

--- a/test/core/util/host_port_test.cc
+++ b/test/core/util/host_port_test.cc
@@ -69,6 +69,64 @@ TEST(HostPortTest, SplitHostPortInvalid) {
   split_host_port_expect("[a:b]30", nullptr, nullptr, false);
 }
 
+TEST(HostPortTest, SplitHostPortViewClearsOutvarsOnFailure) {
+  absl::string_view host = "original_host";
+  absl::string_view port = "original_port";
+
+  // Unmatched [
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+
+  // Junk after bracket
+  host = "original_host";
+  port = "original_port";
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b]30", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+
+  // IPv6 literal without colon inside brackets
+  host = "original_host";
+  port = "original_port";
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a]", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+}
+
+TEST(HostPortTest, SplitHostPortStringClearsOutvarsOnFailure) {
+  std::string host;
+  std::string port;
+
+  // Unmatched [
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+
+  // Junk after bracket
+  host.clear();
+  port.clear();
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b]30", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+
+  // IPv6 literal without colon inside brackets
+  host.clear();
+  port.clear();
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a]", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+
+#ifdef NDEBUG
+  // In release builds where DCHECK is disabled, we should also verify that
+  // pre-existing non-empty strings are successfully cleared on failure.
+  host = "original_host";
+  port = "original_port";
+  EXPECT_FALSE(grpc_core::SplitHostPort("[a:b", &host, &port));
+  EXPECT_EQ(host, "");
+  EXPECT_EQ(port, "");
+#endif
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
SplitHostPort promises to clear outputs on failure, but the string_view overload didn't. The helper DoSplitHostPort could leave them partially modified. 

This PR makes the helper transactional (local variables, write outputs only on success) and adds explicit clearing in the public wrappers. Tests now verify that pre‑seeded outputs become empty on invalid inputs like unmatched brackets or junk after IPv6. No parsing changes.

