### PR TITLE
[Python] Fix typo in gRPC Python observability error messages

### DIFF
--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -486,7 +486,7 @@ def _start_open_telemetry_observability(
             _OPEN_TELEMETRY_OBSERVABILITY = otel_o11y
             _OPEN_TELEMETRY_OBSERVABILITY.observability_init()
         else:
-            error_msg = "gPRC Python observability was already initialized!"
+            error_msg = "gRPC Python observability was already initialized!"
             raise RuntimeError(error_msg)
 
 
@@ -494,7 +494,7 @@ def _end_open_telemetry_observability() -> None:
     global _OPEN_TELEMETRY_OBSERVABILITY  # pylint: disable=global-statement # noqa: PLW0603
     with _observability_lock:
         if not _OPEN_TELEMETRY_OBSERVABILITY:
-            error_msg = "Trying to end gPRC Python observability without initialize first!"
+            error_msg = "Trying to end gRPC Python observability without initialize first!"
             raise RuntimeError(error_msg)
         _OPEN_TELEMETRY_OBSERVABILITY.observability_deinit()
         _OPEN_TELEMETRY_OBSERVABILITY = None

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -494,7 +494,7 @@ def _end_open_telemetry_observability() -> None:
     global _OPEN_TELEMETRY_OBSERVABILITY  # pylint: disable=global-statement # noqa: PLW0603
     with _observability_lock:
         if not _OPEN_TELEMETRY_OBSERVABILITY:
-            error_msg = "Trying to end gRPC Python observability without initialize first!"
+            error_msg = "Trying to end gRPC Python observability without initializing first!"
             raise RuntimeError(error_msg)
         _OPEN_TELEMETRY_OBSERVABILITY.observability_deinit()
         _OPEN_TELEMETRY_OBSERVABILITY = None

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -165,7 +165,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             otel_plugin.register_global()
         except RuntimeError as exp:
             self.assertIn(
-                "gPRC Python observability was already initialized", str(exp)
+                "gRPC Python observability was already initialized", str(exp)
             )
 
         otel_plugin.deregister_global()
@@ -181,7 +181,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                 otel_plugin.register_global()
             except RuntimeError as exp:
                 self.assertIn(
-                    "gPRC Python observability was already initialized",
+                    "gRPC Python observability was already initialized",
                     str(exp),
                 )
 
@@ -197,7 +197,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                 pass
         except RuntimeError as exp:
             self.assertIn(
-                "gPRC Python observability was already initialized", str(exp)
+                "gRPC Python observability was already initialized", str(exp)
             )
         otel_plugin.deregister_global()
 
@@ -212,7 +212,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                     pass
             except RuntimeError as exp:
                 self.assertIn(
-                    "gPRC Python observability was already initialized",
+                    "gRPC Python observability was already initialized",
                     str(exp),
                 )
 


### PR DESCRIPTION
Fix a typo in gRPC Python observability error messages that incorrectly spelled `gPRC` instead of `gRPC`. 

Updated related tests.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

