### PR TITLE
Fix segfault when skipping server verification with older OpenSSL or no root certs (#41356)

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -3367,9 +3367,9 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
       SSL_CTX_set_cert_store(ssl_context, options->root_store->store);
     }
 #endif
-    if (OPENSSL_VERSION_NUMBER < 0x10100000 ||
-        (options->root_store == nullptr &&
-         options->root_cert_info != nullptr)) {
+    if (options->root_cert_info != nullptr &&
+        (OPENSSL_VERSION_NUMBER < 0x10100000 ||
+         options->root_store == nullptr)) {
       Match(
           *options->root_cert_info,
           [&](const std::string& pem_root_certs) {

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1310,6 +1310,18 @@ TEST(SslTransportSecurityTest, TestClientHandshakerFactoryBadParams) {
   tsi_ssl_client_handshaker_factory_unref(client_handshaker_factory);
 }
 
+TEST(SslTransportSecurityTest,
+     TestClientHandshakerFactorySkipServerVerificationNoRoots) {
+  tsi_ssl_client_handshaker_factory* client_handshaker_factory = nullptr;
+  tsi_ssl_client_handshaker_options options;
+  options.skip_server_certificate_verification = true;
+  EXPECT_EQ(tsi_create_ssl_client_handshaker_factory_with_options(
+                &options, &client_handshaker_factory),
+            TSI_OK);
+  tsi_ssl_client_handshaker_factory_unref(client_handshaker_factory);
+}
+
+
 TEST(SslTransportSecurityTest, DuplicateRootCertificates) {
   std::string root_cert =
       GetFileContents(absl::StrCat(kSslTsiTestCredentialsDir, "ca.pem"));

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1321,7 +1321,6 @@ TEST(SslTransportSecurityTest,
   tsi_ssl_client_handshaker_factory_unref(client_handshaker_factory);
 }
 
-
 TEST(SslTransportSecurityTest, DuplicateRootCertificates) {
   std::string root_cert =
       GetFileContents(absl::StrCat(kSslTsiTestCredentialsDir, "ca.pem"));


### PR DESCRIPTION
This PR resolves #41356.

It fixes a null pointer dereference in `tsi_create_ssl_client_handshaker_factory_with_options` when skipping server verification with older OpenSSL versions or when no root certificates are configured. We rearrange the conditional check to ensure we only access `root_cert_info` when it is not null.