### PR TITLE
[core] Add GPR_UNREACHABLE_CODE to fix -Wreturn-type warnings

### DIFF
--- a/src/core/call/call_state.h
+++ b/src/core/call/call_state.h
@@ -158,6 +158,7 @@ class CallState {
       case ClientToServerPullState::kTerminated:
         return "Terminated";
     }
+    GPR_UNREACHABLE_CODE(return "Unknown");
   }
   template <typename Sink>
   friend void AbslStringify(Sink& out, ClientToServerPullState state) {
@@ -188,6 +189,7 @@ class CallState {
       case ClientToServerPushState::kFinished:
         return "Finished";
     }
+    GPR_UNREACHABLE_CODE(return "Unknown");
   }
   template <typename Sink>
   friend void AbslStringify(Sink& out, ClientToServerPushState state) {
@@ -241,6 +243,7 @@ class CallState {
       case ServerToClientPullState::kTerminated:
         return "Terminated";
     }
+    GPR_UNREACHABLE_CODE(return "Unknown");
   }
   template <typename Sink>
   friend void AbslStringify(Sink& out, ServerToClientPullState state) {
@@ -281,6 +284,7 @@ class CallState {
       case ServerToClientPushState::kFinished:
         return "Finished";
     }
+    GPR_UNREACHABLE_CODE(return "Unknown");
   }
   template <typename Sink>
   friend void AbslStringify(Sink& out, ServerToClientPushState state) {
@@ -311,6 +315,7 @@ class CallState {
       case ServerTrailingMetadataState::kPulledCancel:
         return "PulledCancel";
     }
+    GPR_UNREACHABLE_CODE(return "Unknown");
   }
   template <typename Sink>
   friend void AbslStringify(Sink& out, ServerTrailingMetadataState state) {

--- a/src/core/channelz/channelz.h
+++ b/src/core/channelz/channelz.h
@@ -183,6 +183,7 @@ class BaseNode : public DualRefCounted<BaseNode> {
       case EntityType::kMetricsDomainStorage:
         return "metrics_domain_storage";
     }
+    GPR_UNREACHABLE_CODE(return "unknown");
   }
 
   static std::optional<EntityType> KindToEntityType(absl::string_view kind) {

--- a/src/core/lib/promise/inter_activity_mutex.h
+++ b/src/core/lib/promise/inter_activity_mutex.h
@@ -307,6 +307,7 @@ class InterActivityMutex {
         case State::kMovedFrom:
           LOG(FATAL) << "Mutex acquirer already moved from";
       }
+      GPR_UNREACHABLE_CODE(return Pending{});
     }
 
    private:


### PR DESCRIPTION
Fixes #43115

This PR adds `GPR_UNREACHABLE_CODE` after switch statements in:
- `src/core/call/call_state.h`
- `src/core/channelz/channelz.h`
- `src/core/lib/promise/inter_activity_mutex.h`

This resolves the `-Wreturn-type` warnings when building with compilers/flags that don't deduce full enum coverage in those switches.