### PR TITLE
Update `HTTP Connect` proxy domain names logic (#43110)

### DIFF
--- a/include/grpc/impl/channel_arg_names.h
+++ b/include/grpc/impl/channel_arg_names.h
@@ -394,6 +394,10 @@
  */
 #define GRPC_ARG_ADDRESS_HTTP_PROXY_ENABLED_ADDRESSES \
   "grpc.address_http_proxy_enabled_addresses"
+/** The host to connect to for HTTP CONNECT proxy. */
+#define GRPC_ARG_HTTP_CONNECT_SERVER "grpc.http_connect_server"
+/** Additional HTTP headers to send in HTTP CONNECT request. */
+#define GRPC_ARG_HTTP_CONNECT_HEADERS "grpc.http_connect_headers"
 /** If set to non zero, surfaces the user agent string to the server. User
     agent is surfaced by default. */
 #define GRPC_ARG_SURFACE_USER_AGENT "grpc.surface_user_agent"

--- a/src/core/handshaker/http_connect/http_connect_client_handshaker.h
+++ b/src/core/handshaker/http_connect/http_connect_client_handshaker.h
@@ -19,18 +19,10 @@
 #ifndef GRPC_SRC_CORE_HANDSHAKER_HTTP_CONNECT_HTTP_CONNECT_CLIENT_HANDSHAKER_H
 #define GRPC_SRC_CORE_HANDSHAKER_HTTP_CONNECT_HTTP_CONNECT_CLIENT_HANDSHAKER_H
 
+#include <grpc/grpc.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/config/core_configuration.h"
-
-/// Channel arg indicating the server in HTTP CONNECT request (string).
-/// The presence of this arg triggers the use of HTTP CONNECT.
-#define GRPC_ARG_HTTP_CONNECT_SERVER "grpc.http_connect_server"
-
-/// Channel arg indicating HTTP CONNECT headers (string).
-/// Multiple headers are separated by newlines.  Key/value pairs are
-/// separated by colons.
-#define GRPC_ARG_HTTP_CONNECT_HEADERS "grpc.http_connect_headers"
 
 namespace grpc_core {
 

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -294,7 +294,9 @@ std::optional<grpc_resolved_address> HttpProxyMapper::MapAddress(
       !AddressIncluded(address, host_name, *enabled_addresses)) {
     return std::nullopt;
   }
-  *args = args->Set(GRPC_ARG_HTTP_CONNECT_SERVER, *address_string);
+  if (!args->Contains(GRPC_ARG_HTTP_CONNECT_SERVER)) {
+    *args = args->Set(GRPC_ARG_HTTP_CONNECT_SERVER, *address_string);
+  }
   return proxy_address;
 }
 

--- a/src/core/util/http_client/httpcli.cc
+++ b/src/core/util/http_client/httpcli.cc
@@ -46,6 +46,7 @@
 #include "src/core/lib/slice/slice.h"
 #include "src/core/lib/transport/error_utils.h"
 #include "src/core/util/grpc_check.h"
+#include "src/core/util/host_port.h"
 #include "src/core/util/http_client/format_request.h"
 #include "src/core/util/http_client/parser.h"
 #include "src/core/util/status_helper.h"
@@ -378,6 +379,18 @@ void HttpRequest::DoHandshake(const EventEngine::ResolvedAddress& addr) {
   }
   args = args.SetObject(std::move(sc))
              .Set(GRPC_ARG_TCP_HANDSHAKER_RESOLVED_ADDRESS, address.value());
+  if (!args.Contains(GRPC_ARG_HTTP_CONNECT_SERVER)) {
+    absl::string_view host;
+    absl::string_view port;
+    SplitHostPort(uri_.authority(), &host, &port);
+    std::string connect_server;
+    if (port.empty()) {
+      connect_server = JoinHostPort(host, uri_.scheme() == "http" ? 80 : 443);
+    } else {
+      connect_server = uri_.authority();
+    }
+    args = args.Set(GRPC_ARG_HTTP_CONNECT_SERVER, std::move(connect_server));
+  }
   // Start the handshake
   handshake_mgr_ = MakeRefCounted<HandshakeManager>();
   CoreConfiguration::Get().handshaker_registry().AddHandshakers(

--- a/test/core/handshake/http_proxy_mapper_test.cc
+++ b/test/core/handshake/http_proxy_mapper_test.cc
@@ -275,6 +275,22 @@ TEST_P(IncludedAddressesTest, AddressIncluded) {
   EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), GetParam());
 }
 
+TEST(AddressProxyTest, PreservesExistingConnectServer) {
+  ScopedEnvVar address_proxy(HttpProxyMapper::kAddressProxyEnvVar,
+                             "[2001:db8::1111]:2020");
+  ScopedEnvVar address_proxy_enabled(
+      HttpProxyMapper::kAddressProxyEnabledAddressesEnvVar,
+      "192.168.1.1");
+  auto address = StringToSockaddr("192.168.1.1:3333");
+  ASSERT_TRUE(address.ok()) << address.status();
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_CONNECT_SERVER,
+                                "iamcredentials.googleapis.com:443");
+  EXPECT_THAT(HttpProxyMapper().MapAddress(*address, &args),
+              AddressEq("[2001:db8::1111]:2020"));
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "iamcredentials.googleapis.com:443");
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace grpc_core


### PR DESCRIPTION
This PR resolves #43110.

It updates the `HTTP Connect` proxy domain name resolution logic to avoid hardcoded domain assumptions and use appropriate channel arguments for HTTP proxy mapper resolution.