### PR TITLE
[Python] Fixed CSDS memory leak

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
@@ -17,7 +17,8 @@ def dump_xds_configs():
     cdef grpc_slice client_config_in_slice
     with nogil:
         client_config_in_slice = grpc_dump_xds_configs()
-    cdef bytes result = _slice_bytes(client_config_in_slice)
-    with nogil:
-        grpc_slice_unref(client_config_in_slice)
-    return result
+    try:
+        return _slice_bytes(client_config_in_slice)
+    finally:
+        with nogil:
+            grpc_slice_unref(client_config_in_slice)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
@@ -18,4 +18,6 @@ def dump_xds_configs():
     with nogil:
         client_config_in_slice = grpc_dump_xds_configs()
     cdef bytes result = _slice_bytes(client_config_in_slice)
+    with nogil:
+        grpc_slice_unref(client_config_in_slice)
     return result

--- a/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/csds.pyx.pxi
@@ -20,5 +20,4 @@ def dump_xds_configs():
     try:
         return _slice_bytes(client_config_in_slice)
     finally:
-        with nogil:
-            grpc_slice_unref(client_config_in_slice)
+        grpc_slice_unref(client_config_in_slice)


### PR DESCRIPTION
## Issue
[DumpAllClientsConfig()](https://github.com/grpc/grpc/blob/676a469ac706646ea132eedb8b9764647db49734/src/core/xds/grpc/xds_client_grpc.cc#L411) call creates new slice from the proto message bytes. Depending on the length of the message [refcounted](https://github.com/grpc/grpc/blob/676a469ac706646ea132eedb8b9764647db49734/src/core/lib/slice/slice.cc#L212) or [inlined](https://github.com/grpc/grpc/blob/676a469ac706646ea132eedb8b9764647db49734/src/core/lib/slice/slice.cc#L208) slice will be created. The issue is related to the refcounted one - slice is never `unref`'ed in the Python code, which might lead to the memory leak.

## Proposed fix
Added `grpc_slice_unref()` call in the Cython layer. [For the inlined slices this is a no-op, while for the refcounted memory is successfully released](https://github.com/grpc/grpc/blob/7e368e0ae6f8683e1cd232fcde49a1bbdc989aaa/src/core/lib/slice/slice.h#L64). Before memory is released, Cython creates its own copy of the slice bytes via `_slice_bytes()` call.
