### PR TITLE
[EventEngine] Fix a bug causing crashes when writing to the network on MacOS

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -1135,7 +1135,9 @@ bool PosixEndpointImpl::TcpFlush(absl::Status& status) {
     }
 
     GRPC_CHECK_EQ(outgoing_byte_idx_, 0u);
-    GRPC_CHECK_LE((static_cast<size_t>(*send_result)), sending_length);
+    if (static_cast<size_t>(*send_result) > sending_length) {
+      *send_result = sending_length;
+    }
     bytes_counter_ += *send_result;
     trailing = sending_length - static_cast<size_t>(*send_result);
     while (trailing > 0) {


### PR DESCRIPTION
Fixes #41250

Description
In gRPC C++, on macOS, `sendmsg` might sometimes return a value larger than the requested `sending_length` due to OS quirks. When this happens in `PosixEndpointImpl::TcpFlush`, the calculation for `trailing` underflows (since both operands are unsigned), resulting in a huge number. This causes the reverse loop to decrement `outgoing_slice_idx` past 0 until it underflows, leading to out-of-bounds access inside `SliceBuffer::RefSlice` and eventually a crash.

This PR replaces the `GRPC_CHECK_LE` added in #41924 with a logic that safely clamps the returned `*send_result` to `sending_length`. This resolves the underlying crash entirely.