### PR TITLE
[RetryTimer] Fix #41036: Release CallCombiner on invalid retry timer

### DIFF
--- a/src/core/client_channel/retry_filter_legacy_call_data.cc
+++ b/src/core/client_channel/retry_filter_legacy_call_data.cc
@@ -1907,6 +1907,8 @@ void RetryFilter::LegacyCallData::OnRetryTimerLocked(
   if (calld->retry_timer_handle_ != TaskHandle::kInvalid) {
     calld->retry_timer_handle_ = TaskHandle::kInvalid;
     calld->CreateCallAttempt(/*is_transparent_retry=*/false);
+  } else {
+    GRPC_CALL_COMBINER_STOP(calld->call_combiner_, "retry timer cancelled");
   }
   GRPC_CALL_STACK_UNREF(calld->owning_call_, "OnRetryTimer");
 }


### PR DESCRIPTION
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Fixes #41036

### Description
In gRPC C++ v1.76, setting a retry policy could cause the client to hang indefinitely if the initial connection attempt fails immediately and `retry_timer_handle_` was already fired/cancelled. The `CallCombiner` was incorrectly left held.

This PR adds the missing `GRPC_CALL_COMBINER_STOP` call in the `else` branch of `OnRetryTimerLocked` to ensure the `CallCombiner` is properly released when the retry timer is cancelled or invalid, preventing the client from hanging. 

Tested locally by reproducing the hang with a custom client and verifying it correctly fails the RPC after this fix.