### PR TITLE
Bug 41168

### DIFF
--- a/src/core/call/metadata_batch.h
+++ b/src/core/call/metadata_batch.h
@@ -467,7 +467,7 @@ struct GrpcStatusMetadata {
       on_error("negative value", value);
       return GRPC_STATUS_UNKNOWN;
     }
-    if (wire_value >= GRPC_STATUS__DO_NOT_USE) {
+    if (wire_value > 16) {
       on_error("out of range", value);
       return GRPC_STATUS_UNKNOWN;
     }


### PR DESCRIPTION
Fixes #41168

Description
This PR modifies `GrpcStatusMetadata::ParseMemento()` to reject status values > 16 (`GRPC_STATUS_UNAUTHENTICATED`) instead of > `GRPC_STATUS__DO_NOT_USE`. 
This guarantees that any out-of-range status codes received over the wire are converted to `GRPC_STATUS_UNKNOWN` during parsing, avoiding Undefined Behavior when these values are used in subsequent layers (e.g. `StatusCodeSet::Contains`). This aligns with the gRPC specification to either propagate or convert out-of-range values to UNKNOWN.