### PR TITLE
[Fix][CI] macOS jobs: Partially undo gnupg workaround #42403 to use cached sources

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -56,7 +56,7 @@ fi
 
 # Disable HOMEBREW update to avoid new updates which potentially have problems.
 # Brew packages installed when Kokoro image was built tend to have less conflict.
-export HOMEBREW_NO_AUTO_UPDATE=1
+# export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Dump the brew configuration for debugging just in case. Check "Core tap HEAD" field
 # because it should be the same as below unless it's been updated.

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -57,7 +57,6 @@ fi
 # Disable HOMEBREW update to avoid new updates which potentially have problems.
 # Brew packages installed when Kokoro image was built tend to have less conflict.
 export HOMEBREW_NO_AUTO_UPDATE=1
-export HOMEBREW_NO_INSTALL_FROM_API=1
 
 # Dump the brew configuration for debugging just in case. Check "Core tap HEAD" field
 # because it should be the same as below unless it's been updated.
@@ -65,12 +64,6 @@ export HOMEBREW_NO_INSTALL_FROM_API=1
 brew config
 
 if $is_sonoma; then
-  # A temporary fix for ca-certificates brew install:
-  # ==> Pouring ca-certificates--2026-05-14.all.bottle.tar.gz
-  # Error: undefined method '[]' for nil
-  # TODO(sergiitk): undo PR #42403 once ca-certificates is installable
-  brew install --build-from-source gnupg
-
   brew install cmake
   brew install gnupg
   brew install ccache
@@ -147,11 +140,11 @@ gem install cocoapods -v 1.15.2 --no-document --user-install
 
 # 4. Add the gem binary directory to PATH
 export PATH="$(ruby -e 'puts Gem.user_dir')/bin:$PATH"
-  
+
   # 2. Verify the installation
   ruby --version
   pod --version
-  
+
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -56,7 +56,15 @@ fi
 
 # Disable HOMEBREW update to avoid new updates which potentially have problems.
 # Brew packages installed when Kokoro image was built tend to have less conflict.
-# export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+# A temporary fix for ca-certificates brew install:
+# ==> Pouring ca-certificates--2026-05-14.all.bottle.tar.gz
+# Error: undefined method '[]' for nil
+# TODO(sergiitk): consider undoing once ca-certificates is installable.
+# See:
+# - https://github.com/grpc/grpc/pull/43193 - Initial ca-certificates fix.
+# - https://github.com/grpc/grpc/pull/43217 - Workaround for gnupg ftp down.
+export HOMEBREW_NO_INSTALL_FROM_API=1
 
 # Dump the brew configuration for debugging just in case. Check "Core tap HEAD" field
 # because it should be the same as below unless it's been updated.
@@ -140,11 +148,11 @@ gem install cocoapods -v 1.15.2 --no-document --user-install
 
 # 4. Add the gem binary directory to PATH
 export PATH="$(ruby -e 'puts Gem.user_dir')/bin:$PATH"
-
+  
   # 2. Verify the installation
   ruby --version
   pod --version
-
+  
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
This fixes the issue with the main GnuPG sources site being down at the moment.

```
$ xh -h https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.8.tar.bz2
HTTP/1.1 403 Forbidden
Connection: Keep-Alive
Content-Length: 275
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 12 Aug 2026 22:36:33 GMT
Keep-Alive: timeout=5, max=100
Server: Apache/2.4.56 (Debian)
```

This caused all MacOS Kokoro jobs to fail with:
```
++ brew install --build-from-source gnupg
... 
Error: Failed to download resource "gnupg (2.4.8)"
Download failed: [https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.8.tar.bz2](https://www.google.com/url?q=https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.8.tar.bz2&sa=D)
```

https://source.cloud.google.com/results/invocations/1cbfa293-bb04-4d44-9b74-68f0231230f4

I tried to undo #42403 fully, but we're still broken:

```
==> Installing dependencies for gnupg: ca-certificates, libunistring, json-c, gettext, libtasn1, nettle, p11-kit, gnutls, libgpg-error, libassuan, libgcrypt, libksba, libusb, npth and pinentry
==> Installing gnupg dependency: ca-certificates
==> Pouring ca-certificates--2026-07-16.all.bottle.2.tar.gz
Error: undefined method '[]' for nil
```

Surprisingly, removing `brew install --build-from-source gnupg` fixes everything. Why? No idea. Maybe it wasn't necessary for #42403 fix to work in the first place.

On a semi-related note, I learned is that we actually had `gnupg (2.4.8)` sources cached on the VM already:

```
++ brew --cache --build-from-source gnupg
/Users/kbuilder/Library/Caches/Homebrew/downloads/f3fa6052a2929df4e614d315998cfa23fd3ad51db8f50c298603933b3e592858--gnupg-2.4.8.tar.bz2
```

(note that `brew --cache --build-from-source gnupg` is not the same as `brew install --build-from-source gnupg`: it just prints the cached path).
