### PR TITLE
[RetryFilter] Fix #40283: Ensure all in-flight ops complete before switching to fast path

### DIFF
--- a/src/core/client_channel/retry_filter_legacy_call_data.cc
+++ b/src/core/client_channel/retry_filter_legacy_call_data.cc
@@ -223,11 +223,35 @@ void RetryFilter::LegacyCallData::CallAttempt::MaybeSwitchToFastPath() {
   if (calld_->committed_call_ != nullptr) return;
   // If the perAttemptRecvTimeout timer is pending, we can't switch yet.
   if (per_attempt_recv_timer_handle_ != TaskHandle::kInvalid) return;
-  // If there are still send ops to replay, we can't switch yet.
-  if (HaveSendOpsToReplay()) return;
   // If we started an internal batch for recv_trailing_metadata but have not
   // yet seen that op from the surface, we can't switch yet.
   if (recv_trailing_metadata_internal_batch_ != nullptr) return;
+  if (calld_->seen_send_initial_metadata_ &&
+      !completed_send_initial_metadata_) {
+    return;
+  }
+  if (completed_send_message_count_ < calld_->send_messages_.size() ||
+      started_send_message_count_ > completed_send_message_count_ ||
+      calld_->pending_send_message_) {
+    return;
+  }
+  if (calld_->seen_send_trailing_metadata_ &&
+      !completed_send_trailing_metadata_) {
+    return;
+  }
+  if (calld_->pending_send_initial_metadata_ ||
+      calld_->pending_send_trailing_metadata_) {
+    return;
+  }
+  if (started_recv_initial_metadata_ && !completed_recv_initial_metadata_) {
+    return;
+  }
+  if (started_recv_message_count_ > completed_recv_message_count_) {
+    return;
+  }
+  if (started_recv_trailing_metadata_ && !completed_recv_trailing_metadata_) {
+    return;
+  }
   // Switch to fast path.
   GRPC_TRACE_LOG(retry, INFO)
       << "chand=" << calld_->chand_ << " calld=" << calld_


### PR DESCRIPTION
Fixes #40283

### Description
In `RetryFilter::LegacyCallData::CallAttempt::MaybeSwitchToFastPath`, the filter previously only checked `HaveSendOpsToReplay()` and whether `recv_trailing_metadata_internal_batch_` was null before switching to the fast path (`calld_->committed_call_ = lb_call_`).

However, if there were in-flight send ops (such as initial/trailing metadata or messages that have been started but not yet completed) or pending recv ops in-flight when commit occurred, switching immediately to the fast path causes subsequent surface batches to bypass the retry filter and go directly to `lb_call_` while the retry filter's internal state machine still has unfinished callbacks, resulting in race conditions and segfaults in `StartRetriableBatch`.

This PR adds complete checks in `MaybeSwitchToFastPath` to ensure that all in-flight and pending send and recv operations have completed before switching to the fast path.