### PR TITLE
[Python] Fixed CSDS stream test case

### DIFF
--- a/src/python/grpcio_tests/tests/csds/csds_test.py
+++ b/src/python/grpcio_tests/tests/csds/csds_test.py
@@ -126,12 +126,12 @@ class TestCsds(unittest.TestCase):
 class TestCsdsStream(TestCsds):
     def get_xds_config_dump(self):
         if not hasattr(self, "request_queue"):
-            request_queue = queue.Queue()
-            response_iterator = self._stub.StreamClientStatus(
-                iter(request_queue.get, None)
+            self.request_queue = queue.Queue()
+            self.response_iterator = self._stub.StreamClientStatus(
+                iter(self.request_queue.get, None)
             )
-        request_queue.put(csds_pb2.ClientStatusRequest())
-        return next(response_iterator)
+        self.request_queue.put(csds_pb2.ClientStatusRequest())
+        return next(self.response_iterator)
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests/csds/csds_test.py
+++ b/src/python/grpcio_tests/tests/csds/csds_test.py
@@ -124,13 +124,18 @@ class TestCsds(unittest.TestCase):
 
 
 class TestCsdsStream(TestCsds):
+    def setUp(self):
+        super().setUp()
+        self.request_queue = None
+        self.response_iterator = None
+
     def tearDown(self):
-        if hasattr(self, "request_queue"):
+        if self.request_queue is not None:
             self.request_queue.put(None)
         super().tearDown()
 
     def get_xds_config_dump(self):
-        if not hasattr(self, "request_queue"):
+        if self.request_queue is None:
             self.request_queue = queue.Queue()
             self.response_iterator = self._stub.StreamClientStatus(
                 iter(self.request_queue.get, None)

--- a/src/python/grpcio_tests/tests/csds/csds_test.py
+++ b/src/python/grpcio_tests/tests/csds/csds_test.py
@@ -124,6 +124,11 @@ class TestCsds(unittest.TestCase):
 
 
 class TestCsdsStream(TestCsds):
+    def tearDown(self):
+        if hasattr(self, "request_queue"):
+            self.request_queue.put(None)
+        super().tearDown()
+
     def get_xds_config_dump(self):
         if not hasattr(self, "request_queue"):
             self.request_queue = queue.Queue()

--- a/src/python/grpcio_tests/tests/csds/csds_test.py
+++ b/src/python/grpcio_tests/tests/csds/csds_test.py
@@ -126,22 +126,22 @@ class TestCsds(unittest.TestCase):
 class TestCsdsStream(TestCsds):
     def setUp(self):
         super().setUp()
-        self.request_queue = None
-        self.response_iterator = None
+        self._request_queue = None
+        self._response_iterator = None
 
     def tearDown(self):
-        if self.request_queue is not None:
-            self.request_queue.put(None)
+        if self._request_queue is not None:
+            self._request_queue.put(None)
         super().tearDown()
 
     def get_xds_config_dump(self):
-        if self.request_queue is None:
-            self.request_queue = queue.Queue()
-            self.response_iterator = self._stub.StreamClientStatus(
-                iter(self.request_queue.get, None)
+        if self._request_queue is None:
+            self._request_queue = queue.Queue()
+            self._response_iterator = self._stub.StreamClientStatus(
+                iter(self._request_queue.get, None)
             )
-        self.request_queue.put(csds_pb2.ClientStatusRequest())
-        return next(self.response_iterator)
+        self._request_queue.put(csds_pb2.ClientStatusRequest())
+        return next(self._response_iterator)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
The `get_xds_config_dump()` method (from `TestCsdsStream`) intent is to reuse existing stream RPC (if any) and push a request in and read the response out. Stream RPC existence check is done via following code:
``` Python
    if not hasattr(self, "request_queue"):
```

Basically we check the `self` pointer if it contains the attribute of `request_queue`. However later on in the code `self.request_queue` is **never** created - a local variable is created instead. The memorization of previous stream RPCs never happens. `hasattr()` check is always `False` meaning that every call creates brand new stream RPC.

## Proposed fix
Apply `self` pointer to the missing places.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

