### PR TITLE
[telemetry] Fix #43050: Do not abort when a metric name has already been registered

### DIFF
--- a/src/core/telemetry/metrics.cc
+++ b/src/core/telemetry/metrics.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <optional>
 
+#include "absl/log/log.h"
 #include "src/core/util/crash.h"
 #include "src/core/util/grpc_check.h"
 
@@ -46,8 +47,8 @@ GlobalInstrumentsRegistry::RegisterInstrument(
   auto& instruments = GetInstrumentList();
   for (const auto& descriptor : instruments) {
     if (descriptor.name == name) {
-      Crash(
-          absl::StrFormat("Metric name %s has already been registered.", name));
+      LOG(ERROR) << "Metric name " << name << " has already been registered.";
+      return descriptor.index;
     }
   }
   InstrumentID index = instruments.size();


### PR DESCRIPTION
<!-- Auto-generated PR body -->
### Summary
In `src/core/telemetry/metrics.cc`, `GlobalInstrumentsRegistry::RegisterInstrument` used to `Crash()` when a metric name had already been registered.
When multiple shared libraries linked against gRPC are loaded, or under certain initialization scenarios with ASAN/LTO (causing ODR violations), the same metric might be registered more than once.

This change aligns `metrics.cc` with the existing behavior in `instrument.cc`, which logs an error (using `LOG(ERROR)`) and ignores the subsequent registrations instead of aborting the process entirely.

### Fixes
Fixes #43050