### PR TITLE
[examples/cpp] Fix wait_for_ready CMake syntax

### DIFF
--- a/examples/cpp/wait_for_ready/CMakeLists.txt
+++ b/examples/cpp/wait_for_ready/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(hw_grpc_proto
 
 # Targets greeter_[async_](client|server)
 foreach(_target
-  greeter_callback_client greeter_callback_server
+  greeter_callback_client)
   add_executable(${_target} "${_target}.cc")
   target_link_libraries(${_target}
     hw_grpc_proto


### PR DESCRIPTION
An unterminated CMake target loop prevents `wait_for_ready` configuration and names a server target with no source file.

Fix the unterminated target list and remove `greeter_callback_server`, which has no source file.
