### PR TITLE
[WRR] remove env var guard for custom backend metrics

### DIFF
--- a/doc/grpc_xds_features.md
+++ b/doc/grpc_xds_features.md
@@ -83,3 +83,4 @@ Stateful Session Affinity | [A55](https://github.com/grpc/proposal/blob/master/A
 xDS Locality label for OpenTelemetry metrics | [A78](https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md) | v1.63.0 (C++) | v1.64.0 | | |
 xDS Fallback | [A71](https://github.com/grpc/proposal/blob/master/A71-xds-fallback.md) | v1.67.0 | v1.71.0 | v1.70.0 | |
 Dualstack Backend Support | [A61](https://github.com/grpc/proposal/blob/master/A61-IPv4-IPv6-dualstack-backends.md) | v1.66.1 | | v1.71.0 | v1.12.0 |
+WRR Support for Custom Backend Metrics | [A114](https://github.com/grpc/proposal/blob/master/A114-wrr-metric-names-for-computing-utilization.md) | v1.84.0 | | | |

--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
@@ -80,10 +80,6 @@
 
 namespace grpc_core {
 
-bool WrrCustomMetricsEnabled() {
-  return IsExperimentEnvVarEnabled("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
-}
-
 namespace {
 
 constexpr absl::string_view kWeightedRoundRobin = "weighted_round_robin";
@@ -216,41 +212,40 @@ void WeightedRoundRobinConfig::JsonPostLoad(const Json& json,
     ValidationErrors::ScopedField field(errors, ".errorUtilizationPenalty");
     errors->AddError("must be non-negative");
   }
-  if (WrrCustomMetricsEnabled()) {
-    std::optional<std::vector<std::string>>
-        metric_names_for_computing_utilization =
-            LoadJsonObjectField<std::vector<std::string>>(
-                json.object(), args, "metricNamesForComputingUtilization",
-                errors, /*required=*/false);
-    if (metric_names_for_computing_utilization.has_value()) {
-      size_t i = 0;
-      for (const auto& metric_name : *metric_names_for_computing_utilization) {
-        if (metric_name == "cpu_utilization") {
-          parsed_custom_metrics_.push_back(
-              {WeightedRoundRobinConfig::ParsedMetric::Type::kCpu, ""});
-        } else if (metric_name == "mem_utilization") {
-          parsed_custom_metrics_.push_back(
-              {WeightedRoundRobinConfig::ParsedMetric::Type::kMem, ""});
-        } else if (metric_name == "application_utilization") {
-          parsed_custom_metrics_.push_back(
-              {WeightedRoundRobinConfig::ParsedMetric::Type::kApplication, ""});
-        } else if (absl::StartsWith(metric_name, "named_metrics.")) {
-          parsed_custom_metrics_.push_back(
-              {WeightedRoundRobinConfig::ParsedMetric::Type::kNamedMetric,
-               std::string(absl::StripPrefix(metric_name, "named_metrics."))});
-        } else if (absl::StartsWith(metric_name, "utilization.")) {
-          parsed_custom_metrics_.push_back(
-              {WeightedRoundRobinConfig::ParsedMetric::Type::kUtilization,
-               std::string(absl::StripPrefix(metric_name, "utilization."))});
-        } else {
-          ValidationErrors::ScopedField field(
-              errors,
-              absl::StrCat(".metricNamesForComputingUtilization[", i, "]"));
-          errors->AddError(
-              absl::StrCat("unsupported metric name \"", metric_name, "\""));
-        }
-        ++i;
+  // Handle metricNamesForComputingUtilization.
+  std::optional<std::vector<std::string>>
+      metric_names_for_computing_utilization =
+          LoadJsonObjectField<std::vector<std::string>>(
+              json.object(), args, "metricNamesForComputingUtilization", errors,
+              /*required=*/false);
+  if (metric_names_for_computing_utilization.has_value()) {
+    size_t i = 0;
+    for (const auto& metric_name : *metric_names_for_computing_utilization) {
+      if (metric_name == "cpu_utilization") {
+        parsed_custom_metrics_.push_back(
+            {WeightedRoundRobinConfig::ParsedMetric::Type::kCpu, ""});
+      } else if (metric_name == "mem_utilization") {
+        parsed_custom_metrics_.push_back(
+            {WeightedRoundRobinConfig::ParsedMetric::Type::kMem, ""});
+      } else if (metric_name == "application_utilization") {
+        parsed_custom_metrics_.push_back(
+            {WeightedRoundRobinConfig::ParsedMetric::Type::kApplication, ""});
+      } else if (absl::StartsWith(metric_name, "named_metrics.")) {
+        parsed_custom_metrics_.push_back(
+            {WeightedRoundRobinConfig::ParsedMetric::Type::kNamedMetric,
+             std::string(absl::StripPrefix(metric_name, "named_metrics."))});
+      } else if (absl::StartsWith(metric_name, "utilization.")) {
+        parsed_custom_metrics_.push_back(
+            {WeightedRoundRobinConfig::ParsedMetric::Type::kUtilization,
+             std::string(absl::StripPrefix(metric_name, "utilization."))});
+      } else {
+        ValidationErrors::ScopedField field(
+            errors,
+            absl::StrCat(".metricNamesForComputingUtilization[", i, "]"));
+        errors->AddError(
+            absl::StrCat("unsupported metric name \"", metric_name, "\""));
       }
+      ++i;
     }
   }
 }

--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.h
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.h
@@ -30,8 +30,6 @@
 
 namespace grpc_core {
 
-bool WrrCustomMetricsEnabled();
-
 class WeightedRoundRobinConfig final : public LoadBalancingPolicy::Config {
  public:
   struct ParsedMetric {

--- a/src/core/xds/grpc/xds_bootstrap_grpc_builder.cc
+++ b/src/core/xds/grpc/xds_bootstrap_grpc_builder.cc
@@ -206,20 +206,18 @@ class ClientSideWeightedRoundRobinLbPolicyConfigFactory final
       config["errorUtilizationPenalty"] = Json::FromNumber(value);
     }
     // metric_names_for_computing_utilization
-    if (WrrCustomMetricsEnabled()) {
-      size_t size;
-      auto metric_names_for_computing_utilization =
-          envoy_extensions_load_balancing_policies_client_side_weighted_round_robin_v3_ClientSideWeightedRoundRobin_metric_names_for_computing_utilization(
-              resource, &size);
-      if (metric_names_for_computing_utilization != nullptr && size != 0) {
-        Json::Array metric_names;
-        for (size_t i = 0; i < size; ++i) {
-          metric_names.emplace_back(Json::FromString(
-              UpbStringToStdString(metric_names_for_computing_utilization[i])));
-        }
-        config["metricNamesForComputingUtilization"] =
-            Json::FromArray(std::move(metric_names));
+    size_t size;
+    auto metric_names_for_computing_utilization =
+        envoy_extensions_load_balancing_policies_client_side_weighted_round_robin_v3_ClientSideWeightedRoundRobin_metric_names_for_computing_utilization(
+            resource, &size);
+    if (metric_names_for_computing_utilization != nullptr && size != 0) {
+      Json::Array metric_names;
+      for (size_t i = 0; i < size; ++i) {
+        metric_names.emplace_back(Json::FromString(
+            UpbStringToStdString(metric_names_for_computing_utilization[i])));
       }
+      config["metricNamesForComputingUtilization"] =
+          Json::FromArray(std::move(metric_names));
     }
     return Json::Object{
         {"weighted_round_robin", Json::FromObject(std::move(config))}};

--- a/test/core/load_balancing/weighted_round_robin_config_test.cc
+++ b/test/core/load_balancing/weighted_round_robin_config_test.cc
@@ -100,7 +100,6 @@ TEST(WeightedRoundRobinConfigTest, InvalidValues) {
 }
 
 TEST(WeightedRoundRobinConfigTest, UnsupportedMetricNames) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const char* service_config_json =
       "{\n"
       "  \"loadBalancingConfig\":[{\n"
@@ -122,7 +121,6 @@ TEST(WeightedRoundRobinConfigTest, UnsupportedMetricNames) {
 }
 
 TEST(WeightedRoundRobinConfigTest, ValidMetricNamesEnabled) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const char* service_config_json =
       "{\n"
       "  \"loadBalancingConfig\":[{\n"
@@ -149,31 +147,6 @@ TEST(WeightedRoundRobinConfigTest, ValidMetricNamesEnabled) {
   EXPECT_EQ(custom_metrics[0].type,
             WeightedRoundRobinConfig::ParsedMetric::Type::kCpu);
   EXPECT_EQ(custom_metrics[0].name, "");
-}
-
-TEST(WeightedRoundRobinConfigTest, MetricNamesDisabled) {
-  const char* service_config_json =
-      "{\n"
-      "  \"loadBalancingConfig\":[{\n"
-      "    \"weighted_round_robin\":{\n"
-      "      \"metricNamesForComputingUtilization\": [\"cpu_utilization\"]\n"
-      "    }\n"
-      "  }]\n"
-      "}\n";
-  auto service_config =
-      ServiceConfigImpl::Create(ChannelArgs(), service_config_json);
-  ASSERT_TRUE(service_config.ok()) << service_config.status();
-  EXPECT_NE(*service_config, nullptr);
-  auto global_config = DownCast<internal::ClientChannelGlobalParsedConfig*>(
-      (*service_config)
-          ->GetGlobalParsedConfig(
-              internal::ClientChannelServiceConfigParser::ParserIndex()));
-  ASSERT_NE(global_config, nullptr);
-  auto lb_config = global_config->parsed_lb_config();
-  ASSERT_NE(lb_config, nullptr);
-  ASSERT_EQ(lb_config->name(), "weighted_round_robin");
-  auto* wrr_config = DownCast<WeightedRoundRobinConfig*>(lb_config.get());
-  EXPECT_TRUE(wrr_config->parsed_custom_metrics().empty());
 }
 
 }  // namespace

--- a/test/core/load_balancing/weighted_round_robin_test.cc
+++ b/test/core/load_balancing/weighted_round_robin_test.cc
@@ -448,36 +448,7 @@ TEST_F(WeightedRoundRobinTest, AppUtilOverCpuUtil) {
       {{kAddresses[0], 1}, {kAddresses[1], 3}, {kAddresses[2], 3}});
 }
 
-TEST_F(WeightedRoundRobinTest, WrrCustomMetricDisabledFallback) {
-  const std::array<absl::string_view, 3> kAddresses = {
-      "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
-  std::vector<std::string> metric_names = {"named_metrics.foo"};
-  auto picker = SendInitialUpdateAndWaitForConnected(
-      kAddresses,
-      ConfigBuilder().SetMetricNamesForComputingUtilization(metric_names));
-  ASSERT_NE(picker, nullptr);
-  // Address 0 reports a high named metric "foo", but since feature is disabled,
-  // it should use cpu_utilization (fallback) or app_utilization.
-  // Here we provide
-  // app_utilization=0
-  // cpu_utilization=0.1.
-  // "foo" = 0.9.
-  // If ignored, utilization = 0.1 (cpu).
-  WaitForWeightedRoundRobinPicks(
-      &picker,
-      {{kAddresses[0],
-        MakeBackendMetricData(/*app_utilization=*/0,
-                              /*qps=*/100.0, /*eps=*/0.0,
-                              /*cpu_utilization=*/0.1,
-                              /*mem_utilization=*/0.0, {{"foo", 0.9}})},
-       {kAddresses[1], MakeBackendMetricData(/*app_utilization=*/0,
-                                             /*qps=*/100.0, /*eps=*/0.0,
-                                             /*cpu_utilization=*/0.1)}},
-      {{kAddresses[0], 1}, {kAddresses[1], 1}, {kAddresses[2], 1}});
-}
-
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledCpuUtilization) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"cpu_utilization"};
@@ -502,7 +473,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledCpuUtilization) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledMemUtilization) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"mem_utilization"};
@@ -526,7 +496,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledMemUtilization) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledAppUtilization) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"application_utilization"};
@@ -546,7 +515,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledAppUtilization) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledNamedMetric) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"named_metrics.foo"};
@@ -572,7 +540,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledNamedMetric) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledUtilizationMetric) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"utilization.foo"};
@@ -598,7 +565,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledUtilizationMetric) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledMultipleMetricsMax) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   // Checks that we take the MAX of the specified metrics.
@@ -626,7 +592,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledMultipleMetricsMax) {
 }
 
 TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledFallbackPriority) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
   const std::array<absl::string_view, 3> kAddresses = {
       "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
   std::vector<std::string> metric_names = {"named_metrics.foo"};
@@ -656,30 +621,6 @@ TEST_F(WeightedRoundRobinTest, WrrCustomMetricEnabledFallbackPriority) {
                            /*cpu_utilization=*/0.45, /*mem_utilization=*/0.0,
                            {{"foo", 0.0}})}},
       {{kAddresses[0], 1}, {kAddresses[1], 1}, {kAddresses[2], 2}});
