### PR TITLE
Unchecked malloc() in GrpcMemoryAllocatorImpl::MakeSlice

### DIFF
--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -405,9 +405,7 @@ void GrpcMemoryAllocatorImpl::Replenish() {
 
 grpc_slice GrpcMemoryAllocatorImpl::MakeSlice(MemoryRequest request) {
   auto size = Reserve(request.Increase(sizeof(SliceRefCount)));
-  void* p = malloc(size);
-  GRPC_CHECK_NE(p, nullptr) << absl::StrFormat(
-      "GrpcMemoryAllocatorImpl::MakeSlice: malloc(%zu) returned nullptr", size);
+  void* p = gpr_malloc(size);
   new (p) SliceRefCount(shared_from_this(), size);
   grpc_slice slice;
   slice.refcount = static_cast<SliceRefCount*>(p);

--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -406,6 +406,8 @@ void GrpcMemoryAllocatorImpl::Replenish() {
 grpc_slice GrpcMemoryAllocatorImpl::MakeSlice(MemoryRequest request) {
   auto size = Reserve(request.Increase(sizeof(SliceRefCount)));
   void* p = malloc(size);
+  GRPC_CHECK_NE(p, nullptr) << absl::StrFormat(
+      "GrpcMemoryAllocatorImpl::MakeSlice: malloc(%zu) returned nullptr", size);
   new (p) SliceRefCount(shared_from_this(), size);
   grpc_slice slice;
   slice.refcount = static_cast<SliceRefCount*>(p);


### PR DESCRIPTION
Change from PR #42499 that didn't end up getting merged. This checks if malloc() is returning a nullptr, and handles it gracefully rather than leading to a SEGFAULT. Addresses #42148 .