### PR TITLE
[AI] Add repository-level Python and Shell authoring guides

### DIFF
--- a/.agents/rules/python_authoring_guide.md
+++ b/.agents/rules/python_authoring_guide.md
@@ -18,7 +18,7 @@ Adhere strictly to the [Google Python Style Guide](https://raw.githubusercontent
 ## 2. Code Formatting, Linting & Static Analysis
 
 *   **Mandatory Tool Execution**: Strictly execute configured formatters, linters, and type checkers (e.g., `black`, `ruff`, `pyright`, `isort`) on modified Python source files prior to committing or finalizing changes.
-*   **Line Limits & Indentation**: Enforce 80-character line length limit and use 4 spaces per indentation level.
+*   **Line Limits & Indentation**: Enforce 80-character line length limit and use 4 spaces per indentation level. Exemptions include long import statements, URLs/paths in comments, and module-level constants.
 *   **Virtual Environment Tool Execution**: Prefer direct binary invocation (`./.venv/bin/<tool>`) over global paths; avoid subshell chaining (`source .venv/bin/activate`).
 *   **Package Management**: Prefer `uv pip` over `./.venv/bin/pip` if `uv` is used or available.
 *   **Tool Fallback Strategy**: Verify binary exists in `.venv/bin/` before execution; fallback to global `which <tool>` if absent.
@@ -34,7 +34,7 @@ Adhere strictly to the [Google Python Style Guide](https://raw.githubusercontent
 
 ## 4. Type Annotations & Parameter Defaults
 
-*   **Modern Specific Type Annotations**: Prefer native PEP 604 unions and built-in generic collections (`str | None`, `list[str]`, `dict[str, int]`) over generic `object` or legacy typing constructs (`Optional[str]`, `List[str]`).
+*   **Modern Specific Type Annotations**: Prefer native PEP 604 unions and built-in generic collections (`str | None`, `list[str]`, `dict[str, int]`) over generic `object` or legacy typing constructs (`Optional[str]`, `List[str]`). Prefer abstract container types (`Sequence`, `Iterable`, `Mapping`) over concrete ones (`list`, `dict`) for function parameters.
 *   **Immutable Static Defaults**: Prohibit binding mutable containers (`{}`, `[]`) as static parameter defaults; strictly assign `None` with lazy in-body initialization (`if items is None: items = []`).
 *   **Dynamic Runtime Stream Binding**: Prohibit binding system stream attributes (`sys.stdout`, `sys.stderr`) as static parameter defaults; strictly assign `None` and resolve stream objects dynamically inside function bodies.
 

--- a/.agents/rules/python_authoring_guide.md
+++ b/.agents/rules/python_authoring_guide.md
@@ -1,0 +1,63 @@
+---
+trigger: glob
+globs: "*.py"
+---
+
+<python_authoring_safeguards>
+
+# Python Code Authoring & Formatting Guidelines (Google Style)
+
+Adhere strictly to the [Google Python Style Guide](https://raw.githubusercontent.com/google/styleguide/refs/heads/gh-pages/pyguide.md) across all Python source code modifications:
+
+## 1. Imports & Module Organization
+
+*   **Module & Package Imports**: Import modules and packages exclusively (`import sys`, `from urllib import parse`); prohibit importing individual domain functions or classes directly.
+*   **Typing Symbol Exemptions**: Permit importing individual symbols strictly from static analysis modules (`from typing import Any, TextIO`, `from collections.abc import Callable, Iterable`, `from typing_extensions import override, TypeAlias`).
+*   **No Relative Imports**: Enforce full absolute package paths (`from grpc.tools import bloat`); prohibit relative imports (`from . import bloat`).
+
+## 2. Code Formatting, Linting & Static Analysis
+
+*   **Mandatory Tool Execution**: Strictly execute configured formatters, linters, and type checkers (e.g., `black`, `ruff`, `pyright`, `isort`) on modified Python source files prior to committing or finalizing changes.
+*   **Line Limits & Indentation**: Enforce 80-character line length limit and use 4 spaces per indentation level.
+*   **Virtual Environment Tool Execution**: Prefer direct binary invocation (`./.venv/bin/<tool>`) over global paths or `npx`; avoid subshell chaining (`source .venv/bin/activate`).
+*   **Package Management**: Prefer `uv pip` over `./.venv/bin/pip` if `uv` is used or available.
+*   **Tool Fallback Strategy**: Verify binary exists in `.venv/bin/` before execution; fallback to global `which <tool>` if absent.
+*   **Tool Installation**: Prompt user to install needed tools using `VIRTUAL_ENV=.venv uv pip install <tool>==<version>`.
+*   **Version Discovery**: Inspect `tools/distrib/*.sh` (e.g., `tools/distrib/pyright_code.sh`) to determine required tool versions.
+*   **Respect Project Tool Settings**: Inspect workspace settings (`.code-workspace`) and project configuration files (`grpc-style-config.toml`, `pyproject.toml`); pass explicit `--config` flags when executing tooling.
+*   **Native f-String Formatting**: Prefer f-strings and format specifiers (`f"{msg:#^{width}}"`) over string methods or general `%` formatting.
+*   **Lazy Logging Interpolation**: Prohibit f-strings and `.format()` in logging invocations (`logging.info(f"...")`); strictly pass positional `%` format placeholders (`logging.info("Value: %s", val)`).
+
+## 3. System Operations & Subprocess Execution
+
+*   **Prefer `pathlib.Path`**: Prefer `pathlib.Path` for filesystem operations (directory creation, path resolution, globbing) over spawning shell subprocesses (`mkdir`, `rm`) or manual path string manipulation via `os.path`.
+
+## 4. Type Annotations & Parameter Defaults
+
+*   **Modern Specific Type Annotations**: Prefer native PEP 604 unions and built-in generic collections (`str | None`, `list[str]`, `dict[str, int]`) over generic `object` or legacy typing constructs (`Optional[str]`, `List[str]`).
+*   **Immutable Static Defaults**: Prohibit binding mutable containers (`{}`, `[]`) as static parameter defaults; strictly assign `None` with lazy in-body initialization (`if items is None: items = []`).
+*   **Dynamic Runtime Stream Binding**: Prohibit binding system stream attributes (`sys.stdout`, `sys.stderr`) as static parameter defaults; strictly assign `None` and resolve stream objects dynamically inside function bodies.
+
+## 5. Exception & Cleanup Safety
+
+*   **Catch Specific Exception Types**: Prefer narrow exception types (`subprocess.CalledProcessError`) over broad `Exception` or bare `except:`.
+*   **Robust Cleanup Blocks**: Strictly handle secondary errors within `finally` cleanup blocks without overriding primary exceptions or `SystemExit` codes.
+
+## 6. Docstrings & Documentation Syntax
+
+*   **Google Docstring Syntax**: Enforce Google-style docstrings (`Args:`, `Returns:`, `Raises:`, `Yields:`) with 2-space indented descriptions for non-trivial functions; prohibit legacy reStructuredText tags (`:param x:`).
+*   **Prohibit Type Duplication**: Prohibit repeating parameter or return types inside docstring descriptions when static type annotations already exist in the function signature.
+
+## 7. Control Flow & Boolean Evaluations
+
+*   **Implicit Boolean Evaluations**: Enforce implicit truth evaluations for containers and strings (`if not items:`, `if name:`); prohibit verbose length or equality comparisons (`if len(items) == 0:`, `if name != "":`).
+*   **Singleton Identity Checks**: Strictly evaluate singletons via identity operators (`if obj is None:`); prohibit equality operators (`if obj == None:`).
+*   **Comprehension Complexity Limits**: Restrict list, dict, and set comprehensions to a single `for` clause and a single simple `if` condition; convert multi-clause expressions into explicit `for` loops.
+
+## 8. Resource Management & State Architecture
+
+*   **Mandatory Resource Contexts**: Strictly manage stateful resources (files, sockets, transactions) inside explicit context managers (`with open(...) as f:`); prohibit manual `.close()` lifecycle calls.
+*   **Prohibit Mutable Global State**: Prohibit defining module-level mutable containers or class attributes that mutate at runtime; encapsulate state within instantiated objects or dedicated caching mechanisms.
+*   **Internal Attribute Naming**: Enforce a single leading underscore for internal class attributes and helper methods (`_internal_method()`, `self._cache`); prohibit double-underscore name mangling (`__private`) unless avoiding subclass collisions in third-party frameworks.
+
+</python_authoring_safeguards>

--- a/.agents/rules/python_authoring_guide.md
+++ b/.agents/rules/python_authoring_guide.md
@@ -19,7 +19,7 @@ Adhere strictly to the [Google Python Style Guide](https://raw.githubusercontent
 
 *   **Mandatory Tool Execution**: Strictly execute configured formatters, linters, and type checkers (e.g., `black`, `ruff`, `pyright`, `isort`) on modified Python source files prior to committing or finalizing changes.
 *   **Line Limits & Indentation**: Enforce 80-character line length limit and use 4 spaces per indentation level.
-*   **Virtual Environment Tool Execution**: Prefer direct binary invocation (`./.venv/bin/<tool>`) over global paths or `npx`; avoid subshell chaining (`source .venv/bin/activate`).
+*   **Virtual Environment Tool Execution**: Prefer direct binary invocation (`./.venv/bin/<tool>`) over global paths; avoid subshell chaining (`source .venv/bin/activate`).
 *   **Package Management**: Prefer `uv pip` over `./.venv/bin/pip` if `uv` is used or available.
 *   **Tool Fallback Strategy**: Verify binary exists in `.venv/bin/` before execution; fallback to global `which <tool>` if absent.
 *   **Tool Installation**: Prompt user to install needed tools using `VIRTUAL_ENV=.venv uv pip install <tool>==<version>`.

--- a/.agents/rules/shell_authoring_guide.md
+++ b/.agents/rules/shell_authoring_guide.md
@@ -29,7 +29,7 @@ Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.
 ## 3. Code Formatting & Control Flow Syntax
 
 *   **Indentation & Line Limits**: Indent 2 spaces with no tabs (except `<<-` here-docs). Enforce 80-character line length limit; use here-docs or embedded newlines for long strings.
-*   **Pipeline Splitting**: Fit short pipelines on one line; split long pipelines one segment per line with trailing line continuation `\` and 2-space indented pipes (`command1 \\\n  | command2`).
+*   **Pipeline Splitting**: Fit short pipelines on one line; split long pipelines one segment per line. Prefer placing operators (`|`, `||`, `&&`) at the end of the line (automatic continuation) over trailing backslash `\` continuation. Both styles are acceptable.
 *   **Control Flow Formatting**: Place `; then` and `; do` on the same line as header (`if`, `for`, `while`, `until`, `select`). Keep `else`, `fi`, and `done` on dedicated lines. Explicitly iterate positional parameters (`for arg in "$@"; do`).
 *   **Case Statement Formatting**: Indent patterns by 2 spaces and actions by 4 spaces. Prohibit leading pattern parenthesis `(` and fallthrough operators (`;&`, `;;&`).
 

--- a/.agents/rules/shell_authoring_guide.md
+++ b/.agents/rules/shell_authoring_guide.md
@@ -9,6 +9,8 @@ globs: "*.sh, *.bash"
 
 Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.com/google/styleguide/refs/heads/gh-pages/shellguide.md) when authoring or modifying shell script files (*.sh, *.bash); does NOT apply to inline terminal execution commands run directly by the agent:
 
+*   **Consistency**: Stay consistent with existing code style and conventions in the file being modified.
+
 ## 1. Executable Shells & Interpreter Invocation
 
 *   **Executable Interpreter**: Prefer `#!/usr/bin/env bash` over fixed path `#!/bin/bash` for new executable scripts; preserve existing shebangs in modified files. Set execution flags in-body (`set -euo pipefail`).
@@ -56,7 +58,7 @@ Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.
 ## 7. Naming Conventions & Functions
 
 *   **Naming Conventions**: Enforce snake_case for functions and variables (`my_func`, `my_var`); use `::` for package namespaces (`pkg::my_func`).
-*   **Function Syntax & Docstrings**: Place opening brace on declaration line without space (`func() {`). Write header comments documenting `Globals:`, `Arguments:`, `Outputs:`, and `Returns:`.
+*   **Function Syntax & Docstrings**: Place opening brace on declaration line without space (`func() {`). Write header comments explicitly documenting `Globals:`, `Arguments:`, `Outputs:`, and `Returns:`.
 *   **Script Main Entry Point**: Encapsulate executable script logic in a `main` function placed as the final function; conclude file with `main "$@"`.
 *   **Return Code Verification**: Verify command exit status (`if ! cmd; then`, `(( $? == 0 ))`). Inspect `PIPESTATUS` for pipeline stages (`return_codes=("${PIPESTATUS[@]}")`).
 

--- a/.agents/rules/shell_authoring_guide.md
+++ b/.agents/rules/shell_authoring_guide.md
@@ -21,7 +21,7 @@ Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.
 ## 2. Environment & Stream Redirection
 
 *   **Error Stream Routing**: Route error and status messages exclusively to `STDERR` (`err() { echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2; }`).
-*   **Combined Redirection & Piping (`&>` and `|&`)**: Mandate `&>` over `> file 2>&1` or `> /dev/null 2>&1` (`cmd &> file`, `cmd &> /dev/null`) and `|&` over `2>&1 |` (`cmd1 |& cmd2`) when redirecting or piping stdout and stderr together in Bash scripts. Prohibit explicit fd duplication (`2>&1`). Single-stream redirections (e.g., `2>/dev/null`) remain unaffected.
+*   **Combined Redirection & Piping (`&>` and `|&`)**: Prefer `&>` over `> file 2>&1` or `> /dev/null 2>&1` (`cmd &> file`, `cmd &> /dev/null`) and `|&` over `2>&1 |` (`cmd1 |& cmd2`) when redirecting or piping stdout and stderr together in Bash scripts. Avoid explicit fd duplication (`2>&1`) unless required for specific ordering or command substitution capturing. Single-stream redirections (e.g., `2>/dev/null`) remain unaffected.
 *   **Quoted Here-Document Delimiters**: Enforce quoted here-doc delimiters (`<<'EOF'`) when emitting or generating scripts containing literal shell variables to prevent unintended expansion.
 
 ## 3. Code Formatting & Control Flow Syntax
@@ -41,7 +41,7 @@ Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.
 ## 5. Shell Features, Tests & `set -e` Traps
 
 *   **Mandatory ShellCheck**: Verify scripts with `shellcheck` to catch syntax defects, security risks, and portability warnings prior to finalizing changes.
-*   **`set -e` Arithmetic Safety**: Prohibit standalone post-increments (`(( i++ ))`) or zero-evaluating arithmetic expressions under `set -e`; use explicit assignment (`(( i += 1 ))` or `i=$(( i + 1 ))`).
+*   **`set -e` Arithmetic Safety**: Avoid standalone `(( ... ))` statements, especially with `set -e`; use standard assignment `i=$(( i + 1 ))` or append `|| true` to prevent zero-evaluation exits.
 *   **Conditional Evaluation & RHS Patterns**: Prefer `[[ ... ]]` over `[ ... ]` or `test`. Enforce explicit `-z` / `-n` string tests, `==` equality, and `(( ... ))` for numeric checks. Leave RHS unquoted for regex/glob matching (`[[ $v =~ ^[0-9]+$ ]]`, `[[ $v == f* ]]`); prohibit quoting RHS unless matching literal string.
 *   **Wildcard Filename Expansion**: Enforce explicit relative path prefixes (`./*`) during wildcard expansion to prevent hyphenated filenames from parsing as options.
 *   **Prohibit `eval` & Aliases**: Prohibit `eval` and script aliases; use functions and arrays exclusively.

--- a/.agents/rules/shell_authoring_guide.md
+++ b/.agents/rules/shell_authoring_guide.md
@@ -1,0 +1,63 @@
+---
+trigger: glob
+globs: "*.sh, *.bash"
+---
+
+<shell_authoring_safeguards>
+
+# Shell Code Authoring & Formatting Guidelines (Google Style)
+
+Adhere strictly to the [Google Shell Style Guide](https://raw.githubusercontent.com/google/styleguide/refs/heads/gh-pages/shellguide.md) when authoring or modifying shell script files (*.sh, *.bash); does NOT apply to inline terminal execution commands run directly by the agent:
+
+## 1. Executable Shells & Interpreter Invocation
+
+*   **Executable Interpreter**: Prefer `#!/usr/bin/env bash` over fixed path `#!/bin/bash` for new executable scripts; preserve existing shebangs in modified files. Set execution flags in-body (`set -euo pipefail`).
+*   **Trace Prompt Formatting (`PS4`)**: Recommend setting `PS4='+ \D{[%H:%M:%S %Z]}\011 '` when enabling execution tracing (`set -x`).
+*   **Trace Secret Leak Safeguards**: Mandate verifying no sensitive data (access/identity tokens, bearer headers, API credentials) is logged when execution tracing (`set -x`) or verbose output (`curl -v`, `gcloud auth print-access-token`) is enabled; disable tracing (`set +x`) around credential commands or avoid tracing altogether by using alternative approaches.
+*   **File Extensions**: Omit extensions for `PATH` executables; use `.sh` for build targets and standalone scripts. Enforce `.sh` and non-executable status (`chmod -x`) for libraries.
+*   **Forbidden SUID/SGID**: Prohibit SUID/SGID flags on shell scripts; execute with `sudo` for elevated access.
+*   **Language Scope Limits**: Restrict shell usage to small utilities or wrappers (<100 lines); rewrite scripts exceeding 100 lines or complex control flow in a structured language (e.g., Python).
+
+## 2. Environment & Stream Redirection
+
+*   **Error Stream Routing**: Route error and status messages exclusively to `STDERR` (`err() { echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2; }`).
+*   **Combined Redirection & Piping (`&>` and `|&`)**: Mandate `&>` over `> file 2>&1` or `> /dev/null 2>&1` (`cmd &> file`, `cmd &> /dev/null`) and `|&` over `2>&1 |` (`cmd1 |& cmd2`) when redirecting or piping stdout and stderr together in Bash scripts. Prohibit explicit fd duplication (`2>&1`). Single-stream redirections (e.g., `2>/dev/null`) remain unaffected.
+*   **Quoted Here-Document Delimiters**: Enforce quoted here-doc delimiters (`<<'EOF'`) when emitting or generating scripts containing literal shell variables to prevent unintended expansion.
+
+## 3. Code Formatting & Control Flow Syntax
+
+*   **Indentation & Line Limits**: Indent 2 spaces with no tabs (except `<<-` here-docs). Enforce 80-character line length limit; use here-docs or embedded newlines for long strings.
+*   **Pipeline Splitting**: Fit short pipelines on one line; split long pipelines one segment per line with trailing line continuation `\` and 2-space indented pipes (`command1 \\\n  | command2`).
+*   **Control Flow Formatting**: Place `; then` and `; do` on the same line as header (`if`, `for`, `while`, `until`, `select`). Keep `else`, `fi`, and `done` on dedicated lines. Explicitly iterate positional parameters (`for arg in "$@"; do`).
+*   **Case Statement Formatting**: Indent patterns by 2 spaces and actions by 4 spaces. Prohibit leading pattern parenthesis `(` and fallthrough operators (`;&`, `;;&`).
+
+## 4. Variables, Quoting & Expansion
+
+*   **Variable Expansion**: Prefer brace-delimited `"${var}"` over `"$var"`. Omit braces on single-character shell specials and positional parameters (`$1`, `$@`, `$#`, `$?`, `$$`) unless preventing ambiguity (`"${1}0"`).
+*   **String Quoting Discipline**: Quote variables, command substitutions, spaces, and meta-characters. Use `"$@"` for passing positional parameters intact; prohibit quoting literal integer assignments.
+*   **Function Local Variables**: Declare function variables with `local`. Separate local declaration from command substitution assignment (`local var; var="$(cmd)"`) to avoid masking exit status (`$?`).
+*   **Constants & Exports**: Capitalize environment variables and constants (`readonly PATH_TO_FILES='/path'`, `export VAR`). Declare constants at file top and apply `readonly` immediately after assignment.
+
+## 5. Shell Features, Tests & `set -e` Traps
+
+*   **Mandatory ShellCheck**: Verify scripts with `shellcheck` to catch syntax defects, security risks, and portability warnings prior to finalizing changes.
+*   **`set -e` Arithmetic Safety**: Prohibit standalone post-increments (`(( i++ ))`) or zero-evaluating arithmetic expressions under `set -e`; use explicit assignment (`(( i += 1 ))` or `i=$(( i + 1 ))`).
+*   **Conditional Evaluation & RHS Patterns**: Prefer `[[ ... ]]` over `[ ... ]` or `test`. Enforce explicit `-z` / `-n` string tests, `==` equality, and `(( ... ))` for numeric checks. Leave RHS unquoted for regex/glob matching (`[[ $v =~ ^[0-9]+$ ]]`, `[[ $v == f* ]]`); prohibit quoting RHS unless matching literal string.
+*   **Wildcard Filename Expansion**: Enforce explicit relative path prefixes (`./*`) during wildcard expansion to prevent hyphenated filenames from parsing as options.
+*   **Prohibit `eval` & Aliases**: Prohibit `eval` and script aliases; use functions and arrays exclusively.
+*   **Arrays & Process Substitution**: Use arrays (`declare -a flags`) for parameter lists. Prefer process substitution (`while read -r line; do ...; done < <(cmd)`) or `readarray` over piped `while` loops to avoid subshell state loss.
+
+## 6. Builtin Commands & Parameter Expansions
+
+*   **Builtins over External Subprocesses**: Prefer shell builtins over external utility processes (`sed`, `awk`, `cut`, `expr`, `grep`).
+*   **Native Parameter Expansions**: Use built-in string expansions for parsing and manipulation (`${var#prefix}`, `${var##*glob}`, `${var%suffix}`, `${var%%suffix*}`), replacement (`${var//pattern/replace}`), and default assignment (`${var:=default}`).
+*   **Regex Match Arrays**: Use `${BASH_REMATCH[1]}` for regex capture extraction after `[[ $var =~ pattern ]]` evaluation.
+
+## 7. Naming Conventions & Functions
+
+*   **Naming Conventions**: Enforce snake_case for functions and variables (`my_func`, `my_var`); use `::` for package namespaces (`pkg::my_func`).
+*   **Function Syntax & Docstrings**: Place opening brace on declaration line without space (`func() {`). Write header comments documenting `Globals:`, `Arguments:`, `Outputs:`, and `Returns:`.
+*   **Script Main Entry Point**: Encapsulate executable script logic in a `main` function placed as the final function; conclude file with `main "$@"`.
+*   **Return Code Verification**: Verify command exit status (`if ! cmd; then`, `(( $? == 0 ))`). Inspect `PIPESTATUS` for pipeline stages (`return_codes=("${PIPESTATUS[@]}")`).
+
+</shell_authoring_safeguards>


### PR DESCRIPTION
Contributes modular rule files to `.agents/rules/` to guide agents when working on Python and Shell scripts in this repository.

1. `python_authoring_guide.md`: Enforces [Google Python Style](https://google.github.io/styleguide/pyguide.html), 80-char line limit, 4-space indents, and `uv`/`.venv` best practices.
2. `shell_authoring_guide.md`: Enforces [Google Shell Style](https://google.github.io/styleguide/shellguide.html) (Bash), 80-char line limit, and safe redirection/piping practices.

Both are configured to trigger automatically via `glob` when relevant files are open.

*_Note: This PR was initially drafted with AI assistance, then carefully reviewed, refined, and tested through human engineer iteration._*
