### PR TITLE
[CI] Add back missing files from #43185

### DIFF
--- a/third_party/rake-compiler-dock/README.md
+++ b/third_party/rake-compiler-dock/README.md
@@ -1,0 +1,53 @@
+# Building gRPC's Custom Rake Compiler Docker Images
+
+**INTERNAL ONLY**
+
+This document describes how to build custom `rake-compiler-dock` Docker images for gRPC, based on the upstream [rake-compiler-dock repository](https://github.com/rake-compiler/rake-compiler-dock).
+
+## Prerequisites
+
+Set up the required environment variables:
+
+```bash
+export GEM_ROOT=<path_to_clone_rake_compiler_dock_repo>
+export GIT_ROOT=<path_to_grpc_git_repo>
+```
+
+## Step-by-Step Instructions
+
+### 1. Clone upstream repository
+
+Clone the repository using `umask 0022` because the build process will execute
+scripts under `build/` using a different Linux user inside Docker. Therefore, we
+need to grant the necessary read/write permissions to other users.
+
+```bash
+(umask 0022; git clone https://github.com/rake-compiler/rake-compiler-dock -b v1.12.0 "$GEM_ROOT")
+```
+
+### 2. Build images
+
+Apply the customization patch and build the images locally.
+
+```bash
+cd "$GEM_ROOT" && git apply "${GIT_ROOT}/third_party/rake-compiler-dock/update_cross_compilers.patch"
+bundle config set --local path '.bundle/gems'
+bundle install
+bundle exec rake build:images
+```
+
+### 3. Re-tag customized images
+
+Tag the locally built images from the upstream reference prefix (`ghcr.io/rake-compiler/rake-compiler-dock-image`) to the gRPC public testing images repository prefix (`us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image`).
+
+```bash
+docker image ls --filter "reference=ghcr.io/rake-compiler/rake-compiler-dock-image" --format "{{.Repository}}:{{.Tag}}" | grep '1\.12\.0' | sed -E 's@^[^:]+:@@' | xargs -r -n1 -I{} docker tag ghcr.io/rake-compiler/rake-compiler-dock-image:{} us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:{}
+```
+
+### 4. Upload customized images
+
+Push the newly tagged images to the remote Google Artifact Registry repository.
+
+```bash
+docker image ls --filter "reference=ghcr.io/rake-compiler/rake-compiler-dock-image" --format "{{.Repository}}:{{.Tag}}" | grep '1\.12\.0' | sed -E 's@^[^:]+:@@' | xargs -r -n1 -I{} docker push us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:{}
+```

--- a/third_party/rake-compiler-dock/rake_aarch64-linux-gnu.current_version
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux-gnu.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux-gnu:b2e4f88d9ab2306817161e5b842bb83b85a4640b@sha256:630e8ee14181ad896a67bfba59168781a4081707762ad3b22fd424b0599a1099
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux-gnu:97fe6049c0f1df49f088a5b44b990ff91a8de589@sha256:e5cc04633d47df82ddef269753b4023058ee7dbb59b7f780060ec8779b19af77

--- a/third_party/rake-compiler-dock/rake_aarch64-linux-gnu/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-aarch64-linux-gnu
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-aarch64-linux-gnu
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_aarch64-linux-musl.current_version
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux-musl.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux-musl:167201b4a3f448f7be7ff75ae45c88736d3b461c@sha256:a35685d4087732d3deecdc0f3214598deef6a8c94a44e15ed8b39851e6bd5241
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux-musl:330993c50fbb357e4c5b0aaabccda45191c2e7c2@sha256:75fc70cf5662d49636f46807e33a779db1812a1ad39ca0c147507554cba91fc4

--- a/third_party/rake-compiler-dock/rake_aarch64-linux-musl/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-aarch64-linux-musl
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-aarch64-linux-musl
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:18a4fe844d2bca92db18b9ecd55a9101f82c5f07@sha256:cf957c32dd8817d45d3ebb02e4b3c66fcbe4c38db812d2cdbba2d2cd642241a5
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:71477211345e1d7e7c8cfdf7665cc58091551b79@sha256:57b04cda5a10f4ae09c0824a1b02f59cb4abdea393fdd20782208dc2e57ca750

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-arm64-darwin
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-arm64-darwin

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:5d6524738ce863bf0a8535630ef101dc40cc84b8@sha256:307bb7983dc3acebd1a7dde7433955d67863b675f6240d7f7729003d55765061
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:e8715aa7eb98afb3644d987634b8aa9ed92bd3c5@sha256:b0fa5fdfaedf469159085a5ef51e0512d04b040db677d1a41af776c5f29c9be2

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x64-mingw-ucrt
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x64-mingw-ucrt
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86-linux-gnu.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-linux-gnu.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux-gnu:dcf81aebad1b54d0890e050ee1f117249f74424b@sha256:42a74d7b9413a217a5ac94dd42c6b9e8748df9901a445c5fce677c9d513f2add
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux-gnu:b9a4ef688f15d08314441b7d590226286cf3e4b7@sha256:d467bc73fe20431b4f2884f024da2e4e69b7c6c2991617465b9471a97e590327

--- a/third_party/rake-compiler-dock/rake_x86-linux-gnu/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86-linux-gnu
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86-linux-gnu
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86-linux-musl.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-linux-musl.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux-musl:a2ae20d3067ebc429d74f039c96c62334d8f928b@sha256:c9f5d24cd75e1eb2d0f159c7a51dec05b7c13f07fa9a0b26618d842e9c6a01e1
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux-musl:4aa2b83557f5509fd48128cfcfecd647767961a8@sha256:be6c0e6d86568fcd29d7cfdc5f5601898b8287faa6fbed2c2e393a45de4fbac8

--- a/third_party/rake-compiler-dock/rake_x86-linux-musl/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86-linux-musl
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86-linux-musl
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:7d66d2ffd68e4f00e45f9149a4d9022f20e5c221@sha256:fa427e2ed1b3997f88b2cf04685f4311aa8eedd31457405fdd9ac1efa285f539
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:28ad626ef056c4e78cfe2186b4c82b86af3e0c08@sha256:61da9550c1794f3d89fa6c08318629b0594e90e5c72bc43b97ec6563e6da1dd4

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86-mingw32
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86-mingw32
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:8638abf6cedca794a28fa05dc80c4fa9373f796c@sha256:cbfa7625b6656941765827324141e6a06c3c3c30d2a15ff8d466e1f1bd2bde77
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:ae8eb11e4c6ae7e72931a388cadf284321f3e440@sha256:bf903e970f8a49033fa94765f35ee413c032c6b9c1f9b3798daa5e2b7f15f81f

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86_64-darwin
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86_64-darwin

--- a/third_party/rake-compiler-dock/rake_x86_64-linux-gnu.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux-gnu.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux-gnu:ec51eb4d1aa9479042438270adc1de14111ce1d1@sha256:b2b12feff4dd05afd57de30d995316a3080d48e58b26e0dbfbebc5c3dcd14014
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux-gnu:44caa501e3e37b25ad382ab2e2b6c1fabb4ed2a0@sha256:ab954f1cab34ec4f89fa752cb02139b3344f6892d28d06e06cd47baf57836c29

--- a/third_party/rake-compiler-dock/rake_x86_64-linux-gnu/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86_64-linux-gnu
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86_64-linux-gnu
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86_64-linux-musl.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux-musl.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux-musl:166dd283bac2323e5757f30eea6d4d86df404cc9@sha256:22bdfac59e753047aa17d4ef7b4ca720df75f66cab0248f92b2044be5b9b4c97
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux-musl:66259ef9c42c137feb533f73506ed862145212eb@sha256:9ee9bcfb53fd2f38c673e31dc208016310e1de006e82f98c494f568a69d1f6a1

--- a/third_party/rake-compiler-dock/rake_x86_64-linux-musl/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.11.1-mri-x86_64-linux-musl
+FROM us-docker.pkg.dev/grpc-testing/testing-images-public/rake-compiler-dock-image:1.12.0-mri-x86_64-linux-musl
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/update_cross_compilers.patch
+++ b/third_party/rake-compiler-dock/update_cross_compilers.patch
@@ -1,0 +1,122 @@
+# Adopted from https://github.com/rake-compiler/rake-compiler-dock/pull/201.
+# Install clang 14 and gcc 10 for better C++17 support.
+
+diff --git a/Dockerfile.mri.erb b/Dockerfile.mri.erb
+index 1bf488e..9d5c9ca 100644
+--- a/Dockerfile.mri.erb
++++ b/Dockerfile.mri.erb
+@@ -108,18 +108,58 @@ EOF
+ COPY build/mk_musl_cross.sh /tmp
+ RUN /tmp/mk_musl_cross.sh <%= target %>
+ 
++<% else %>
++<% if platform =~ /darwin/ %>
++RUN apt-get -y update && \
++    apt-get install -y wget && \
++    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /usr/share/keyrings/llvm-snapshot.gpg && \
++    echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" \
++        > /etc/apt/sources.list.d/llvm14.list && \
++    apt-get update && \
++    apt-get install -y clang-14 llvm-14-dev libc++-14-dev libc++abi-14-dev python3 lzma-dev libxml2-dev libssl-dev && \
++    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
++    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100 && \
++    rm -rf /var/lib/apt/lists/*
+ <% else %>
+ RUN apt-get -y update && \
+     apt-get install -y <%
+-if platform =~ /darwin/            %> clang python lzma-dev libxml2-dev libssl-dev libc++-10-dev <% end %><%
+-if platform =~ /aarch64-linux-gnu/ %> gcc-aarch64-linux-gnu g++-aarch64-linux-gnu <% end %><%
+-if platform =~ /arm-linux-gnu/     %> gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf <% end %><%
+-if platform =~ /x86-linux-gnu/     %> gcc-i686-linux-gnu g++-i686-linux-gnu <% end %><%
+-if platform =~ /x86_64-linux-gnu/  %> gcc-x86-64-linux-gnu g++-x86-64-linux-gnu <% end %><%
++if platform =~ /arm-linux-gnu/     %> gcc-10-arm-linux-gnueabihf g++-10-arm-linux-gnueabihf <% end %><%
++if platform =~ /x86-linux-gnu/     %> gcc-10-i686-linux-gnu g++-10-i686-linux-gnu <% end %><%
+ if platform =~ /x86-mingw32/       %> gcc-mingw-w64-i686 g++-mingw-w64-i686 <% end %><%
+ if platform =~ /x64-mingw32/       %> gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 <% end %> && \
++<% if platform =~ /aarch64-linux-gnu/ %>
++    if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
++        apt-get install -y gcc-10 g++-10 && \
++        update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/gcc-10 100 && \
++        update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/g++-10 100 ; \
++    else \
++        apt-get install -y gcc-10-aarch64-linux-gnu g++-10-aarch64-linux-gnu && \
++        update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-10 100 && \
++        update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-10 100 ; \
++    fi && \
++<% end %>
++<% if platform =~ /arm-linux-gnu/ %>
++    update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-10 100 && \
++    update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-10 100 && \
++<% end %>
++<% if platform =~ /x86-linux-gnu/ %>
++    update-alternatives --install /usr/bin/i686-linux-gnu-gcc i686-linux-gnu-gcc /usr/bin/i686-linux-gnu-gcc-10 100 && \
++    update-alternatives --install /usr/bin/i686-linux-gnu-g++ i686-linux-gnu-g++ /usr/bin/i686-linux-gnu-g++-10 100 && \
++<% end %>
++<% if platform =~ /x86_64-linux-gnu/ %>
++    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
++        apt-get install -y gcc-10 g++-10 && \
++        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
++        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 && \
++        update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/gcc-10 100 && \
++        update-alternatives --install /usr/bin/x86_64-linux-gnu-g++ x86_64-linux-gnu-g++ /usr/bin/g++-10 100 ; \
++    else \
++        apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu ; \
++    fi && \
++<% end %>
+     rm -rf /var/lib/apt/lists/*
+ <% end %>
++<% end %>
+ 
+ <% if platform =~ /darwin/ %>
+ COPY build/mk_osxcross.sh /tmp
+diff --git a/build/mk_musl_cross.sh b/build/mk_musl_cross.sh
+index e2dfce9..4e6e2e7 100755
+--- a/build/mk_musl_cross.sh
++++ b/build/mk_musl_cross.sh
+@@ -19,6 +19,12 @@ TARGET = $TARGET
+ 
+ DL_CMD = wget -c --no-verbose -O
+ 
++# Use GCC 10.3.0. Binutils 2.33.1 is the newest version that still has a
++# verified hash in musl-cross-make and works with GCC 10 - newer versions
++# (like 2.44, the current default) break the GCC 10 build.
++GCC_VER = 10.3.0
++BINUTILS_VER = 2.33.1
++
+ # to match the location of the apt-installed cross-compiler packages
+ OUTPUT = /usr
+ 
+diff --git a/build/mk_osxcross.sh b/build/mk_osxcross.sh
+index b1964f7..c407022 100755
+--- a/build/mk_osxcross.sh
++++ b/build/mk_osxcross.sh
+@@ -12,15 +12,15 @@ cd /opt/osxcross/tarballs
+ set -x
+ curl -L -o MacOSX11.1.sdk.tar.xz https://github.com/larskanis/MacOSX-SDKs/releases/download/11.1/MacOSX11.1.sdk.tar.xz
+ tar -xf MacOSX11.1.sdk.tar.xz -C .
+-cp -rf /usr/lib/llvm-10/include/c++ MacOSX11.1.sdk/usr/include/c++
+-cp -rf /usr/include/*-linux-gnu/c++/9/bits/ MacOSX11.1.sdk/usr/include/c++/v1/bits
++cp -rf /usr/lib/llvm-14/include/c++ MacOSX11.1.sdk/usr/include/c++
++cp -rf /usr/include/*-linux-gnu/c++/*/bits/ MacOSX11.1.sdk/usr/include/c++/v1/bits
+ tar -cJf MacOSX11.1.sdk.tar.xz MacOSX11.1.sdk
+ 
+ set +x
+ cd /opt/osxcross
+ set -x
+ UNATTENDED=1 SDK_VERSION=11.1 OSX_VERSION_MIN=10.13 USE_CLANG_AS=1 ./build.sh
+-ln -s /usr/bin/llvm-config-10 /usr/bin/llvm-config
++ln -s /usr/bin/llvm-config-14 /usr/bin/llvm-config
+ ENABLE_COMPILER_RT_INSTALL=1 SDK_VERSION=11.1 ./build_compiler_rt.sh
+ rm -rf *~ build tarballs/*
+ 
+@@ -36,8 +36,8 @@ rm -f /opt/osxcross/target/bin/*-apple-darwin-*
+ find /opt/osxcross/target/bin/ -name '*-apple-darwin[0-9]*' | sort | while read f ; do d=`echo $f | sed s/darwin[0-9\.]*/darwin/`; echo $f '"$@"' | tee $d && chmod +x $d ; done
+ 
+ # There's no objdump in osxcross but we can use llvm's
+-ln -s /usr/lib/llvm-10/bin/llvm-objdump /opt/osxcross/target/bin/x86_64-apple-darwin-objdump
+-ln -s /usr/lib/llvm-10/bin/llvm-objdump /opt/osxcross/target/bin/aarch64-apple-darwin-objdump
++ln -s /usr/lib/llvm-14/bin/llvm-objdump /opt/osxcross/target/bin/x86_64-apple-darwin-objdump
++ln -s /usr/lib/llvm-14/bin/llvm-objdump /opt/osxcross/target/bin/aarch64-apple-darwin-objdump
+ 
+ # install /usr/bin/codesign and make a symlink for codesign_allocate (the architecture doesn't matter)
+ git clone -q --depth=1 https://github.com/flavorjones/sigtool --branch flavorjones-fix-link-line-library-order


### PR DESCRIPTION
#43185 was imported as cl/964508166. The copybara workflow didn't export third_party/rake-compiler-dock and resulted in a merge instead of PR (https://github.com/grpc/grpc/commit/ecd5429314f4639651216548b9c6fa1bca3d98ca). This PR should be github-only and amends the previous change.