### PR TITLE
[CI] macOS jobs: brew offline installation for gnupg

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -69,7 +69,7 @@ if $is_sonoma; then
   # ==> Pouring ca-certificates--2026-05-14.all.bottle.tar.gz
   # Error: undefined method '[]' for nil
   # TODO(sergiitk): undo PR #42403 once ca-certificates is installable
-  brew install --cache --build-from-source gnupg
+  brew --cache --build-from-source gnupg
 
   brew install cmake
   brew install gnupg

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -69,7 +69,7 @@ if $is_sonoma; then
   # ==> Pouring ca-certificates--2026-05-14.all.bottle.tar.gz
   # Error: undefined method '[]' for nil
   # TODO(sergiitk): undo PR #42403 once ca-certificates is installable
-  brew install --build-from-source gnupg
+  brew install --cache --build-from-source gnupg
 
   brew install cmake
   brew install gnupg
@@ -147,11 +147,11 @@ gem install cocoapods -v 1.15.2 --no-document --user-install
 
 # 4. Add the gem binary directory to PATH
 export PATH="$(ruby -e 'puts Gem.user_dir')/bin:$PATH"
-  
+
   # 2. Verify the installation
   ruby --version
   pod --version
-  
+
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
Add `--cache` flag to attempt to build gnupg from the local tarball cache.