-}
-
-// TODO(rishesh): Once the env var guard is removed, this entire test case can
-// be removed, since it will be a duplicate of several existing tests above.
-// Checks that if enabled but no metric names provided, we default to CPU.
-TEST_F(WeightedRoundRobinTest,
-       WrrCustomMetricEnabledNoMetricNamesDefaultsToCpu) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
-  const std::array<absl::string_view, 3> kAddresses = {
-      "ipv4:127.0.0.1:441", "ipv4:127.0.0.1:442", "ipv4:127.0.0.1:443"};
-  // No metric names provided, should default to CPU utilization.
-  auto picker = SendInitialUpdateAndWaitForConnected(kAddresses);
-  ASSERT_NE(picker, nullptr);
-  // Addr 0: cpu=0.9
-  // Addr 1: cpu=0.1
-  WaitForWeightedRoundRobinPicks(
-      &picker,
-      {{kAddresses[0], MakeBackendMetricData(/*app_utilization=*/0,
-                                             /*qps=*/100.0, /*eps=*/0.0,
-                                             /*cpu_utilization=*/0.9)},
-       {kAddresses[1], MakeBackendMetricData(/*app_utilization=*/0,
-                                             /*qps=*/100.0, /*eps=*/0.0,
-                                             /*cpu_utilization=*/0.1)}},
-      {{kAddresses[0], 1}, {kAddresses[1], 9}, {kAddresses[2], 5}});
 }
 
 TEST_F(WeightedRoundRobinTest, Eps) {

--- a/test/core/xds/xds_lb_policy_registry_test.cc
+++ b/test/core/xds/xds_lb_policy_registry_test.cc
@@ -166,8 +166,7 @@ TEST(ClientSideWeightedRoundRobinTest, FieldsExplicitlySet) {
             "}}");
 }
 
