### PR TITLE
[jwt] Check return value of EVP_PKEY_new and related OpenSSL allocati…

### DIFF
--- a/src/core/credentials/call/jwt/json_token.cc
+++ b/src/core/credentials/call/jwt/json_token.cc
@@ -244,7 +244,7 @@ char* compute_and_encode_signature(const grpc_auth_json_key* json_key,
   const EVP_MD* md = openssl_digest_from_algorithm(signature_algorithm);
   EVP_MD_CTX* md_ctx = nullptr;
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
-  EVP_PKEY* key = EVP_PKEY_new();
+  EVP_PKEY* key = nullptr;
 #endif
   size_t sig_len = 0;
   unsigned char* sig = nullptr;
@@ -256,7 +256,15 @@ char* compute_and_encode_signature(const grpc_auth_json_key* json_key,
     goto end;
   }
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
-  EVP_PKEY_set1_RSA(key, json_key->private_key);
+  key = EVP_PKEY_new();
+  if (key == nullptr) {
+    LOG(ERROR) << "Could not create EVP_PKEY";
+    goto end;
+  }
+  if (EVP_PKEY_set1_RSA(key, json_key->private_key) == 0) {
+    LOG(ERROR) << "Could not set RSA key";
+    goto end;
+  }
   if (EVP_DigestSignInit(md_ctx, nullptr, md, nullptr, key) != 1) {
 #else
   if (EVP_DigestSignInit(md_ctx, nullptr, md, nullptr, json_key->private_key) !=

--- a/src/core/credentials/call/jwt/jwt_verifier.cc
+++ b/src/core/credentials/call/jwt/jwt_verifier.cc
@@ -538,6 +538,11 @@ static EVP_PKEY* pkey_from_jwk(const Json& json, const char* kty) {
     LOG(ERROR) << "Could not create rsa key.";
     goto end;
   }
+#else
+  if (bld == nullptr) {
+    LOG(ERROR) << "Could not create OSSL_PARAM_BLD.";
+    goto end;
+  }
 #endif
   it = json.object().find("n");
   if (it == json.object().end()) {
@@ -562,7 +567,16 @@ static EVP_PKEY* pkey_from_jwk(const Json& json, const char* kty) {
   tmp_n = nullptr;
   tmp_e = nullptr;
   result = EVP_PKEY_new();
-  EVP_PKEY_set1_RSA(result, rsa);  // uprefs rsa.
+  if (result == nullptr) {
+    LOG(ERROR) << "Could not create EVP_PKEY.";
+    goto end;
+  }
+  if (EVP_PKEY_set1_RSA(result, rsa) == 0) {
+    LOG(ERROR) << "Cannot set RSA key from inputs.";
+    EVP_PKEY_free(result);
+    result = nullptr;
+    goto end;
+  }
 #else
 
   if (!OSSL_PARAM_BLD_push_BN(bld, "n", tmp_n) ||


### PR DESCRIPTION
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

### Problem Summary
In `jwt_verifier.cc` and `json_token.cc`, `EVP_PKEY_new()` and `OSSL_PARAM_BLD_new()` return values were not checked for `nullptr` before being passed to OpenSSL functions such as `EVP_PKEY_set1_RSA()` and `OSSL_PARAM_BLD_push_BN()`, which could lead to `nullptr` dereferences or crashes upon allocation failure. In addition:
- The return code of `EVP_PKEY_set1_RSA()` was ignored.
- In `compute_and_encode_signature()`, `EVP_PKEY_new()` was allocated before validating the digest algorithm or context creation, causing memory leaks on early exit.

### Proposed Changes
1. **`src/core/credentials/call/jwt/jwt_verifier.cc` (`pkey_from_jwk`)**:
   - Added `nullptr` check for `result = EVP_PKEY_new();`. If allocation fails, log an error and jump to `end:`.
   - Checked return value of `EVP_PKEY_set1_RSA(result, rsa)`. On failure, free `result`, clear pointer to `nullptr`, and jump to `end:`.
   - On OpenSSL 3.0+ path, added `nullptr` check for `bld = OSSL_PARAM_BLD_new()`.
2. **`src/core/credentials/call/jwt/json_token.cc` (`compute_and_encode_signature`)**:
   - Initialized `key = nullptr;` safely and deferred `key = EVP_PKEY_new()` allocation until after digest and `md_ctx` checks, preventing memory leaks on invalid algorithms.
   - Added `nullptr` check for `key` and return status check for `EVP_PKEY_set1_RSA(key, json_key->private_key)`.

### Verification
- **Formatting**: Verified with `./tools/distrib/clang_format_code.sh` (0 diffs).
- **Tests**: Ran credentials and security test suite with Bazel:
  - `//test/core/credentials/call/jwt:json_token_test` — **PASSED**
  - `//test/core/credentials/call/jwt:jwt_verifier_test` — **PASSED**
  - `//test/core/credentials/call/jwt:jwt_util_test` — **PASSED**
  - All 109 test configurations under `//test/core/credentials/...` and `//test/core/security/...` passed across `poll` and `epoll1` pollers.

Closes #37695.