### PR TITLE
Extend experiments

### DIFF
--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -58,12 +58,12 @@
   allow_in_fuzzing_config: false
 - name: call_tracer_send_initial_metadata_is_an_annotation
   description: Use the new annotation-based CallTracer API.
-  expiry: 2026/08/01
+  expiry: 2026/10/01
   owner: aadik@google.com
   test_tags: []
 - name: call_tracer_send_trailing_metadata_is_an_annotation
   description: Use the new annotation-based CallTracer API.
-  expiry: 2026/08/01
+  expiry: 2026/10/01
   owner: aadik@google.com
   test_tags: []
 - name: callv3_batch_validation
@@ -259,7 +259,7 @@
   test_tags: []
 - name: otel_export_telemetry_domains
   description: Export telemetry domains in OpenTelemetry metrics.
-  expiry: 2026/08/01
+  expiry: 2026/10/01
   owner: aadik@google.com
   test_tags: [core_end2end_test]
 - name: ph2_client


### PR DESCRIPTION
Extend call tracer and otel domains experiments to end of September to allow for the required changes to be made before the experiments can be removed.

