### PR TITLE
[HttpTokenFetcherCredentials] simplify API for implementations

### DIFF
--- a/src/core/credentials/call/gcp_service_account_identity/gcp_service_account_identity_credentials.cc
+++ b/src/core/credentials/call/gcp_service_account_identity/gcp_service_account_identity_credentials.cc
@@ -37,30 +37,14 @@ namespace grpc_core {
 // JwtTokenFetcherCallCredentials
 //
 
-OrphanablePtr<TokenFetcherCredentials::FetchRequest>
-JwtTokenFetcherCallCredentials::FetchToken(
-    Timestamp deadline,
-    absl::AnyInvocable<
-        void(absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>)>
-        on_done) {
-  return MakeOrphanable<HttpTokenFetcherCredentials::HttpFetchRequest>(
-      this, deadline,
-      [on_done = std::move(on_done)](
-          absl::StatusOr<grpc_http_response> response) mutable {
-        if (!response.ok()) {
-          on_done(response.status());
-          return;
-        }
-        absl::string_view body(response->body, response->body_length);
-        auto expiration_time = GetJwtExpirationTime(body);
-        if (!expiration_time.ok()) {
-          on_done(expiration_time.status());
-          return;
-        }
-        on_done(MakeRefCounted<Token>(
-            Slice::FromCopiedString(absl::StrCat("Bearer ", body)),
-            *expiration_time));
-      });
+absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>
+JwtTokenFetcherCallCredentials::ExtractToken(
+    const grpc_http_response& response) {
+  absl::string_view body(response.body, response.body_length);
+  auto expiration_time = GetJwtExpirationTime(body);
+  if (!expiration_time.ok()) return expiration_time.status();
+  return MakeRefCounted<Token>(
+      Slice::FromCopiedString(absl::StrCat("Bearer ", body)), *expiration_time);
 }
 
 //

--- a/src/core/credentials/call/gcp_service_account_identity/gcp_service_account_identity_credentials.h
+++ b/src/core/credentials/call/gcp_service_account_identity/gcp_service_account_identity_credentials.h
@@ -42,16 +42,13 @@ namespace grpc_core {
 // Subclasses must implement StartHttpRequest().
 class JwtTokenFetcherCallCredentials : public HttpTokenFetcherCredentials {
  public:
-  OrphanablePtr<FetchRequest> FetchToken(
-      Timestamp deadline,
-      absl::AnyInvocable<
-          void(absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>)>
-          on_done) final;
+  absl::StatusOr<RefCountedPtr<Token>> ExtractToken(
+      const grpc_http_response& response) final;
 };
 
 // GCP service account identity call credentials.
 // See gRFC A83 (https://github.com/grpc/proposal/pull/438).
-class GcpServiceAccountIdentityCallCredentials
+class GcpServiceAccountIdentityCallCredentials final
     : public JwtTokenFetcherCallCredentials {
  public:
   explicit GcpServiceAccountIdentityCallCredentials(absl::string_view audience)

--- a/src/core/credentials/call/oauth2/oauth2_credentials.cc
+++ b/src/core/credentials/call/oauth2/oauth2_credentials.cc
@@ -220,33 +220,20 @@ UniqueTypeName Oauth2TokenFetcherCredentials::type() const {
   return kFactory.Create();
 }
 
-OrphanablePtr<TokenFetcherCredentials::FetchRequest>
-Oauth2TokenFetcherCredentials::FetchToken(
-    Timestamp deadline,
-    absl::AnyInvocable<
-        void(absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>)>
-        on_done) {
-  return MakeOrphanable<HttpTokenFetcherCredentials::HttpFetchRequest>(
-      this, deadline,
-      [on_done = std::move(on_done)](
-          absl::StatusOr<grpc_http_response> response) mutable {
-        if (!response.ok()) {
-          on_done(response.status());
-          return;
-        }
-        // Parse oauth2 token.
-        std::optional<Slice> access_token_value;
-        Duration token_lifetime;
-        grpc_credentials_status status =
-            grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &(*response), &access_token_value, &token_lifetime);
-        if (status != GRPC_CREDENTIALS_OK) {
-          on_done(absl::UnavailableError("error parsing oauth2 token"));
-          return;
-        }
-        on_done(MakeRefCounted<Token>(std::move(*access_token_value),
-                                      Timestamp::Now() + token_lifetime));
-      });
+absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>
+Oauth2TokenFetcherCredentials::ExtractToken(
+    const grpc_http_response& response) {
+  // Parse oauth2 token.
+  std::optional<Slice> access_token_value;
+  Duration token_lifetime;
+  grpc_credentials_status status =
+      grpc_oauth2_token_fetcher_credentials_parse_server_response(
+          &response, &access_token_value, &token_lifetime);
+  if (status != GRPC_CREDENTIALS_OK) {
+    return absl::UnavailableError("error parsing oauth2 token");
+  }
+  return MakeRefCounted<Token>(std::move(*access_token_value),
+                               Timestamp::Now() + token_lifetime);
 }
 
 }  // namespace grpc_core
@@ -298,6 +285,7 @@ class grpc_compute_engine_token_fetcher_credentials
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> StartHttpRequest(
       grpc_polling_entity* pollent, grpc_core::Timestamp deadline,
       grpc_http_response* response, grpc_closure* on_complete) override {
+    email_fetcher_->StartEmailFetch();
     memset(response, 0, sizeof(*response));
     grpc_http_header header = {const_cast<char*>("Metadata-Flavor"),
                                const_cast<char*>("Google")};
@@ -322,39 +310,25 @@ class grpc_compute_engine_token_fetcher_credentials
     return http_request;
   }
 
-  grpc_core::OrphanablePtr<FetchRequest> FetchToken(
-      grpc_core::Timestamp deadline,
-      absl::AnyInvocable<void(absl::StatusOr<grpc_core::RefCountedPtr<
-                                  TokenFetcherCredentials::Token>>)>
-          on_done) override {
-    email_fetcher_->StartEmailFetch();
-    return grpc_core::MakeOrphanable<HttpFetchRequest>(
-        this, deadline,
-        [email_fetcher = email_fetcher_, on_done = std::move(on_done)](
-            absl::StatusOr<grpc_http_response> response) mutable {
-          if (!response.ok()) {
-            on_done(response.status());
-            return;
-          }
-          std::optional<grpc_core::Slice> access_token_value;
-          grpc_core::Duration token_lifetime;
-          grpc_credentials_status status =
-              grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                  &(*response), &access_token_value, &token_lifetime);
-          if (status != GRPC_CREDENTIALS_OK) {
-            on_done(absl::UnavailableError("error parsing oauth2 token"));
-            return;
-          }
-          on_done(grpc_core::MakeRefCounted<TokenWithEmail>(
-              std::move(*access_token_value),
-              grpc_core::Timestamp::Now() + token_lifetime,
-              std::move(email_fetcher)));
-        });
+  absl::StatusOr<grpc_core::RefCountedPtr<Token>> ExtractToken(
+      const grpc_http_response& response) final {
+    std::optional<grpc_core::Slice> access_token_value;
+    grpc_core::Duration token_lifetime;
+    grpc_credentials_status status =
+        grpc_oauth2_token_fetcher_credentials_parse_server_response(
+            &response, &access_token_value, &token_lifetime);
+    if (status != GRPC_CREDENTIALS_OK) {
+      return absl::UnavailableError("error parsing oauth2 token");
+    }
+    return grpc_core::MakeRefCounted<TokenWithEmail>(
+        std::move(*access_token_value),
+        grpc_core::Timestamp::Now() + token_lifetime, email_fetcher_);
   }
 
   grpc_core::RefCountedPtr<grpc_core::EmailFetcher> email_fetcher_;
   std::vector<grpc_core::URI::QueryParam> query_params_;
 };
+
 }  // namespace
 
 grpc_call_credentials* grpc_google_compute_engine_credentials_create(

--- a/src/core/credentials/call/oauth2/oauth2_credentials.h
+++ b/src/core/credentials/call/oauth2/oauth2_credentials.h
@@ -95,11 +95,8 @@ class Oauth2TokenFetcherCredentials : public HttpTokenFetcherCredentials {
 
   UniqueTypeName type() const override;
 
-  OrphanablePtr<FetchRequest> FetchToken(
-      Timestamp deadline,
-      absl::AnyInvocable<
-          void(absl::StatusOr<RefCountedPtr<TokenFetcherCredentials::Token>>)>
-          on_done) final;
+  absl::StatusOr<RefCountedPtr<Token>> ExtractToken(
+      const grpc_http_response& response) final;
 
  private:
   int cmp_impl(const grpc_call_credentials* other) const override {

--- a/src/core/credentials/call/token_fetcher/token_fetcher_credentials.cc
+++ b/src/core/credentials/call/token_fetcher/token_fetcher_credentials.cc
@@ -307,13 +307,13 @@ TokenFetcherCredentials::GetRequestMetadata(
 //
 
 HttpTokenFetcherCredentials::HttpFetchRequest::HttpFetchRequest(
-    HttpTokenFetcherCredentials* creds, Timestamp deadline,
-    absl::AnyInvocable<void(absl::StatusOr<grpc_http_response>)> on_done)
-    : on_done_(std::move(on_done)) {
+    WeakRefCountedPtr<HttpTokenFetcherCredentials> creds, Timestamp deadline,
+    absl::AnyInvocable<void(absl::StatusOr<RefCountedPtr<Token>>)> on_done)
+    : creds_(std::move(creds)), on_done_(std::move(on_done)) {
   GRPC_CLOSURE_INIT(&on_http_response_, OnHttpResponse, this, nullptr);
   Ref().release();  // Ref held by HTTP request callback.
-  http_request_ = creds->StartHttpRequest(creds->pollent(), deadline,
-                                          &response_, &on_http_response_);
+  http_request_ = creds_->StartHttpRequest(creds_->pollent(), deadline,
+                                           &response_, &on_http_response_);
 }
 
 void HttpTokenFetcherCredentials::HttpFetchRequest::Orphan() {
@@ -332,6 +332,7 @@ void HttpTokenFetcherCredentials::HttpFetchRequest::OnHttpResponse(
     self->on_done_(absl::UnavailableError(StatusToString(error)));
     return;
   }
+  // Check HTTP status code.
   if (self->response_.status != 200) {
     grpc_status_code status_code =
         grpc_http2_status_to_grpc_status(self->response_.status);
@@ -344,7 +345,18 @@ void HttpTokenFetcherCredentials::HttpFetchRequest::OnHttpResponse(
                                   self->response_.status)));
     return;
   }
-  self->on_done_(self->response_);
+  // Extract token and return result.
+  auto token = self->creds_->ExtractToken(self->response_);
+  self->on_done_(std::move(token));
+}
+
+OrphanablePtr<TokenFetcherCredentials::FetchRequest>
+HttpTokenFetcherCredentials::FetchToken(
+    Timestamp deadline,
+    absl::AnyInvocable<void(absl::StatusOr<RefCountedPtr<Token>>)> on_done) {
+  return MakeOrphanable<HttpFetchRequest>(
+      WeakRefAsSubclass<HttpTokenFetcherCredentials>(), deadline,
+      std::move(on_done));
 }
 
 }  // namespace grpc_core

--- a/src/core/credentials/call/token_fetcher/token_fetcher_credentials.h
+++ b/src/core/credentials/call/token_fetcher/token_fetcher_credentials.h
@@ -183,32 +183,46 @@ class TokenFetcherCredentials : public grpc_call_credentials {
 };
 
 // A base class for fetching tokens via an HTTP request.
+// Subclasses must implement StartHttpRequest() and ExtractToken().
 class HttpTokenFetcherCredentials : public TokenFetcherCredentials {
  public:
+  // Starts an HTTP request.
   virtual OrphanablePtr<HttpRequest> StartHttpRequest(
       grpc_polling_entity* pollent, Timestamp deadline,
       grpc_http_response* response, grpc_closure* on_complete) = 0;
 
- protected:
+  // Extracts a token from the HTTP response.
+  // This will be called only if the HTTP status code was 200 (OK).
+  virtual absl::StatusOr<RefCountedPtr<Token>> ExtractToken(
+      const grpc_http_response& response) = 0;
+
+ private:
   // State held for a pending HTTP request.
   class HttpFetchRequest : public TokenFetcherCredentials::FetchRequest {
    public:
-    // The given callback should assume the http response status has already
-    // been checked and handle the token parsing.
     HttpFetchRequest(
-        HttpTokenFetcherCredentials* creds, Timestamp deadline,
-        absl::AnyInvocable<void(absl::StatusOr<grpc_http_response>)> on_done);
+        WeakRefCountedPtr<HttpTokenFetcherCredentials> creds,
+        Timestamp deadline,
+        absl::AnyInvocable<void(absl::StatusOr<RefCountedPtr<Token>>)> on_done);
+
     ~HttpFetchRequest() override { grpc_http_response_destroy(&response_); }
 
     void Orphan() override;
 
    private:
     static void OnHttpResponse(void* arg, grpc_error_handle error);
-    OrphanablePtr<HttpRequest> http_request_;
+
+    WeakRefCountedPtr<HttpTokenFetcherCredentials> creds_;
+    absl::AnyInvocable<void(absl::StatusOr<RefCountedPtr<Token>>)> on_done_;
     grpc_closure on_http_response_;
+    OrphanablePtr<HttpRequest> http_request_;
     grpc_http_response response_;
-    absl::AnyInvocable<void(absl::StatusOr<grpc_http_response>)> on_done_;
   };
+
+  OrphanablePtr<FetchRequest> FetchToken(
+      Timestamp deadline,
+      absl::AnyInvocable<void(absl::StatusOr<RefCountedPtr<Token>>)> on_done)
+      final;
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
Refactor the `HttpTokenFetcherCredentials` API (introduced in https://github.com/grpc/grpc/pull/40907) to make it easier to implement subclasses.

Subclasses no longer need to override the `FetchToken()` method or wrap the `on_done` callback.  Instead, they just need to implement the `ExtractToken()` method to extract the token from the HTTP response.