-TEST(ClientSideWeightedRoundRobinTest, WrrCustomMetricsEnabled) {
-  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS");
+TEST(ClientSideWeightedRoundRobinTest, WrrCustomMetrics) {
   ClientSideWeightedRoundRobin wrr;
   wrr.add_metric_names_for_computing_utilization("cpu_usage");
   LoadBalancingPolicyProto policy;
@@ -181,19 +180,6 @@ TEST(ClientSideWeightedRoundRobinTest, WrrCustomMetricsEnabled) {
             "{\"weighted_round_robin\":{"
             "\"metricNamesForComputingUtilization\":[\"cpu_usage\"]"
             "}}");
-}
-
-TEST(ClientSideWeightedRoundRobinTest, WrrCustomMetricsDisabled) {
-  ClientSideWeightedRoundRobin wrr;
-  wrr.add_metric_names_for_computing_utilization("cpu_usage");
-  LoadBalancingPolicyProto policy;
-  policy.add_policies()
-      ->mutable_typed_extension_config()
-      ->mutable_typed_config()
-      ->PackFrom(wrr);
-  auto result = ConvertXdsPolicy(policy);
-  ASSERT_TRUE(result.ok()) << result.status();
-  EXPECT_EQ(*result, "{\"weighted_round_robin\":{}}");
 }
 
 TEST(ClientSideWeightedRoundRobinTest, InvalidValues) {

--- a/test/core/xds/xds_lb_policy_registry_test.cc
+++ b/test/core/xds/xds_lb_policy_registry_test.cc
@@ -160,25 +160,10 @@ TEST(ClientSideWeightedRoundRobinTest, FieldsExplicitlySet) {
             "\"blackoutPeriod\":\"2.000000000s\","
             "\"enableOobLoadReport\":true,"
             "\"errorUtilizationPenalty\":5,"
+            "\"metricNamesForComputingUtilization\":[\"cpu_usage\"],"
             "\"oobReportingPeriod\":\"1.000000000s\","
             "\"weightExpirationPeriod\":\"3.000000000s\","
             "\"weightUpdatePeriod\":\"4.000000000s\""
-            "}}");
-}
-
-TEST(ClientSideWeightedRoundRobinTest, WrrCustomMetrics) {
-  ClientSideWeightedRoundRobin wrr;
-  wrr.add_metric_names_for_computing_utilization("cpu_usage");
-  LoadBalancingPolicyProto policy;
-  policy.add_policies()
-      ->mutable_typed_extension_config()
-      ->mutable_typed_config()
-      ->PackFrom(wrr);
-  auto result = ConvertXdsPolicy(policy);
-  ASSERT_TRUE(result.ok()) << result.status();
-  EXPECT_EQ(*result,
-            "{\"weighted_round_robin\":{"
-            "\"metricNamesForComputingUtilization\":[\"cpu_usage\"]"
             "}}");
 }
 


### PR DESCRIPTION
This enables support for [gRFC A114](https://github.com/grpc/proposal/blob/master/A114-wrr-metric-names-for-computing-utilization.md).