### PR TITLE
[bloat_diff] Improve build logging and clarify diff base failures

### DIFF
--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -81,7 +81,9 @@ def _build(output_dir: str) -> None:
             ],
             cwd=output_dir,
         )
-        subprocess.check_call("make -j%d" % args.jobs, shell=True, cwd=output_dir)
+        subprocess.check_call(
+            "make -j%d" % args.jobs, shell=True, cwd=output_dir
+        )
     except Exception:
         _print_banner(f"BUILD END: {output_dir} FAILED", file=sys.stderr)
         raise

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -83,7 +83,7 @@ def _build(output_dir: str) -> None:
             cwd=output_dir,
         )
         subprocess.check_call(["make", f"-j{args.jobs}"], cwd=output_dir)
-    except Exception:
+    except subprocess.CalledProcessError:
         _print_banner(f"BUILD END: {output_dir} FAILED", file=sys.stderr)
         raise
     _print_banner(f"BUILD END: {output_dir} SUCCEEDED")
@@ -108,7 +108,7 @@ _build("bloat_diff_new")
 
 if args.diff_base:
     where_am_i = (
-        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        subprocess.check_output(["git", "rev-parse", "HEAD"])
         .decode()
         .strip()
     )
@@ -118,7 +118,6 @@ if args.diff_base:
         subprocess.check_call(["git", "submodule", "update"])
         _build("bloat_diff_old")
     except Exception as e:
