### PR TITLE
Enforce `grpc.max_receive_message_length` early in CHTTP2 (#43012)

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -567,6 +567,12 @@ static void read_channel_args(grpc_chttp2_transport* t,
       channel_args.GetInt(GRPC_ARG_HTTP2_MAX_DEALLOCATING_STREAMS)
           .value_or(grpc_core::IsH2MaxDeallocatingStreamsHeadroomEnabled() ? 100
                                                                            : 0);
+
+  auto max_receive_message_length =
+      channel_args.GetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
+  if (max_receive_message_length.has_value()) {
+    t->max_receive_message_length = *max_receive_message_length;
+  }
 }
 
 static void init_keepalive_pings_if_enabled_locked(

--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.cc
@@ -289,7 +289,8 @@ Http2Status Http2ClientTransport::ProcessIncomingFrame(Http2DataFrame&& frame) {
     GRPC_HTTP2_CLIENT_DLOG
         << "Http2ClientTransport::ProcessIncomingFrame(DataFrame) "
            "ExtractMessage";
-    ValueOrHttp2Status<MessageHandle> result = assembler.ExtractMessage();
+    ValueOrHttp2Status<MessageHandle> result =
+        assembler.ExtractMessage(max_receive_message_length_);
     if (!result.IsOk()) {
       GRPC_HTTP2_CLIENT_DLOG
           << "Http2ClientTransport::ProcessIncomingFrame(DataFrame) "
@@ -1278,6 +1279,7 @@ void Http2ClientTransport::ReadChannelArgs(const ChannelArgs& channel_args,
   read_context_.set_soft_limit(args.max_header_list_size_soft_limit);
   keepalive_permit_without_calls_ = args.keepalive_permit_without_calls;
   test_only_ack_pings_ = args.test_only_ack_pings;
+  max_receive_message_length_ = args.max_receive_message_length;
 
   if (args.initial_sequence_number > 0) {
     next_stream_id_ = args.initial_sequence_number;

--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.h
@@ -710,6 +710,7 @@ class Http2ClientTransport final : public ClientTransport,
   std::optional<KeepaliveManager> keepalive_manager_;
 
   bool keepalive_permit_without_calls_;
+  std::optional<uint32_t> max_receive_message_length_;
 
   GoawayManager goaway_manager_;
 

--- a/src/core/ext/transport/chttp2/transport/http2_server_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_server_transport.cc
@@ -344,7 +344,8 @@ Http2Status Http2ServerTransport::ProcessIncomingFrame(Http2DataFrame&& frame) {
     GRPC_HTTP2_SERVER_DLOG
         << "Http2ServerTransport::ProcessIncomingFrame(DataFrame) "
            "ExtractMessage";
-    ValueOrHttp2Status<MessageHandle> result = assembler.ExtractMessage();
+    ValueOrHttp2Status<MessageHandle> result =
+        assembler.ExtractMessage(max_receive_message_length_);
     if (!result.IsOk()) {
       GRPC_HTTP2_SERVER_DLOG
           << "Http2ServerTransport::ProcessIncomingFrame(DataFrame) "
@@ -1801,6 +1802,7 @@ void Http2ServerTransport::ReadChannelArgs(const ChannelArgs& channel_args,
   read_context_.set_soft_limit(args.max_header_list_size_soft_limit);
   keepalive_permit_without_calls_ = args.keepalive_permit_without_calls;
   test_only_ack_pings_ = args.test_only_ack_pings;
+  max_receive_message_length_ = args.max_receive_message_length;
 
   settings_->SetSettingsTimeout(args.settings_timeout);
   if (args.max_usable_hpack_table_size >= 0) {

--- a/src/core/ext/transport/chttp2/transport/http2_server_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_server_transport.h
@@ -727,6 +727,7 @@ class Http2ServerTransport final : public ServerTransport,
   std::optional<KeepaliveManager> keepalive_manager_;
 
   bool keepalive_permit_without_calls_;
+  std::optional<uint32_t> max_receive_message_length_;
 
   GoawayManager goaway_manager_;
 

--- a/src/core/ext/transport/chttp2/transport/http2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_transport.cc
@@ -135,14 +135,19 @@ void InitLocalSettings(Http2Settings& settings, const bool is_client) {
 
 std::string TransportChannelArgs::DebugString() const {
   return absl::StrCat(
-      "keepalive_time: ", keepalive_time,
-      " keepalive_timeout: ", keepalive_timeout,
-      " ping_timeout: ", ping_timeout, " settings_timeout: ", settings_timeout,
+      "keepalive_time: ", keepalive_time.ToString(),
+      " keepalive_timeout: ", keepalive_timeout.ToString(),
+      " ping_timeout: ", ping_timeout.ToString(),
+      " settings_timeout: ", settings_timeout.ToString(),
       " keepalive_permit_without_calls: ", keepalive_permit_without_calls,
+      " test_only_ack_pings: ", test_only_ack_pings,
       " max_header_list_size_soft_limit: ", max_header_list_size_soft_limit,
       " max_usable_hpack_table_size: ", max_usable_hpack_table_size,
       " initial_sequence_number: ", initial_sequence_number,
-      " test_only_ack_pings: ", test_only_ack_pings);
+      " max_receive_message_length: ",
+      max_receive_message_length.has_value()
+          ? std::to_string(max_receive_message_length.value())
+          : "null");
 }
 
 void ReadChannelArgs(const ChannelArgs& channel_args,
@@ -191,6 +196,12 @@ void ReadChannelArgs(const ChannelArgs& channel_args,
 
   args.test_only_ack_pings =
       channel_args.GetBool("grpc.http2.ack_pings").value_or(kDefaultAckPings);
+
+  auto max_receive_message_length =
+      channel_args.GetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH);
+  if (max_receive_message_length.has_value()) {
+    args.max_receive_message_length = *max_receive_message_length;
+  }
 
   GRPC_HTTP2_COMMON_DLOG << "ChannelArgs: " << args.DebugString();
 }

--- a/src/core/ext/transport/chttp2/transport/http2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_transport.h
@@ -20,6 +20,7 @@
 #define GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HTTP2_TRANSPORT_H
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -133,6 +134,7 @@ struct TransportChannelArgs {
   uint32_t max_header_list_size_soft_limit;
   int max_usable_hpack_table_size;
   int initial_sequence_number;
+  std::optional<uint32_t> max_receive_message_length;
 
   std::string DebugString() const;
 };

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -548,6 +548,7 @@ struct grpc_chttp2_transport final : public grpc_core::FilterStackTransport,
   grpc_chttp2_keepalive_state keepalive_state;
   // Soft limit on max header size.
   uint32_t max_header_list_size_soft_limit = 0;
+  std::optional<uint32_t> max_receive_message_length;
   grpc_core::ContextList* context_list = nullptr;
   grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode> channelz_socket;
   std::unique_ptr<ChannelzDataSource> channelz_data_source;

--- a/src/core/ext/transport/chttp2/transport/message_assembler.h
+++ b/src/core/ext/transport/chttp2/transport/message_assembler.h
@@ -22,6 +22,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 #include "src/core/call/message.h"
@@ -78,7 +79,8 @@ class GrpcMessageAssembler {
   // Returns a valid MessageHandle if it has a complete message.
   // Returns a nullptr if it does not have a complete message.
   // Returns an error if an incomplete message is received and the stream ends.
-  ValueOrHttp2Status<MessageHandle> ExtractMessage() {
+  ValueOrHttp2Status<MessageHandle> ExtractMessage(
+      std::optional<uint32_t> max_receive_message_length) {
     const size_t current_len = message_buffer_.Length();
     if (current_len < kGrpcHeaderSizeInBytes) {
       return ReturnNullOrError();
@@ -89,6 +91,14 @@ class GrpcMessageAssembler {
       return header.TakeStatus(std::move(header));
     }
     const uint32_t header_length = header.value().length;
+
+    if (max_receive_message_length.has_value() &&
+        header_length > *max_receive_message_length) {
+      return Http2Status::Http2StreamError(
+          Http2ErrorCode::kEnhanceYourCalm,
+          absl::StrCat("Received message larger than max (", header_length,
+                       " vs. ", *max_receive_message_length, ")"));
+    }
 
     if constexpr (sizeof(size_t) == 4) {
       if (GPR_UNLIKELY(header_length > kOneGb)) {


### PR DESCRIPTION
This PR resolves #43012.

It enforces `grpc.max_receive_message_length` early in the `CHTTP2` transport before buffering large messages. Both legacy `CHTTP2` and the new `PH2` promises stack are updated to reject oversized messages immediately after parsing the 9-byte gRPC header frame, preventing large memory allocations.