### PR TITLE
[Python] Fixed channelz module leak

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/channelz.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channelz.pyx.pxi
@@ -20,22 +20,31 @@ def channelz_get_top_channels(start_channel_id):
     if c_returned_str == NULL:
         raise ValueError('Failed to get top channels, please ensure your' \
                          ' start_channel_id==%s is valid' % start_channel_id)
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_servers(start_server_id):
     cdef char *c_returned_str = grpc_channelz_get_servers(start_server_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get servers, please ensure your' \
                          ' start_server_id==%s is valid' % start_server_id)
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_server(server_id):
     cdef char *c_returned_str = grpc_channelz_get_server(server_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the server, please ensure your' \
                          ' server_id==%s is valid' % server_id)
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_server_sockets(server_id, start_socket_id, max_results):
     cdef char *c_returned_str = grpc_channelz_get_server_sockets(
         server_id,
@@ -47,25 +56,36 @@ def channelz_get_server_sockets(server_id, start_socket_id, max_results):
                          ' server_id==%s and start_socket_id==%s and' \
                          ' max_results==%s is valid' %
                          (server_id, start_socket_id, max_results))
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_channel(channel_id):
     cdef char *c_returned_str = grpc_channelz_get_channel(channel_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the channel, please ensure your' \
                          ' channel_id==%s is valid' % (channel_id))
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_subchannel(subchannel_id):
     cdef char *c_returned_str = grpc_channelz_get_subchannel(subchannel_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the subchannel, please ensure your' \
                          ' subchannel_id==%s is valid' % (subchannel_id))
-    return c_returned_str
-    
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result
+
+
 def channelz_get_socket(socket_id):
     cdef char *c_returned_str = grpc_channelz_get_socket(socket_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the socket, please ensure your' \
                          ' socket_id==%s is valid' % (socket_id))
-    return c_returned_str
+    result = <bytes>c_returned_str
+    gpr_free(c_returned_str)
+    return result


### PR DESCRIPTION
## Issue
All `def channelz_get_*` functions from channelz module leak the returned `char*` string from the C-core. 

## Proposed fix
Calling `gpr_free()` before returning the value to the caller.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

