### PR TITLE
Keep completion queue finalize success on the common path

### DIFF
--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -155,10 +155,10 @@ CompletionQueue::NextStatus CompletionQueue::AsyncNextInternal(
             static_cast<grpc::internal::CompletionQueueTag*>(ev.tag);
         *ok = ev.success != 0;
         *tag = core_cq_tag;
-        if (core_cq_tag->FinalizeResult(tag, ok)) {
-          return GOT_EVENT;
+        if (GPR_UNLIKELY(!core_cq_tag->FinalizeResult(tag, ok))) {
+          break;
         }
-        break;
+        return GOT_EVENT;
     }
   }
 }


### PR DESCRIPTION
## Summary

This keeps the common `CompletionQueue::AsyncNextInternal` path on the direct return after `FinalizeResult` succeeds.

`FinalizeResult` returns `false` only when a completion queue tag consumes the event internally and should not be returned to the caller. The updated branch puts that uncommon case behind `GPR_UNLIKELY` and leaves the normal user-visible completion as the straight-line path.

## Why this helps

`AsyncNextInternal` is on the C++ completion queue polling path. In the common case, the event is ready to return immediately after `FinalizeResult` succeeds. Making that successful path the direct return avoids routing the hot path through the loop `break` branch, while preserving the existing behavior for swallowed tags.

## Validation

- `git diff --check`
- `CC=/usr/bin/gcc CXX=/usr/bin/g++ tools/bazel test --test_output=errors //test/core/surface:grpc_completion_queue_test //test/core/surface:completion_queue_threading_test //test/cpp/end2end:async_end2end_test`

Release notes: No
