### PR TITLE
[Python] Fix SyncServicerContext abort not raising exception

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -306,7 +306,7 @@ cdef class _SyncServicerContext:
             self._context.abort(code, details, trailing_metadata),
             self._loop)
         # Abort should raise an AbortError
-        future.exception()
+        future.result()
 
     def send_initial_metadata(self, object metadata):
         future = asyncio.run_coroutine_threadsafe(

--- a/src/python/grpcio_tests/tests_aio/unit/abort_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/abort_test.py
@@ -76,7 +76,9 @@ class _GenericHandler(grpc.GenericRpcHandler):
         if handler_details.method == _UNARY_UNARY_ABORT:
             return grpc.unary_unary_rpc_method_handler(self._unary_unary_abort)
         if handler_details.method == _SYNC_UNARY_UNARY_ABORT:
-            return grpc.unary_unary_rpc_method_handler(self._sync_unary_unary_abort)
+            return grpc.unary_unary_rpc_method_handler(
+                self._sync_unary_unary_abort
+            )
         if handler_details.method == _SUPPRESS_ABORT:
             return grpc.unary_unary_rpc_method_handler(self._suppress_abort)
         if handler_details.method == _REPLACE_ABORT:

--- a/src/python/grpcio_tests/tests_aio/unit/abort_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/abort_test.py
@@ -25,6 +25,7 @@ from tests.unit.framework.common import test_constants
 from tests_aio.unit._test_base import AioTestBase
 
 _UNARY_UNARY_ABORT = "/test/UnaryUnaryAbort"
+_SYNC_UNARY_UNARY_ABORT = "/test/SyncUnaryUnaryAbort"
 _SUPPRESS_ABORT = "/test/SuppressAbort"
 _REPLACE_ABORT = "/test/ReplaceAbort"
 _ABORT_AFTER_REPLY = "/test/AbortAfterReply"
@@ -41,6 +42,11 @@ class _GenericHandler(grpc.GenericRpcHandler):
     @staticmethod
     async def _unary_unary_abort(unused_request, context):
         await context.abort(_ABORT_CODE, _ABORT_DETAILS)
+        raise RuntimeError("This line should not be executed")
+
+    @staticmethod
+    def _sync_unary_unary_abort(unused_request, context):
+        context.abort(_ABORT_CODE, _ABORT_DETAILS)
         raise RuntimeError("This line should not be executed")
 
     @staticmethod
@@ -69,6 +75,8 @@ class _GenericHandler(grpc.GenericRpcHandler):
     def service(self, handler_details):
         if handler_details.method == _UNARY_UNARY_ABORT:
             return grpc.unary_unary_rpc_method_handler(self._unary_unary_abort)
+        if handler_details.method == _SYNC_UNARY_UNARY_ABORT:
+            return grpc.unary_unary_rpc_method_handler(self._sync_unary_unary_abort)
         if handler_details.method == _SUPPRESS_ABORT:
             return grpc.unary_unary_rpc_method_handler(self._suppress_abort)
         if handler_details.method == _REPLACE_ABORT:
@@ -96,6 +104,20 @@ class TestAbort(AioTestBase):
 
     async def test_unary_unary_abort(self):
         method = self._channel.unary_unary(_UNARY_UNARY_ABORT)
+        call = method(_REQUEST)
+
+        self.assertEqual(_ABORT_CODE, await call.code())
+        self.assertEqual(_ABORT_DETAILS, await call.details())
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+
+        rpc_error = exception_context.exception
+        self.assertEqual(_ABORT_CODE, rpc_error.code())
+        self.assertEqual(_ABORT_DETAILS, rpc_error.details())
+
+    async def test_sync_unary_unary_abort(self):
+        method = self._channel.unary_unary(_SYNC_UNARY_UNARY_ABORT)
         call = method(_REQUEST)
 
         self.assertEqual(_ABORT_CODE, await call.code())

--- a/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/compatibility_test.py
@@ -258,9 +258,12 @@ class TestCompatibility(AioTestBase):
         )
 
     async def test_sync_unary_unary_abort(self):
+        seen = []
+
         @grpc.unary_unary_rpc_method_handler
         def abort_unary_unary(request: bytes, context: grpc.ServicerContext):
             context.abort(grpc.StatusCode.INTERNAL, "Test")
+            seen.append("after_abort")
 
         self._adhoc_handlers.set_adhoc_handler(abort_unary_unary)
         with self.assertRaises(aio.AioRpcError) as exception_context:
@@ -270,6 +273,7 @@ class TestCompatibility(AioTestBase):
         self.assertEqual(
             grpc.StatusCode.INTERNAL, exception_context.exception.code()
         )
+        self.assertEqual([], seen)
 
     async def test_sync_unary_unary_set_code(self):
         @grpc.unary_unary_rpc_method_handler


### PR DESCRIPTION
Fixes #37518

### Description
When `context.abort()` is called within a synchronous handler inside an AsyncIO server (`_SyncServicerContext.abort`), it incorrectly calls `future.exception()` which merely returns the exception instead of raising it. This prevents the execution of the thread pool handler from halting, causing unintended continued execution of user code post-abort.

This PR fixes the issue by using `future.result()`, correctly re-raising the `AbortError` in the synchronous thread. This halts execution and successfully routes the `AbortError` through the `_handle_exceptions` flow. A regression test for this specific scenario has been added to the AsyncIO unit tests suite.