### PR TITLE
[core] Clamp default compression algorithm before enum cast

### DIFF
--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -228,7 +228,9 @@ DefaultCompressionAlgorithmFromChannelArgs(const ChannelArgs& args) {
   if (value == nullptr) return std::nullopt;
   auto ival = value->GetIfInt();
   if (ival.has_value()) {
-    return static_cast<grpc_compression_algorithm>(*ival);
+    return static_cast<grpc_compression_algorithm>(
+        Clamp(*ival, static_cast<int>(GRPC_COMPRESS_NONE),
+              static_cast<int>(GRPC_COMPRESS_ALGORITHMS_COUNT - 1)));
   }
   auto sval = value->GetIfString();
   if (sval != nullptr) {

--- a/test/core/compression/BUILD
+++ b/test/core/compression/BUILD
@@ -42,6 +42,7 @@ grpc_cc_test(
         "//:gpr",
         "//:grpc",
         "//src/core:channel_args",
+        "//src/core:compression",
         "//src/core:useful",
         "//test/core/test_util:grpc_test_util",
     ],

--- a/test/core/compression/compression_test.cc
+++ b/test/core/compression/compression_test.cc
@@ -21,8 +21,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <limits>
 #include <memory>
 
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/compression/compression_internal.h"
 #include "src/core/util/useful.h"
 #include "test/core/test_util/test_config.h"
 #include "gtest/gtest.h"
@@ -83,6 +86,19 @@ TEST(CompressionTest, CompressionAlgorithmName) {
       grpc_compression_algorithm_name(GRPC_COMPRESS_ALGORITHMS_COUNT, &name);
   ASSERT_EQ(success, 0);
   // the value of "name" is undefined upon failure
+}
+
+TEST(CompressionTest, DefaultCompressionAlgorithmClampsIntegerChannelArg) {
+  using grpc_core::ChannelArgs;
+  using grpc_core::DefaultCompressionAlgorithmFromChannelArgs;
+
+  EXPECT_EQ(DefaultCompressionAlgorithmFromChannelArgs(ChannelArgs().Set(
+                GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM, -1)),
+            GRPC_COMPRESS_NONE);
+  EXPECT_EQ(DefaultCompressionAlgorithmFromChannelArgs(
+                ChannelArgs().Set(GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM,
+                                  std::numeric_limits<int>::max())),
+            GRPC_COMPRESS_GZIP);
 }
 
 TEST(CompressionTest, CompressionAlgorithmForLevel) {


### PR DESCRIPTION
## What this changes

- Clamp the integer `grpc.default_compression_algorithm` channel argument before converting it to `grpc_compression_algorithm`.
- Add regression coverage for negative and oversized integer values.

## Why

#43094 fixed this undefined conversion in `CompressionOptionsFromChannelArgs`, but the newer `DefaultCompressionAlgorithmFromChannelArgs` helper retained the same cast-before-validation pattern. That helper is used by the promise-based compression filter.

An out-of-range caller-supplied integer therefore created an invalid enum value before the filter could fall back to no compression. UBSan reports an invalid `grpc_compression_algorithm` load for the old conversion. Clamping in the integer domain matches the legacy options parser and ensures only representable enumerators are produced.

## Tests

- `tools/bazel test //test/core/compression:compression_test --jobs=2 --local_ram_resources=4096 --local_cpu_resources=2 --macos_minimum_os=10.13 --test_output=errors`
- Standalone Clang enum-UBSan reproduction for the old conversion (`-fsanitize=enum -fno-sanitize-recover=enum`)
- `clang-format` and `buildifier`
- `git diff --check`
