### PR TITLE
[cmake] Export Windows DLL import macros via CMake INTERFACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2145,6 +2145,8 @@ if(WIN32 AND MSVC)
     target_compile_definitions(gpr
     PRIVATE
       "GPR_DLL_EXPORTS"
+    INTERFACE
+      "GPR_DLL_IMPORTS"
     )
   endif()
   if(gRPC_INSTALL)
@@ -3182,6 +3184,8 @@ if(WIN32 AND MSVC)
     PRIVATE
       "GRPC_DLL_EXPORTS"
       "GPR_DLL_IMPORTS"
+    INTERFACE
+      "GRPC_DLL_IMPORTS"
     )
   endif()
   if(gRPC_INSTALL)
@@ -3926,6 +3930,8 @@ if(WIN32 AND MSVC)
     PRIVATE
       "GRPC_DLL_EXPORTS"
       "GPR_DLL_IMPORTS"
+    INTERFACE
+      "GRPC_DLL_IMPORTS"
     )
   endif()
   if(gRPC_INSTALL)
@@ -5038,6 +5044,8 @@ if(WIN32 AND MSVC)
       "GRPCXX_DLL_EXPORTS"
       "GPR_DLL_IMPORTS"
       "GRPC_DLL_IMPORTS"
+    INTERFACE
+      "GRPCXX_DLL_IMPORTS"
     )
   endif()
   if(gRPC_INSTALL)
@@ -5786,6 +5794,8 @@ if(WIN32 AND MSVC)
       "GRPCXX_DLL_EXPORTS"
       "GPR_DLL_IMPORTS"
       "GRPC_DLL_IMPORTS"
