### PR TITLE
[Python][AsyncIO] Fixed reference cycles

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -186,6 +186,7 @@ cdef class _AioCall(GrpcCallWrapper):
 
         for callback in self._done_callbacks:
             callback()
+        self._done_callbacks = []
 
     cdef void _set_initial_metadata(self, tuple initial_metadata) except *:
         if self._initial_metadata is not None:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -184,9 +184,10 @@ cdef class _AioCall(GrpcCallWrapper):
                 waiter.set_result(None)
         self._waiters_status = []
 
-        for callback in self._done_callbacks:
-            callback()
+        callbacks = self._done_callbacks
         self._done_callbacks = []
+        for callback in callbacks:
+            callback()
 
     cdef void _set_initial_metadata(self, tuple initial_metadata) except *:
         if self._initial_metadata is not None:

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -695,7 +695,6 @@ class InterceptedUnaryUnaryCall(
         response_deserializer: Optional[DeserializingFunction],
     ) -> Union[UnaryUnaryCall, UnaryUnaryCallResponse]:
         """Run the RPC call wrapped in interceptors"""
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
@@ -818,7 +817,6 @@ class InterceptedUnaryStreamCall(
         response_deserializer: Optional[DeserializingFunction],
     ) -> Union[UnaryStreamCall, UnaryStreamCallResponseIterator]:
         """Run the RPC call wrapped in interceptors"""
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
@@ -960,7 +958,6 @@ class InterceptedStreamUnaryCall(
         response_deserializer: Optional[DeserializingFunction],
     ) -> StreamUnaryCall:
         """Run the RPC call wrapped in interceptors"""
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
@@ -1086,7 +1083,6 @@ class InterceptedStreamStreamCall(
         response_deserializer: Optional[DeserializingFunction],
     ) -> Union[StreamStreamCall, StreamStreamCallResponseIterator]:
         """Run the RPC call wrapped in interceptors"""
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -647,7 +647,6 @@ class InterceptedUnaryUnaryCall(
     _loop: asyncio.AbstractEventLoop
     _channel: cygrpc.AioChannel
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         interceptors: Sequence[UnaryUnaryClientInterceptor],
@@ -681,7 +680,6 @@ class InterceptedUnaryUnaryCall(
         )
         super().__init__(interceptors_task)
 
-    # pylint: disable=too-many-arguments
     async def _invoke(
         self,
         interceptors: Sequence[UnaryUnaryClientInterceptor],
@@ -707,7 +705,6 @@ class InterceptedUnaryUnaryCall(
             request,
         )
 
-    # pylint: disable=too-many-arguments
     async def _run_interceptor(
         self,
         interceptors: List[UnaryUnaryClientInterceptor],
@@ -767,7 +764,6 @@ class InterceptedUnaryStreamCall(
     _channel: cygrpc.AioChannel
     _last_returned_call_from_interceptors = Optional[_base_call.UnaryStreamCall]
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         interceptors: Sequence[UnaryStreamClientInterceptor],
@@ -803,7 +799,6 @@ class InterceptedUnaryStreamCall(
         )
         super().__init__(interceptors_task)
 
-    # pylint: disable=too-many-arguments
     async def _invoke(
         self,
         interceptors: Sequence[UnaryStreamClientInterceptor],
@@ -829,7 +824,6 @@ class InterceptedUnaryStreamCall(
             request,
         )
 
-    # pylint: disable=too-many-arguments
     async def _run_interceptor(
         self,
         interceptors: List[UnaryStreamClientInterceptor],
@@ -909,7 +903,6 @@ class InterceptedStreamUnaryCall(
     _loop: asyncio.AbstractEventLoop
     _channel: cygrpc.AioChannel
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         interceptors: Sequence[StreamUnaryClientInterceptor],
@@ -944,7 +937,6 @@ class InterceptedStreamUnaryCall(
         )
         super().__init__(interceptors_task)
 
-    # pylint: disable=too-many-arguments
     async def _invoke(
         self,
         interceptors: Sequence[StreamUnaryClientInterceptor],
@@ -970,7 +962,6 @@ class InterceptedStreamUnaryCall(
             request_iterator,
         )
 
-    # pylint: disable=too-many-arguments
     async def _run_interceptor(
         self,
         interceptors: Sequence[StreamUnaryClientInterceptor],
@@ -1032,7 +1023,6 @@ class InterceptedStreamStreamCall(
         _base_call.StreamStreamCall
     ]
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         interceptors: Sequence[StreamStreamClientInterceptor],
@@ -1069,7 +1059,6 @@ class InterceptedStreamStreamCall(
         )
         super().__init__(interceptors_task)
 
-    # pylint: disable=too-many-arguments
     async def _invoke(
         self,
         interceptors: Sequence[StreamStreamClientInterceptor],
@@ -1095,7 +1084,6 @@ class InterceptedStreamStreamCall(
             request_iterator,
         )
 
-    # pylint: disable=too-many-arguments
     async def _run_interceptor(
         self,
         interceptors: List[StreamStreamClientInterceptor],

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -1101,6 +1101,7 @@ class InterceptedStreamStreamCall(
             request_iterator,
         )
 
+    # pylint: disable=too-many-arguments
     async def _run_interceptor(
         self,
         interceptors: List[StreamStreamClientInterceptor],

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -696,49 +696,63 @@ class InterceptedUnaryUnaryCall(
     ) -> Union[UnaryUnaryCall, UnaryUnaryCallResponse]:
         """Run the RPC call wrapped in interceptors"""
 
-        async def _run_interceptor(
-            interceptors: List[UnaryUnaryClientInterceptor],
-            client_call_details: ClientCallDetails,
-            request: RequestType,
-        ) -> Union[UnaryUnaryCall, UnaryUnaryCallResponse]:
-            if interceptors:
-                continuation = functools.partial(
-                    _run_interceptor, interceptors[1:]
-                )
-                call_or_response = await interceptors[0].intercept_unary_unary(
-                    continuation, client_call_details, request
-                )
-
-                if isinstance(call_or_response, _base_call.UnaryUnaryCall):
-                    return call_or_response
-                return UnaryUnaryCallResponse(call_or_response)
-
-            registered_call_handle = _resolve_registered_call_handle(
-                self._channel,
-                method,
-                client_call_details.method,
-                self._registered_call_handle,
-            )
-
-            return UnaryUnaryCall(
-                request,
-                _timeout_to_deadline(client_call_details.timeout),
-                client_call_details.metadata,
-                client_call_details.credentials,
-                client_call_details.wait_for_ready,
-                self._channel,
-                client_call_details.method,
-                request_serializer,
-                response_deserializer,
-                self._loop,
-                registered_call_handle,
-            )
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
-        return await _run_interceptor(
-            list(interceptors), client_call_details, request
+        return await self._run_interceptor(
+            list(interceptors),
+            method,
+            request_serializer,
+            response_deserializer,
+            client_call_details,
+            request,
+        )
+
+    # pylint: disable=too-many-arguments
+    async def _run_interceptor(
+        self,
+        interceptors: List[UnaryUnaryClientInterceptor],
+        method: bytes,
+        request_serializer: Optional[SerializingFunction],
+        response_deserializer: Optional[DeserializingFunction],
+        client_call_details: ClientCallDetails,
+        request: RequestType,
+    ) -> Union[UnaryUnaryCall, UnaryUnaryCallResponse]:
+        if interceptors:
+            continuation = functools.partial(
+                self._run_interceptor,
+                interceptors[1:],
+                method,
+                request_serializer,
+                response_deserializer,
+            )
+            call_or_response = await interceptors[0].intercept_unary_unary(
+                continuation, client_call_details, request
+            )
+
+            if isinstance(call_or_response, _base_call.UnaryUnaryCall):
+                return call_or_response
+            return UnaryUnaryCallResponse(call_or_response)
+
+        registered_call_handle = _resolve_registered_call_handle(
+            self._channel,
+            method,
+            client_call_details.method,
+            self._registered_call_handle,
+        )
+
+        return UnaryUnaryCall(
+            request,
+            _timeout_to_deadline(client_call_details.timeout),
+            client_call_details.metadata,
+            client_call_details.credentials,
+            client_call_details.wait_for_ready,
+            self._channel,
+            client_call_details.method,
+            request_serializer,
+            response_deserializer,
+            self._loop,
+            registered_call_handle,
         )
 
     def time_remaining(self) -> Optional[float]:
@@ -805,66 +819,80 @@ class InterceptedUnaryStreamCall(
     ) -> Union[UnaryStreamCall, UnaryStreamCallResponseIterator]:
         """Run the RPC call wrapped in interceptors"""
 
-        async def _run_interceptor(
-            interceptors: List[UnaryStreamClientInterceptor],
-            client_call_details: ClientCallDetails,
-            request: RequestType,
-        ) -> Union[UnaryStreamCall, UnaryStreamCallResponseIterator]:
-            if interceptors:
-                continuation = functools.partial(
-                    _run_interceptor, interceptors[1:]
-                )
-
-                call_or_response_iterator = await interceptors[
-                    0
-                ].intercept_unary_stream(
-                    continuation, client_call_details, request
-                )
-
-                if isinstance(
-                    call_or_response_iterator, _base_call.UnaryStreamCall
-                ):
-                    self._last_returned_call_from_interceptors = (
-                        call_or_response_iterator
-                    )
-                else:
-                    self._last_returned_call_from_interceptors = (
-                        UnaryStreamCallResponseIterator(
-                            self._last_returned_call_from_interceptors,
-                            call_or_response_iterator,
-                        )
-                    )
-                return self._last_returned_call_from_interceptors
-
-            registered_call_handle = _resolve_registered_call_handle(
-                self._channel,
-                method,
-                client_call_details.method,
-                self._registered_call_handle,
-            )
-
-            self._last_returned_call_from_interceptors = UnaryStreamCall(
-                request,
-                _timeout_to_deadline(client_call_details.timeout),
-                client_call_details.metadata,
-                client_call_details.credentials,
-                client_call_details.wait_for_ready,
-                self._channel,
-                client_call_details.method,
-                request_serializer,
-                response_deserializer,
-                self._loop,
-                registered_call_handle,
-            )
-
-            return self._last_returned_call_from_interceptors
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
-        return await _run_interceptor(
-            list(interceptors), client_call_details, request
+        return await self._run_interceptor(
+            list(interceptors),
+            method,
+            request_serializer,
+            response_deserializer,
+            client_call_details,
+            request,
         )
+
+    # pylint: disable=too-many-arguments
+    async def _run_interceptor(
+        self,
+        interceptors: List[UnaryStreamClientInterceptor],
+        method: bytes,
+        request_serializer: Optional[SerializingFunction],
+        response_deserializer: Optional[DeserializingFunction],
+        client_call_details: ClientCallDetails,
+        request: RequestType,
+    ) -> Union[UnaryStreamCall, UnaryStreamCallResponseIterator]:
+        if interceptors:
+            continuation = functools.partial(
+                self._run_interceptor,
+                interceptors[1:],
+                method,
+                request_serializer,
+                response_deserializer,
+            )
+
+            call_or_response_iterator = await interceptors[
+                0
+            ].intercept_unary_stream(
+                continuation, client_call_details, request
+            )
+
+            if isinstance(
+                call_or_response_iterator, _base_call.UnaryStreamCall
+            ):
+                self._last_returned_call_from_interceptors = (
+                    call_or_response_iterator
+                )
+            else:
+                self._last_returned_call_from_interceptors = (
+                    UnaryStreamCallResponseIterator(
+                        self._last_returned_call_from_interceptors,
+                        call_or_response_iterator,
+                    )
+                )
+            return self._last_returned_call_from_interceptors
+
+        registered_call_handle = _resolve_registered_call_handle(
+            self._channel,
+            method,
+            client_call_details.method,
+            self._registered_call_handle,
+        )
+
+        self._last_returned_call_from_interceptors = UnaryStreamCall(
+            request,
+            _timeout_to_deadline(client_call_details.timeout),
+            client_call_details.metadata,
+            client_call_details.credentials,
+            client_call_details.wait_for_ready,
+            self._channel,
+            client_call_details.method,
+            request_serializer,
+            response_deserializer,
+            self._loop,
+            registered_call_handle,
+        )
+
+        return self._last_returned_call_from_interceptors
 
     def time_remaining(self) -> Optional[float]:
         raise NotImplementedError()
@@ -935,46 +963,60 @@ class InterceptedStreamUnaryCall(
     ) -> StreamUnaryCall:
         """Run the RPC call wrapped in interceptors"""
 
-        async def _run_interceptor(
-            interceptors: Sequence[StreamUnaryClientInterceptor],
-            client_call_details: ClientCallDetails,
-            request_iterator: RequestIterableType,
-        ) -> _base_call.StreamUnaryCall:
-            if interceptors:
-                continuation = functools.partial(
-                    _run_interceptor, interceptors[1:]
-                )
-
-                return await interceptors[0].intercept_stream_unary(
-                    continuation, client_call_details, request_iterator
-                )
-
-            registered_call_handle = _resolve_registered_call_handle(
-                self._channel,
-                method,
-                client_call_details.method,
-                self._registered_call_handle,
-            )
-
-            return StreamUnaryCall(
-                request_iterator,
-                _timeout_to_deadline(client_call_details.timeout),
-                client_call_details.metadata,
-                client_call_details.credentials,
-                client_call_details.wait_for_ready,
-                self._channel,
-                client_call_details.method,
-                request_serializer,
-                response_deserializer,
-                self._loop,
-                registered_call_handle,
-            )
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
-        return await _run_interceptor(
-            list(interceptors), client_call_details, request_iterator
+        return await self._run_interceptor(
+            list(interceptors),
+            method,
+            request_serializer,
+            response_deserializer,
+            client_call_details,
+            request_iterator,
+        )
+
+    # pylint: disable=too-many-arguments
+    async def _run_interceptor(
+        self,
+        interceptors: Sequence[StreamUnaryClientInterceptor],
+        method: bytes,
+        request_serializer: Optional[SerializingFunction],
+        response_deserializer: Optional[DeserializingFunction],
+        client_call_details: ClientCallDetails,
+        request_iterator: RequestIterableType,
+    ) -> _base_call.StreamUnaryCall:
+        if interceptors:
+            continuation = functools.partial(
+                self._run_interceptor,
+                interceptors[1:],
+                method,
+                request_serializer,
+                response_deserializer,
+            )
+
+            return await interceptors[0].intercept_stream_unary(
+                continuation, client_call_details, request_iterator
+            )
+
+        registered_call_handle = _resolve_registered_call_handle(
+            self._channel,
+            method,
+            client_call_details.method,
+            self._registered_call_handle,
+        )
+
+        return StreamUnaryCall(
+            request_iterator,
+            _timeout_to_deadline(client_call_details.timeout),
+            client_call_details.metadata,
+            client_call_details.credentials,
+            client_call_details.wait_for_ready,
+            self._channel,
+            client_call_details.method,
+            request_serializer,
+            response_deserializer,
+            self._loop,
+            registered_call_handle,
         )
 
     def time_remaining(self) -> Optional[float]:
@@ -1047,65 +1089,78 @@ class InterceptedStreamStreamCall(
     ) -> Union[StreamStreamCall, StreamStreamCallResponseIterator]:
         """Run the RPC call wrapped in interceptors"""
 
-        async def _run_interceptor(
-            interceptors: List[StreamStreamClientInterceptor],
-            client_call_details: ClientCallDetails,
-            request_iterator: RequestIterableType,
-        ) -> Union[StreamStreamCall, StreamStreamCallResponseIterator]:
-            if interceptors:
-                continuation = functools.partial(
-                    _run_interceptor, interceptors[1:]
-                )
-
-                call_or_response_iterator = await interceptors[
-                    0
-                ].intercept_stream_stream(
-                    continuation, client_call_details, request_iterator
-                )
-
-                if isinstance(
-                    call_or_response_iterator, _base_call.StreamStreamCall
-                ):
-                    self._last_returned_call_from_interceptors = (
-                        call_or_response_iterator
-                    )
-                else:
-                    self._last_returned_call_from_interceptors = (
-                        StreamStreamCallResponseIterator(
-                            self._last_returned_call_from_interceptors,
-                            call_or_response_iterator,
-                        )
-                    )
-                return self._last_returned_call_from_interceptors
-
-            registered_call_handle = _resolve_registered_call_handle(
-                self._channel,
-                method,
-                client_call_details.method,
-                self._registered_call_handle,
-            )
-
-            self._last_returned_call_from_interceptors = StreamStreamCall(
-                request_iterator,
-                _timeout_to_deadline(client_call_details.timeout),
-                client_call_details.metadata,
-                client_call_details.credentials,
-                client_call_details.wait_for_ready,
-                self._channel,
-                client_call_details.method,
-                request_serializer,
-                response_deserializer,
-                self._loop,
-                registered_call_handle,
-            )
-            return self._last_returned_call_from_interceptors
-
         client_call_details = ClientCallDetails(
             method, timeout, metadata, credentials, wait_for_ready
         )
-        return await _run_interceptor(
-            list(interceptors), client_call_details, request_iterator
+        return await self._run_interceptor(
+            list(interceptors),
+            method,
+            request_serializer,
+            response_deserializer,
+            client_call_details,
+            request_iterator,
         )
+
+    async def _run_interceptor(
+        self,
+        interceptors: List[StreamStreamClientInterceptor],
+        method: bytes,
+        request_serializer: Optional[SerializingFunction],
+        response_deserializer: Optional[DeserializingFunction],
+        client_call_details: ClientCallDetails,
+        request_iterator: RequestIterableType,
+    ) -> Union[StreamStreamCall, StreamStreamCallResponseIterator]:
+        if interceptors:
+            continuation = functools.partial(
+                self._run_interceptor,
+                interceptors[1:],
+                method,
+                request_serializer,
+                response_deserializer,
+            )
+
+            call_or_response_iterator = await interceptors[
+                0
+            ].intercept_stream_stream(
+                continuation, client_call_details, request_iterator
+            )
+
+            if isinstance(
+                call_or_response_iterator, _base_call.StreamStreamCall
+            ):
+                self._last_returned_call_from_interceptors = (
+                    call_or_response_iterator
+                )
+            else:
+                self._last_returned_call_from_interceptors = (
+                    StreamStreamCallResponseIterator(
+                        self._last_returned_call_from_interceptors,
+                        call_or_response_iterator,
+                    )
+                )
+            return self._last_returned_call_from_interceptors
+
+        registered_call_handle = _resolve_registered_call_handle(
+            self._channel,
+            method,
+            client_call_details.method,
+            self._registered_call_handle,
+        )
+
+        self._last_returned_call_from_interceptors = StreamStreamCall(
+            request_iterator,
+            _timeout_to_deadline(client_call_details.timeout),
+            client_call_details.metadata,
+            client_call_details.credentials,
+            client_call_details.wait_for_ready,
+            self._channel,
+            client_call_details.method,
+            request_serializer,
+            response_deserializer,
+            self._loop,
+            registered_call_handle,
+        )
+        return self._last_returned_call_from_interceptors
 
     def time_remaining(self) -> Optional[float]:
         raise NotImplementedError()

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -852,9 +852,7 @@ class InterceptedUnaryStreamCall(
 
             call_or_response_iterator = await interceptors[
                 0
-            ].intercept_unary_stream(
-                continuation, client_call_details, request
-            )
+            ].intercept_unary_stream(continuation, client_call_details, request)
 
             if isinstance(
                 call_or_response_iterator, _base_call.UnaryStreamCall


### PR DESCRIPTION
This PR is a precondition for enabling OpenTelemetry tracing for AsyncIO gRPC code base. It enables reference counting based garbage collection for two AsyncIO modules. 

1. `src/python/grpcio/grpc/aio/_interceptor.py` - every single interceptor type had an unlucky pattern as follows (simplified):
``` Python
async def _invoke(self, ...):
    async def _run_interceptor(interceptors, details, request):
        if interceptors:
            # call MYSELF for the next interceptor in the chain
            continuation = partial(_run_interceptor, interceptors[1::])
            return await interceptors[0].intercept(continuation, ...)
        return UnaryUnaryCall(..., self._channel, ...)

    return _run_interceptor(...)
```

Inner function whose closure cell points back at itself is a reference cycle. Therefore `_run_interceptor` cannot be garbage collected based on the reference counting.

Fix: Made `_run_interceptor` method of a class. Recursion is done via `self` pointer at call time. Mentioned fix mirrors sync Python stack.

2. `src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi` - https://github.com/grpc/grpc/pull/42503 introduced manual registration of calls via `done_callback` mechanism. Unlucky pattern as follows (simplified):
``` Python
class Call(...):
    ...
    # Call class owns _AioCall object from Cython layer
    _cython_call: cygrpc._AioCall
    ...

    def add_done_callback(self, callback):
        # pass MYSELF to the partial wrapper
        cb = partial(callback, self)
        # which is passed to the Cython layer
        self._cython_call.add_done_callback(cb)
```

For the above the circular path is as follows: `self (Call)` -> `_cython_call` -> `cb (partial wrapper)` -> `self (Call)`. Therefore `_done_callbacks` cannot be garbage collected based on the reference counting.

Fix: Manually reset the `_done_callback` list. Mentioned fix mirrors exactly the same pattern done for `_waiters_status` done couple of the lines above.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

