### PR TITLE
[AuditLogging] Fix #40576: Allow duplicate factory registration in AuditLoggerRegistry

### DIFF
--- a/src/core/lib/security/authorization/audit_logging.cc
+++ b/src/core/lib/security/authorization/audit_logging.cc
@@ -52,8 +52,8 @@ void AuditLoggerRegistry::RegisterFactory(
   GRPC_CHECK(factory != nullptr);
   MutexLock lock(mu);
   absl::string_view name = factory->name();
-  GRPC_CHECK(
-      registry->logger_factories_map_.emplace(name, std::move(factory)).second);
+  registry->logger_factories_map_.erase(name);
+  registry->logger_factories_map_.emplace(name, std::move(factory));
 }
 
 bool AuditLoggerRegistry::FactoryExists(absl::string_view name) {

--- a/test/core/security/grpc_audit_logging_test.cc
+++ b/test/core/security/grpc_audit_logging_test.cc
@@ -74,6 +74,25 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
   }
 };
 
+class CustomTestAuditLoggerFactory : public AuditLoggerFactory {
+ public:
+  class CustomConfig : public Config {
+   public:
+    absl::string_view name() const override { return kName; }
+    std::string ToString() const override { return "custom_config"; }
+  };
+
+  absl::string_view name() const override { return kName; }
+  std::unique_ptr<AuditLogger> CreateAuditLogger(
+      std::shared_ptr<const AuditLoggerFactory::Config>) override {
+    return std::make_unique<TestAuditLogger>();
+  }
+  absl::StatusOr<std::shared_ptr<const Config>> ParseAuditLoggerConfig(
+      const Json&) override {
+    return std::make_shared<CustomConfig>();
+  }
+};
+
 class AuditLoggerRegistryTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -106,6 +125,16 @@ TEST_F(AuditLoggerRegistryTest, UnknownLogger) {
 TEST_F(AuditLoggerRegistryTest, LoggerFactoryExistenceChecks) {
   EXPECT_TRUE(AuditLoggerRegistry::FactoryExists(kName));
   EXPECT_FALSE(AuditLoggerRegistry::FactoryExists("unknown_logger"));
+}
+
+TEST_F(AuditLoggerRegistryTest, DuplicateRegistrationReplacesFactory) {
+  auto result1 = AuditLoggerRegistry::ParseConfig(kName, Json());
+  ASSERT_TRUE(result1.ok());
+  EXPECT_EQ(result1.value()->ToString(), "test_config");
+  RegisterAuditLoggerFactory(std::make_unique<CustomTestAuditLoggerFactory>());
+  auto result2 = AuditLoggerRegistry::ParseConfig(kName, Json());
+  ASSERT_TRUE(result2.ok());
+  EXPECT_EQ(result2.value()->ToString(), "custom_config");
 }
 
 //


### PR DESCRIPTION
<!-- Auto-generated PR body -->
### Summary
When registering an audit logger factory with an already registered name, `AuditLoggerRegistry` asserted via `GRPC_CHECK(registry->logger_factories_map_.emplace(...).second)`.

This change replaces any existing factory for the given name instead of asserting, allowing factories to be updated/re-registered safely without crashing the process.

### Fixes
Fixes #40576

### Testing
- Added unit test `DuplicateRegistrationReplacesFactory` in `test/core/security/grpc_audit_logging_test.cc`.
- Ran `//test/core/security:grpc_audit_logging_test` and authorization engine tests.