### PR TITLE
[core] Fix -Wtrigraphs warning in GRPC_FUNCTION_SIGNATURE

### DIFF
--- a/src/core/util/function_signature.h
+++ b/src/core/util/function_signature.h
@@ -31,9 +31,7 @@
 #elif defined(__GNUC__)
 #define GRPC_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
 #else
-#define GRPC_FUNCTION_SIGNATURE \
-  "??"                          \
-  "?()"
+#define GRPC_FUNCTION_SIGNATURE "??" "?()"
 #endif
 
 namespace grpc_core {


### PR DESCRIPTION
Fixes #43114

C++ trigraph replacement occurs in phase 1 of translation, before preprocessor conditional inclusion evaluates the `#else` block. Thus, GCC emits a warning for the `??(` sequence even when `__GNUC__` is defined and the block is discarded.

This breaks the trigraph sequence safely via string literal concatenation.