-        sys.stdout.flush()
         traceback.print_exc()
         _print_banner(
             "MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED", file=sys.stderr
@@ -129,11 +128,12 @@ if args.diff_base:
         try:
             subprocess.check_call(["git", "checkout", where_am_i])
             subprocess.check_call(["git", "submodule", "update"])
-        except Exception:
+        except Exception as e:
             _print_banner(
                 "FAILED TO RESTORE ORIGINAL GIT REVISION", file=sys.stderr
             )
             traceback.print_exc()
+            sys.exit(getattr(e, "returncode", 1) or 1)
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)
 subprocess.check_call(

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -24,6 +24,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import traceback
 
 sys.path.append(
     os.path.join(
@@ -52,24 +53,39 @@ LIBS = [
 ]
 
 
-def _build(output_dir):
+def _print_banner(msg: str, file: object = sys.stdout) -> None:
+    """Prints a prominent banner line to the specified stream."""
+    sys.stdout.flush()
+    sys.stderr.flush()
+    padded_msg = f" ### {msg} ### "
+    width = max(100, len(padded_msg) + 20)
+    print(f"\n{padded_msg.center(width, '#')}\n", file=file, flush=True)
+
+
+def _build(output_dir: str) -> None:
     """Perform the cmake build under the output_dir."""
+    _print_banner(f"BUILD START: {output_dir}")
     shutil.rmtree(output_dir, ignore_errors=True)
     subprocess.check_call("mkdir -p %s" % output_dir, shell=True, cwd=".")
-    subprocess.check_call(
-        [
-            "cmake",
-            "-DgRPC_BUILD_TESTS=OFF",
-            "-DCMAKE_CXX_STANDARD=17",
-            "-DBUILD_SHARED_LIBS=ON",
-            "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-            '-DCMAKE_C_FLAGS="-gsplit-dwarf"',
-            '-DCMAKE_CXX_FLAGS="-gsplit-dwarf"',
-            "..",
-        ],
-        cwd=output_dir,
-    )
-    subprocess.check_call("make -j%d" % args.jobs, shell=True, cwd=output_dir)
+    try:
+        subprocess.check_call(
+            [
+                "cmake",
+                "-DgRPC_BUILD_TESTS=OFF",
+                "-DCMAKE_CXX_STANDARD=17",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                '-DCMAKE_C_FLAGS="-gsplit-dwarf"',
+                '-DCMAKE_CXX_FLAGS="-gsplit-dwarf"',
+                "..",
+            ],
+            cwd=output_dir,
+        )
+        subprocess.check_call("make -j%d" % args.jobs, shell=True, cwd=output_dir)
+    except Exception:
+        _print_banner(f"BUILD END: {output_dir} FAILED", file=sys.stderr)
+        raise
+    _print_banner(f"BUILD END: {output_dir} SUCCEEDED")
 
 
 def _rank_diff_bytes(diff_bytes):
@@ -95,15 +111,23 @@ if args.diff_base:
         .decode()
         .strip()
     )
-    # checkout the diff base (="old")
-    subprocess.check_call(["git", "checkout", args.diff_base])
-    subprocess.check_call(["git", "submodule", "update"])
     try:
-        _build("bloat_diff_old")
-    finally:
-        # restore the original revision (="new")
-        subprocess.check_call(["git", "checkout", where_am_i])
+        # checkout the diff base (="old")
+        subprocess.check_call(["git", "checkout", args.diff_base])
         subprocess.check_call(["git", "submodule", "update"])
+        try:
+            _build("bloat_diff_old")
+        finally:
+            # restore the original revision (="new")
+            subprocess.check_call(["git", "checkout", where_am_i])
+            subprocess.check_call(["git", "submodule", "update"])
+    except Exception as e:
+        sys.stdout.flush()
+        traceback.print_exc()
+        _print_banner(
+            "MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED", file=sys.stderr
+        )
+        sys.exit(getattr(e, "returncode", 1) or 1)
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)
 subprocess.check_call(

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import sys
 import traceback
+from typing import TextIO
 
 sys.path.append(
     os.path.join(
@@ -53,7 +54,7 @@ LIBS = [
 ]
 
 
-def _print_banner(msg: str, file: object = sys.stdout) -> None:
+def _print_banner(msg: str, file: TextIO = sys.stdout) -> None:
     """Prints a prominent banner line to the specified stream."""
     sys.stdout.flush()
     sys.stderr.flush()
@@ -66,7 +67,7 @@ def _build(output_dir: str) -> None:
     """Perform the cmake build under the output_dir."""
     _print_banner(f"BUILD START: {output_dir}")
     shutil.rmtree(output_dir, ignore_errors=True)
-    subprocess.check_call("mkdir -p %s" % output_dir, shell=True, cwd=".")
+    os.makedirs(output_dir, exist_ok=True)
     try:
         subprocess.check_call(
             [
@@ -81,9 +82,7 @@ def _build(output_dir: str) -> None:
             ],
             cwd=output_dir,
         )
-        subprocess.check_call(
-            "make -j%d" % args.jobs, shell=True, cwd=output_dir
-        )
+        subprocess.check_call(["make", f"-j{args.jobs}"], cwd=output_dir)
     except Exception:
         _print_banner(f"BUILD END: {output_dir} FAILED", file=sys.stderr)
         raise
@@ -114,22 +113,26 @@ if args.diff_base:
         .strip()
     )
     try:
-        try:
-            # checkout the diff base (="old")
-            subprocess.check_call(["git", "checkout", args.diff_base])
-            subprocess.check_call(["git", "submodule", "update"])
-            _build("bloat_diff_old")
-        finally:
-            # restore the original revision (="new")
-            subprocess.check_call(["git", "checkout", where_am_i])
-            subprocess.check_call(["git", "submodule", "update"])
+        # checkout the diff base (="old")
+        subprocess.check_call(["git", "checkout", args.diff_base])
+        subprocess.check_call(["git", "submodule", "update"])
+        _build("bloat_diff_old")
     except Exception as e:
         sys.stdout.flush()
         traceback.print_exc()
         _print_banner(
             "MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED", file=sys.stderr
         )
-        sys.exit(getattr(e, "returncode", 1) or 1)
+        exit_code = (
+            e.returncode
+            if isinstance(e, subprocess.CalledProcessError) and e.returncode
+            else 1
+        )
+        sys.exit(exit_code)
+    finally:
+        # restore the original revision (="new")
+        subprocess.check_call(["git", "checkout", where_am_i])
+        subprocess.check_call(["git", "submodule", "update"])
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)
 subprocess.check_call(

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -62,7 +62,7 @@ def _print_banner(
         file = sys.stdout
     sys.stdout.flush()
     sys.stderr.flush()
-    padded_msg = f" ### {msg} ### "
+    padded_msg = f" {msg} "
     width = max(max_width, len(padded_msg) + 20)
     print(f"\n{padded_msg:#^{width}}", file=file, flush=True)
 

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -54,15 +54,17 @@ LIBS = [
 ]
 
 
-def _print_banner(msg: str, file: Optional[TextIO] = None) -> None:
+def _print_banner(
+    msg: str, file: Optional[TextIO] = None, max_width: int = 120
+) -> None:
     """Prints a prominent banner line to the specified stream."""
     if file is None:
         file = sys.stdout
     sys.stdout.flush()
     sys.stderr.flush()
     padded_msg = f" ### {msg} ### "
-    width = max(100, len(padded_msg) + 20)
-    print(f"\n{padded_msg.center(width, '#')}", file=file, flush=True)
+    width = max(max_width, len(padded_msg) + 20)
+    print(f"\n{padded_msg:#^{width}}", file=file, flush=True)
 
 
 def _build(output_dir: str) -> None:

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -112,9 +112,7 @@ _build("bloat_diff_new")
 
 if args.diff_base:
     where_am_i = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"])
-        .decode()
-        .strip()
+        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
     )
     try:
         # checkout the diff base (="old")

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -87,7 +87,7 @@ def _build(output_dir: str) -> None:
             cwd=output_dir,
         )
         subprocess.check_call(["make", f"-j{args.jobs}"], cwd=output_dir)
-    except subprocess.CalledProcessError:
+    except Exception:
         _print_banner(f"BUILD END: {output_dir} FAILED", file=sys.stderr)
         raise
     _print_banner(f"BUILD END: {output_dir} SUCCEEDED")
@@ -111,31 +111,35 @@ def _rank_diff_bytes(diff_bytes):
 _build("bloat_diff_new")
 
 if args.diff_base:
-    where_am_i = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
-    )
+    where_am_i = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], text=True
+    ).strip()
     try:
         # checkout the diff base (="old")
         subprocess.check_call(["git", "checkout", args.diff_base])
