### PR TITLE
Fix truncation bug in channelz::TextEncode() large-message fallback

### DIFF
--- a/src/core/channelz/text_encode.cc
+++ b/src/core/channelz/text_encode.cc
@@ -57,13 +57,14 @@ std::string TextEncode(upb_Message* message,
   size_t size = upb_TextEncode(message, def, def_pool, 0, buf, sizeof(buf));
   if (size < sizeof(buf)) return std::string(buf, size);
   // upb_TextEncode has snprintf() semantics: it always NUL-terminates
-  // within the given capacity, so writing `size` content bytes requires
-  // a capacity of `size + 1`. std::string guarantees a valid, writable
-  // null-terminator slot at result.data()[size] (C++17), so this avoids
-  // both the raw new[]/delete[] and the previous one-byte-short capacity
-  // that silently truncated the final character of the encoded text.
-  std::string result(size, '\0');
-  upb_TextEncode(message, def, def_pool, 0, result.data(), size + 1);
+  // within the given capacity, so writing size content bytes requires
+  // a capacity of size + 1. We allocate size + 1 bytes in the string,
+  // let upb_TextEncode write the content and the NUL terminator, and then
+  // resize the string back to size to remove the NUL terminator from the
+  // string's active length.
+  std::string result(size + 1, '\0');
+  upb_TextEncode(message, def, def_pool, 0, result.data(), result.size());
+  result.resize(size);
   return result;
 }
 

--- a/src/core/channelz/text_encode.cc
+++ b/src/core/channelz/text_encode.cc
@@ -56,10 +56,14 @@ std::string TextEncode(upb_Message* message,
   auto* def = getmsgdef(def_pool);
   size_t size = upb_TextEncode(message, def, def_pool, 0, buf, sizeof(buf));
   if (size < sizeof(buf)) return std::string(buf, size);
-  char* new_buf = new char[size];
-  upb_TextEncode(message, def, def_pool, 0, new_buf, size);
-  std::string result(new_buf, size);
-  delete[] new_buf;
+  // upb_TextEncode has snprintf() semantics: it always NUL-terminates
+  // within the given capacity, so writing `size` content bytes requires
+  // a capacity of `size + 1`. std::string guarantees a valid, writable
+  // null-terminator slot at result.data()[size] (C++17), so this avoids
+  // both the raw new[]/delete[] and the previous one-byte-short capacity
+  // that silently truncated the final character of the encoded text.
+  std::string result(size, '\0');
+  upb_TextEncode(message, def, def_pool, 0, result.data(), size + 1);
   return result;
 }
 

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -657,11 +657,8 @@ TEST(ChannelzTextEncodeTest, BasicTraceEvent) {
   EXPECT_NE(encoded.length(), 0) << encoded;
 }
 
-// Regression test for a truncation bug in the >10240-byte fallback path:
-// the heap buffer was previously sized exactly `size` bytes and passed as
-// the capacity to upb_TextEncode, which is one byte short of what its
-// snprintf()-style contract needs (content + NUL terminator). That
-// silently replaced the final content byte with a NUL character.
+// Verifies that large trace events exceeding the internal stack buffer
+// are encoded completely without truncating trailing characters.
 TEST(ChannelzTextEncodeTest, LargeTraceEventDoesNotTruncateLastByte) {
   upb::Arena arena;
   grpc_channelz_v2_TraceEvent* event =

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -657,6 +657,31 @@ TEST(ChannelzTextEncodeTest, BasicTraceEvent) {
   EXPECT_NE(encoded.length(), 0) << encoded;
 }
 
+// Regression test for a truncation bug in the >10240-byte fallback path:
+// the heap buffer was previously sized exactly `size` bytes and passed as
+// the capacity to upb_TextEncode, which is one byte short of what its
+// snprintf()-style contract needs (content + NUL terminator). That
+// silently replaced the final content byte with a NUL character.
+TEST(ChannelzTextEncodeTest, LargeTraceEventDoesNotTruncateLastByte) {
+  upb::Arena arena;
+  grpc_channelz_v2_TraceEvent* event =
+      grpc_channelz_v2_TraceEvent_new(arena.ptr());
+  // Long enough that the encoded text exceeds the 10240-byte stack buffer
+  // in TextEncode(), forcing the heap fallback path.
+  std::string long_description(20000, 'a');
+  grpc_channelz_v2_TraceEvent_set_description(
+      event, upb_StringView_FromString(long_description.c_str()));
+  std::string encoded =
+      channelz::TextEncode(reinterpret_cast<upb_Message*>(event),
+                           grpc_channelz_v2_TraceEvent_getmsgdef);
+  // Sanity check that we actually exercised the >10240-byte fallback path.
+  ASSERT_GT(encoded.size(), 10240u);
+  // The fallback path must not silently corrupt the final byte of the
+  // encoded text into a NUL character.
+  EXPECT_EQ(encoded.find('\0'), std::string::npos)
+      << "encoded text unexpectedly contains an embedded NUL byte";
+}
+
 }  // namespace testing
 }  // namespace channelz
 }  // namespace grpc_core


### PR DESCRIPTION
upb_TextEncode() has snprintf() semantics (always NUL-terminates within the given capacity). The >10240-byte fallback path in channelz::TextEncode() allocated a heap buffer of exactly `size` bytes (the true content length) and passed `size` as the capacity -- one byte short of what's needed for content + NUL terminator. This silently replaced the final content byte with a NUL character for any message whose text encoding exceeds 10240 bytes; the second call's return value, which would have flagged the truncation, was discarded.\n\nThis migrates to std::string sized upfront and passes `size + 1` as the capacity, which both fixes the truncation and removes the raw new[]/delete[] pair (Safe Buffers Programming Model). Adds a regression test (`LargeTraceEventDoesNotTruncateLastByte`) that forces the fallback path and asserts no embedded NUL byte in the output.