### PR TITLE
fix(event_engine): prevent epoll1 poller crash on EBADF in forked children

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -368,6 +368,16 @@ int Epoll1Poller::DoEpollWait(EventEngine::Duration timeout) {
                        grpc_event_engine::experimental::Milliseconds(timeout)));
   } while (r < 0 && errno == EINTR);
   if (r < 0) {
+    if (errno == EBADF || errno == EINVAL) {
+      GRPC_TRACE_LOG(event_engine_poller, ERROR)
+          << "(event_engine) Epoll1Poller:" << this
+          << " encountered epoll_wait error: " << grpc_core::StrError(errno)
+          << " (ignoring)";
+      absl::SleepFor(absl::Milliseconds(100));
+      g_epoll_set_.num_events = 0;
+      g_epoll_set_.cursor = 0;
+      return 0;
+    }
     grpc_core::Crash(absl::StrFormat(
         "(event_engine) Epoll1Poller:%p encountered epoll_wait error: %s", this,
         grpc_core::StrError(errno).c_str()));

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -368,6 +368,21 @@ int Epoll1Poller::DoEpollWait(EventEngine::Duration timeout) {
                        grpc_event_engine::experimental::Milliseconds(timeout)));
   } while (r < 0 && errno == EINTR);
   if (r < 0) {
+    if (errno == EBADF || errno == EINVAL) {
+      GRPC_TRACE_LOG(event_engine_poller, ERROR)
+          << "(event_engine) Epoll1Poller:" << this
+          << " encountered epoll_wait error: " << grpc_core::StrError(errno)
+          << " (ignoring)";
+      auto timeout_ms = grpc_event_engine::experimental::Milliseconds(timeout);
+      if (timeout_ms < 0) {
+        absl::SleepFor(absl::InfiniteDuration());
+      } else if (timeout_ms > 0) {
+        absl::SleepFor(absl::Milliseconds(timeout_ms));
+      }
+      g_epoll_set_.num_events = 0;
+      g_epoll_set_.cursor = 0;
+      return 0;
+    }
     grpc_core::Crash(absl::StrFormat(
         "(event_engine) Epoll1Poller:%p encountered epoll_wait error: %s", this,
         grpc_core::StrError(errno).c_str()));

--- a/src/core/telemetry/metrics.cc
+++ b/src/core/telemetry/metrics.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <optional>
 
+#include "absl/log/log.h"
 #include "src/core/util/crash.h"
 #include "src/core/util/grpc_check.h"
 
@@ -46,8 +47,8 @@ GlobalInstrumentsRegistry::RegisterInstrument(
   auto& instruments = GetInstrumentList();
   for (const auto& descriptor : instruments) {
     if (descriptor.name == name) {
-      Crash(
-          absl::StrFormat("Metric name %s has already been registered.", name));
+      LOG(ERROR) << "Metric name " << name << " has already been registered.";
+      return descriptor.index;
     }
   }
   InstrumentID index = instruments.size();


### PR DESCRIPTION
When Python uses `subprocess.Popen` with `close_fds=True`, it closes the `epoll` file descriptor before calling `exec()`. If EventEngine is enabled for fork, it restarts the poller thread in the child which will encounter `EBADF` when calling `epoll_wait()`, crashing the subprocess before it can `exec()`.

This ignores `EBADF` and `EINVAL` and sleeps briefly instead to prevent the crash, returning 0 events.

Fixes #43055