-        subprocess.check_call(["git", "submodule", "update"])
+        subprocess.check_call(
+            ["git", "submodule", "update", "--init", "--recursive"]
+        )
         _build("bloat_diff_old")
     except Exception as e:
         traceback.print_exc()
         _print_banner(
             "MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED", file=sys.stderr
         )
-        sys.exit(getattr(e, "returncode", 1) or 1)
+        sys.exit(getattr(e, "returncode", None) or 1)
     finally:
         # restore the original revision (="new")
         try:
             subprocess.check_call(["git", "checkout", where_am_i])
-            subprocess.check_call(["git", "submodule", "update"])
+            subprocess.check_call(
+                ["git", "submodule", "update", "--init", "--recursive"]
+            )
         except Exception as e:
             traceback.print_exc()
             _print_banner(
                 "FAILED TO RESTORE ORIGINAL GIT REVISION", file=sys.stderr
             )
-            sys.exit(getattr(e, "returncode", 1) or 1)
+            sys.exit(getattr(e, "returncode", None) or 1)
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)
 subprocess.check_call(

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -25,7 +25,7 @@ import shutil
 import subprocess
 import sys
 import traceback
-from typing import TextIO
+from typing import Optional, TextIO
 
 sys.path.append(
     os.path.join(
@@ -54,13 +54,15 @@ LIBS = [
 ]
 
 
-def _print_banner(msg: str, file: TextIO = sys.stdout) -> None:
+def _print_banner(msg: str, file: Optional[TextIO] = None) -> None:
     """Prints a prominent banner line to the specified stream."""
+    if file is None:
+        file = sys.stdout
     sys.stdout.flush()
     sys.stderr.flush()
     padded_msg = f" ### {msg} ### "
     width = max(100, len(padded_msg) + 20)
-    print(f"\n{padded_msg.center(width, '#')}\n", file=file, flush=True)
+    print(f"\n{padded_msg.center(width, '#')}", file=file, flush=True)
 
 
 def _build(output_dir: str) -> None:
@@ -129,10 +131,10 @@ if args.diff_base:
             subprocess.check_call(["git", "checkout", where_am_i])
             subprocess.check_call(["git", "submodule", "update"])
         except Exception as e:
+            traceback.print_exc()
             _print_banner(
                 "FAILED TO RESTORE ORIGINAL GIT REVISION", file=sys.stderr
             )
-            traceback.print_exc()
             sys.exit(getattr(e, "returncode", 1) or 1)
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -112,10 +112,10 @@ if args.diff_base:
         .strip()
     )
     try:
-        # checkout the diff base (="old")
-        subprocess.check_call(["git", "checkout", args.diff_base])
-        subprocess.check_call(["git", "submodule", "update"])
         try:
+            # checkout the diff base (="old")
+            subprocess.check_call(["git", "checkout", args.diff_base])
+            subprocess.check_call(["git", "submodule", "update"])
             _build("bloat_diff_old")
         finally:
             # restore the original revision (="new")

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -67,7 +67,7 @@ def _build(output_dir: str) -> None:
     """Perform the cmake build under the output_dir."""
     _print_banner(f"BUILD START: {output_dir}")
     shutil.rmtree(output_dir, ignore_errors=True)
-    os.makedirs(output_dir, exist_ok=True)
+    pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
     try:
         subprocess.check_call(
             [
@@ -123,16 +123,17 @@ if args.diff_base:
         _print_banner(
             "MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED", file=sys.stderr
         )
-        exit_code = (
-            e.returncode
-            if isinstance(e, subprocess.CalledProcessError) and e.returncode
-            else 1
-        )
-        sys.exit(exit_code)
+        sys.exit(getattr(e, "returncode", 1) or 1)
     finally:
         # restore the original revision (="new")
-        subprocess.check_call(["git", "checkout", where_am_i])
-        subprocess.check_call(["git", "submodule", "update"])
+        try:
+            subprocess.check_call(["git", "checkout", where_am_i])
+            subprocess.check_call(["git", "submodule", "update"])
+        except Exception:
+            _print_banner(
+                "FAILED TO RESTORE ORIGINAL GIT REVISION", file=sys.stderr
+            )
+            traceback.print_exc()
 
 pathlib.Path("bloaty-build").mkdir(exist_ok=True)
 subprocess.check_call(


### PR DESCRIPTION
- Add prominent build banners in bloat_diff.py to denote the start and finish (success/failure) of individual build phases, improving visibility in long CI log streams.
- Explicitly trap exceptions when building against the diff base (bloat_diff_old), outputting a clear diagnostic banner ('MAIN BUILD SUCCEEDED, BUT DIFF BASE BUILD FAILED') immediately following the traceback.
- Preserve exact non-zero subprocess return codes when terminating on diff base failures without altering existing build failure exit semantics.