+    INTERFACE
+      "GRPCXX_DLL_IMPORTS"
     )
   endif()
   if(gRPC_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56107,6 +56107,16 @@ function(generate_pkgconfig name description version requires requires_private
   set(PC_REQUIRES_PRIVATE "${requires_private}")
   set(PC_LIB "${libs}")
   set(PC_LIBS_PRIVATE "${libs_private}")
+  set(PC_CFLAGS "")
+  if(WIN32 AND BUILD_SHARED_LIBS)
+    if(name STREQUAL "gpr")
+      set(PC_CFLAGS "-DGPR_DLL_IMPORTS")
+    elseif(name STREQUAL "gRPC" OR name STREQUAL "gRPC unsecure")
+      set(PC_CFLAGS "-DGRPC_DLL_IMPORTS -DGPR_DLL_IMPORTS")
+    elseif(name MATCHES "^gRPC\\+\\+")
+      set(PC_CFLAGS "-DGRPCXX_DLL_IMPORTS -DGRPC_DLL_IMPORTS -DGPR_DLL_IMPORTS")
+    endif()
+  endif()
   set(output_filepath "${grpc_BINARY_DIR}/libs/opt/pkgconfig/${output_filename}")
   configure_file(
     "${grpc_SOURCE_DIR}/cmake/pkg-config-template.pc.in"

--- a/cmake/pkg-config-template.pc.in
+++ b/cmake/pkg-config-template.pc.in
@@ -6,7 +6,7 @@ libdir=${exec_prefix}/@gRPC_INSTALL_LIBDIR@
 Name: @PC_NAME@
 Description: @PC_DESCRIPTION@
 Version: @PC_VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @PC_CFLAGS@
 Requires: @PC_REQUIRES@
 Requires.private: @PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} @PC_LIB@

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -877,27 +877,39 @@
     set_target_properties(${lib.name} PROPERTIES COMPILE_PDB_NAME "${lib.name}"
       COMPILE_PDB_OUTPUT_DIRECTORY <%text>"${CMAKE_BINARY_DIR}</%text>"
     )<%
-    dll_annotations = []
+    private_dll_annotations = []
+    interface_dll_annotations = []
     if lib.name in gpr_libs:
-      dll_annotations.append("GPR_DLL_EXPORTS")
+      private_dll_annotations.append("GPR_DLL_EXPORTS")
+      interface_dll_annotations.append("GPR_DLL_IMPORTS")
     if lib.name in grpc_libs:
-      dll_annotations.append("GRPC_DLL_EXPORTS")
+      private_dll_annotations.append("GRPC_DLL_EXPORTS")
+      interface_dll_annotations.append("GRPC_DLL_IMPORTS")
     if lib.name in grpcxx_libs:
-      dll_annotations.append("GRPCXX_DLL_EXPORTS")
+      private_dll_annotations.append("GRPCXX_DLL_EXPORTS")
+      interface_dll_annotations.append("GRPCXX_DLL_IMPORTS")
     if set(gpr_libs) & set(lib.transitive_deps):
-      dll_annotations.append("GPR_DLL_IMPORTS")
+      private_dll_annotations.append("GPR_DLL_IMPORTS")
     if set(grpc_libs) & set(lib.transitive_deps):
-      dll_annotations.append("GRPC_DLL_IMPORTS")
+      private_dll_annotations.append("GRPC_DLL_IMPORTS")
     if set(grpcxx_libs) & set(lib.transitive_deps):
-      dll_annotations.append("GRPCXX_DLL_IMPORTS")
+      private_dll_annotations.append("GRPCXX_DLL_IMPORTS")
     %>
-    % if dll_annotations:
+    % if private_dll_annotations or interface_dll_annotations:
     if(BUILD_SHARED_LIBS)
       target_compile_definitions(${lib.name}
+    % if private_dll_annotations:
       PRIVATE
-    % for definition in dll_annotations:
+    % for definition in private_dll_annotations:
         "${definition}"
     % endfor
+    % endif
+    % if interface_dll_annotations:
+      INTERFACE
+    % for definition in interface_dll_annotations:
+        "${definition}"
+    % endfor
+    % endif
       )
     endif()
     % endif

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -1122,6 +1122,16 @@
     set(PC_REQUIRES_PRIVATE "<%text>${requires_private}</%text>")
     set(PC_LIB "<%text>${libs}</%text>")
     set(PC_LIBS_PRIVATE "<%text>${libs_private}</%text>")
+    set(PC_CFLAGS "")
+    if(WIN32 AND BUILD_SHARED_LIBS)
+      if(name STREQUAL "gpr")
+        set(PC_CFLAGS "-DGPR_DLL_IMPORTS")
+      elseif(name STREQUAL "gRPC" OR name STREQUAL "gRPC unsecure")
+        set(PC_CFLAGS "-DGRPC_DLL_IMPORTS -DGPR_DLL_IMPORTS")
+      elseif(name MATCHES "^gRPC\\+\\+")
+        set(PC_CFLAGS "-DGRPCXX_DLL_IMPORTS -DGRPC_DLL_IMPORTS -DGPR_DLL_IMPORTS")
+      endif()
+    endif()
     set(output_filepath "<%text>${grpc_BINARY_DIR}/libs/opt/pkgconfig/${output_filename}</%text>")
     configure_file(
       "<%text>${grpc_SOURCE_DIR}/cmake/pkg-config-template.pc.in</%text>"

--- a/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
@@ -78,11 +78,6 @@ popd
 @rem folders, like the following command trying to imitate.
 git submodule foreach bash -c "cd $toplevel; rm -rf $name"
 
-@rem TODO(dawidcha): Remove this once this DLL test can pass {
-echo Skipped!
-exit /b 0
-@rem TODO(dawidcha): Remove this once this DLL test can pass }
-
 @rem Install gRPC
 @rem NOTE(jtattermusch): The -DProtobuf_USE_STATIC_LIBS=ON is necessary on cmake3.16+
 @rem since by default "find_package(Protobuf ...)" uses the cmake's builtin


### PR DESCRIPTION
Fixes #37836 by separating PRIVATE compile definitions (used during internal compilation) from INTERFACE compile definitions (exported via gRPCTargets.cmake to consumers). This ensures external projects consuming shared library builds on Windows MSVC properly receive GPR_DLL_IMPORTS, GRPC_DLL_IMPORTS, and GRPCXX_DLL_IMPORTS.