### PR TITLE
[core] Fix #40991: Do not fallback to single CPU when sched_getcpu fails

### DIFF
--- a/src/core/util/linux/cpu.cc
+++ b/src/core/util/linux/cpu.cc
@@ -38,14 +38,6 @@
 static int ncpus = 0;
 
 static void init_num_cpus() {
-#ifndef GPR_MUSL_LIBC_COMPAT
-  if (sched_getcpu() < 0) {
-    LOG(ERROR) << "Error determining current CPU: "
-               << grpc_core::StrError(errno) << "\n";
-    ncpus = 1;
-    return;
-  }
-#endif
   // This must be signed. sysconf returns -1 when the number cannot be
   // determined
   ncpus = static_cast<int>(sysconf(_SC_NPROCESSORS_ONLN));


### PR DESCRIPTION
<!-- Auto-generated PR body -->
### Summary
In `src/core/util/linux/cpu.cc`, `init_num_cpus()` checked `sched_getcpu() < 0` and prematurely set `ncpus = 1`, returning without querying `sysconf(_SC_NPROCESSORS_ONLN)`. 

`sched_getcpu()` only retrieves the current thread's core ID and is not required for `sysconf` to determine the total number of online CPU cores.

This change removes the premature early exit, ensuring that systems where `sched_getcpu()` is restricted or fails still accurately detect the online CPU count.

### Fixes
Fixes #40991

### Testing
- Tested with `//test/core/util:cpu_test` (passed).