### PR TITLE
performance: Enable php8 tests

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -153,6 +153,7 @@ declare -A useLanguage=(
   [python]=1
   [ruby]=1
   [rust]=1
+  [php8]=1
 )
 
 # Disable specific languages.
@@ -219,6 +220,14 @@ if [[ -v "useLanguage[rust]" ]]; then
   configLangArgs8core+=(-l rust)
   configLangArgs32core+=(-l rust)
   runnerLangArgs+=(-l "rust:${GRPC_RUST_REPO}:${GRPC_RUST_COMMIT}")
+fi
+
+# php8
+if [[ -v "useLanguage[php8]" ]]; then
+  configLangArgs8core+=(-l php8) # 8-core only.
+  runnerLangArgs+=(-l "php8:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
+  configLangArgs8core+=(-l php8_protobuf_c) # 8-core only.
+  runnerLangArgs+=(-l "php8_protobuf_c:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
 
 # Disable broken tests by regex.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=grpc/test-infra
-TEST_INFRA_GITREF=master
+TEST_INFRA_REPO=arjan-bal/test-infra
+TEST_INFRA_GITREF=bump-php
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -146,13 +146,13 @@ disableTestsRegex() {
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
-  [dotnet]=1
-  [go]=1
-  [java]=1
-  [node]=1
-  [python]=1
-  [ruby]=1
-  [rust]=1
+  # [dotnet]=1
+  # [go]=1
+  # [java]=1
+  # [node]=1
+  # [python]=1
+  # [ruby]=1
+  # [rust]=1
   [php8]=1
 )
 
@@ -246,7 +246,7 @@ regexArgs8core=(-r "$(disableTestsRegex "${disabledTests8core[@]}")")
 regexArgs32core=(-r "$(disableTestsRegex "${disabledTests32core[@]}")")
 
 buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}" "${regexArgs8core[@]}"
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
+# buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
 
 # Delete prebuilt images on exit.
 deleteImages() {
@@ -266,9 +266,8 @@ time ../test-infra/bin/prepare_prebuilt_workers "${runnerLangArgs[@]}" \
 # Run tests.
 time ../test-infra/bin/runner \
   -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
-  -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
   -log-url-prefix "${LOG_URL_PREFIX}" \
   -polling-interval 5s \
   -delete-successful-tests \
-  -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
+  -c "${WORKER_POOL_8CORE}:2" \
   -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -33,8 +33,8 @@ GRPC_NODE_REPO=grpc/grpc-node
 GRPC_NODE_GITREF=master
 GRPC_RUST_REPO=grpc/grpc-rust
 GRPC_RUST_GITREF=master
-TEST_INFRA_REPO=arjan-bal/test-infra
-TEST_INFRA_GITREF=bump-php
+TEST_INFRA_REPO=grpc/test-infra
+TEST_INFRA_GITREF=master
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
@@ -146,13 +146,13 @@ disableTestsRegex() {
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
-  # [dotnet]=1
-  # [go]=1
-  # [java]=1
-  # [node]=1
-  # [python]=1
-  # [ruby]=1
-  # [rust]=1
+  [dotnet]=1
+  [go]=1
+  [java]=1
+  [node]=1
+  [python]=1
+  [ruby]=1
+  [rust]=1
   [php8]=1
 )
 
@@ -246,7 +246,7 @@ regexArgs8core=(-r "$(disableTestsRegex "${disabledTests8core[@]}")")
 regexArgs32core=(-r "$(disableTestsRegex "${disabledTests32core[@]}")")
 
 buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}" "${regexArgs8core[@]}"
-# buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
 
 # Delete prebuilt images on exit.
 deleteImages() {
@@ -266,8 +266,9 @@ time ../test-infra/bin/prepare_prebuilt_workers "${runnerLangArgs[@]}" \
 # Run tests.
 time ../test-infra/bin/runner \
   -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
+  -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
   -log-url-prefix "${LOG_URL_PREFIX}" \
   -polling-interval 5s \
   -delete-successful-tests \
-  -c "${WORKER_POOL_8CORE}:2" \
+  -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
   -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -148,6 +148,7 @@ declare -A useLanguage=(
   [python]=1
   [ruby]=1
   [rust]=1
+  [php8]=1
 )
 
 # Disable specific languages.
@@ -214,6 +215,14 @@ if [[ -v "useLanguage[rust]" ]]; then
   configLangArgs8core+=(-l rust)
   configLangArgs32core+=(-l rust)
   runnerLangArgs+=(-l "rust:${GRPC_RUST_REPO}:${GRPC_RUST_COMMIT}")
+fi
+
+# php8
+if [[ -v "useLanguage[php8]" ]]; then
+  configLangArgs8core+=(-l php8) # 8-core only.
+  runnerLangArgs+=(-l "php8:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
+  configLangArgs8core+=(-l php8_protobuf_c) # 8-core only.
+  runnerLangArgs+=(-l "php8_protobuf_c:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
 
 # Disable broken tests by regex.

--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
@@ -23,7 +23,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 # TODO(jtattermusch): add back "node" language once the scenarios are passing again
 # See https://github.com/grpc/grpc/issues/20234
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python python_asyncio go php7 php7_protobuf_c \
+    -l c++ csharp ruby java python python_asyncio go php8 php8_protobuf_c \
     --netperf \
     --category smoketest \
     -u kbuilder \

--- a/tools/internal_ci/linux/grpc_full_performance_master.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_master.sh
@@ -21,7 +21,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python python_asyncio go php7 php7_protobuf_c node \
+    -l c++ csharp ruby java python python_asyncio go php8 php8_protobuf_c node \
     --netperf \
     --category scalable \
     --remote_worker_host grpc-kokoro-performance-server-8core grpc-kokoro-performance-client-8core grpc-kokoro-performance-client2-8core \

--- a/tools/internal_ci/linux/grpc_full_performance_release.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_release.sh
@@ -21,7 +21,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python python_asyncio go php7 php7_protobuf_c \
+    -l c++ csharp ruby java python python_asyncio go php8 php8_protobuf_c \
     --netperf \
     --category scalable \
     --remote_worker_host grpc-kokoro-performance-server-8core grpc-kokoro-performance-client-8core grpc-kokoro-performance-client2-8core \

--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -45,8 +45,8 @@ Count  Language         Client   Server   Categories
     5  ruby                               scalable
     4  csharp                    c++      scalable
     4  dotnet                    c++      scalable
-    4  php7                      c++      scalable
-    4  php7_protobuf_c           c++      scalable
+    4  php8                      c++      scalable
+    4  php8_protobuf_c           c++      scalable
     3  python_asyncio            c++      scalable
     2  ruby                      c++      scalable
     2  python                    c++      scalable

--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -55,12 +55,12 @@ do
   "rust")
     tools/run_tests/performance/build_performance_rust.sh
     ;;
-  "php7"|"php7_protobuf_c")
+  "php8"|"php8_protobuf_c")
     if [ -n "$PHP_ALREADY_BUILT" ]; then
       echo "Skipping PHP build as already built by $PHP_ALREADY_BUILT"
     else
       PHP_ALREADY_BUILT=$language
-      tools/run_tests/performance/build_performance_php7.sh
+      tools/run_tests/performance/build_performance_php8.sh
     fi
     ;;
   "csharp")

--- a/tools/run_tests/performance/build_performance_php8.sh
+++ b/tools/run_tests/performance/build_performance_php8.sh
@@ -16,6 +16,7 @@
 set -ex
 
 cd "$(dirname "$0")/../../.."
+root="$(pwd)"
 CONFIG=${CONFIG:-opt}
 python tools/run_tests/run_tests.py -l php8 -c "$CONFIG" --build_only -j 8
 
@@ -23,15 +24,19 @@ python tools/run_tests/run_tests.py -l php8 -c "$CONFIG" --build_only -j 8
 cd src/php/tests/qps
 composer install
 # Install protobuf C-extension for php
-cd ../../../../third_party/protobuf/php/ext/google/protobuf
+cd "${root}/third_party/protobuf/php/ext/google/protobuf"
 
 # The PHP extension's build configuration (config.m4) expects 'utf8_range' 
 # to exist locally within the extension tree rather than the repository root.
 # Copy the dependency from the Protobuf third_party submodule to satisfy this.
 mkdir -p third_party/utf8_range
-cp -r "${root}"/third_party/protobuf/third_party/utf8_range/* third_party/utf8_range/
+cp -r "${root}/third_party/utf8_range/"* third_party/utf8_range/
 
 phpize
 ./configure
 make -j8
+
+# Prepare for ruby proxy workers
+cd "${root}"
+python tools/run_tests/run_tests.py -l ruby -c "$CONFIG" --build_only -j 8
 

--- a/tools/run_tests/performance/build_performance_php8.sh
+++ b/tools/run_tests/performance/build_performance_php8.sh
@@ -17,14 +17,21 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 CONFIG=${CONFIG:-opt}
-python tools/run_tests/run_tests.py -l php7 -c "$CONFIG" --build_only -j 8
+python tools/run_tests/run_tests.py -l php8 -c "$CONFIG" --build_only -j 8
 
 # Set up all dependencies needed for PHP QPS test
 cd src/php/tests/qps
 composer install
 # Install protobuf C-extension for php
 cd ../../../../third_party/protobuf/php/ext/google/protobuf
+
+# The PHP extension's build configuration (config.m4) expects 'utf8_range' 
+# to exist locally within the extension tree rather than the repository root.
+# Copy the dependency from the Protobuf third_party submodule to satisfy this.
+mkdir -p third_party/utf8_range
+cp -r "${root}"/third_party/protobuf/third_party/utf8_range/* third_party/utf8_range/
+
 phpize
 ./configure
-make
+make -j8
 

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -42,8 +42,8 @@ example_file() {
         echo "python_asyncio${suffix}"
         return
     fi
-    if [[ "${scenario#php7_protobuf_c_}" != "${scenario}" ]]; then
-        echo "php7_protobuf_c${suffix}"
+    if [[ "${scenario#php8_protobuf_c_}" != "${scenario}" ]]; then
+        echo "php8_protobuf_c${suffix}"
         return
     fi
     echo "${scenario%%_*}${suffix}"
@@ -59,8 +59,8 @@ example_language() {
         echo "python_asyncio"
         return
     fi
-    if [[ "${filename#php7_protobuf_c_}" != "${filename}" ]]; then
-        echo "php7_protobuf_c"
+    if [[ "${filename#php8_protobuf_c_}" != "${filename}" ]]; then
+        echo "php8_protobuf_c"
         return
     fi
     echo "${filename%%_*}"
@@ -73,8 +73,8 @@ scenarios=(
     "go_generic_sync_streaming_ping_pong_secure"
     "java_generic_async_streaming_ping_pong_secure"
     "node_to_node_generic_async_streaming_ping_pong_secure"
-    "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong"
-    "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong"
+    "php8_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong"
+    "php8_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong"
     "python_generic_sync_streaming_ping_pong"
     "python_asyncio_generic_async_streaming_ping_pong"
     "ruby_protobuf_sync_streaming_ping_pong"
@@ -86,8 +86,8 @@ psm_scenarios=(
     "go_protobuf_async_unary_5000rpcs_1KB_psm"
     "java_protobuf_async_unary_5000rpcs_1KB_psm"
     "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm"
-    "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
-    "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "php8_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "php8_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
     "python_protobuf_async_unary_5000rpcs_1KB_psm"
     "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm"
 )

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1355,13 +1355,13 @@ class RubyLanguage(Language):
         return "ruby"
 
 
-class Php7Language(Language):
-    def __init__(self, php7_protobuf_c=False):
+class Php8Language(Language):
+    def __init__(self, php8_protobuf_c=False):
         super().__init__()
-        self.php7_protobuf_c = php7_protobuf_c
+        self.php8_protobuf_c = php8_protobuf_c
 
     def worker_cmdline(self):
-        if self.php7_protobuf_c:
+        if self.php8_protobuf_c:
             return [
                 "tools/run_tests/performance/run_worker_php.sh",
                 "--use_protobuf_c_extension",
@@ -1369,18 +1369,18 @@ class Php7Language(Language):
         return ["tools/run_tests/performance/run_worker_php.sh"]
 
     def worker_port_offset(self):
-        if self.php7_protobuf_c:
+        if self.php8_protobuf_c:
             return 900
         return 800
 
     def scenarios(self):
-        php7_extension_mode = "php7_protobuf_php_extension"
-        if self.php7_protobuf_c:
-            php7_extension_mode = "php7_protobuf_c_extension"
+        php8_extension_mode = "php8_protobuf_php_extension"
+        if self.php8_protobuf_c:
+            php8_extension_mode = "php8_protobuf_c_extension"
 
         yield _ping_pong_scenario(
             "%s_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
-            % php7_extension_mode,
+            % php8_extension_mode,
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1396,7 +1396,7 @@ class Php7Language(Language):
         )
 
         yield _ping_pong_scenario(
-            "%s_to_cpp_protobuf_sync_unary_ping_pong" % php7_extension_mode,
+            "%s_to_cpp_protobuf_sync_unary_ping_pong" % php8_extension_mode,
             rpc_type="UNARY",
             client_type="SYNC_CLIENT",
             server_type="SYNC_SERVER",
@@ -1405,7 +1405,7 @@ class Php7Language(Language):
         )
 
         yield _ping_pong_scenario(
-            "%s_to_cpp_protobuf_sync_streaming_ping_pong" % php7_extension_mode,
+            "%s_to_cpp_protobuf_sync_streaming_ping_pong" % php8_extension_mode,
             rpc_type="STREAMING",
             client_type="SYNC_CLIENT",
             server_type="SYNC_SERVER",
@@ -1417,7 +1417,7 @@ class Php7Language(Language):
         # better than async_server_threads=0/CPU usage 490%.
         yield _ping_pong_scenario(
             "%s_to_cpp_protobuf_sync_unary_qps_unconstrained"
-            % php7_extension_mode,
+            % php8_extension_mode,
             rpc_type="UNARY",
             client_type="SYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1429,7 +1429,7 @@ class Php7Language(Language):
 
         yield _ping_pong_scenario(
             "%s_to_cpp_protobuf_sync_streaming_qps_unconstrained"
-            % php7_extension_mode,
+            % php8_extension_mode,
             rpc_type="STREAMING",
             client_type="SYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1440,9 +1440,9 @@ class Php7Language(Language):
         )
 
     def __str__(self):
-        if self.php7_protobuf_c:
-            return "php7_protobuf_c"
-        return "php7"
+        if self.php8_protobuf_c:
+            return "php8_protobuf_c"
+        return "php8"
 
 
 class JavaLanguage(Language):
@@ -1831,8 +1831,8 @@ LANGUAGES = {
     "csharp": CSharpLanguage(),
     "dotnet": DotnetLanguage(),
     "ruby": RubyLanguage(),
-    "php7": Php7Language(),
-    "php7_protobuf_c": Php7Language(php7_protobuf_c=True),
+    "php8": Php8Language(),
+    "php8_protobuf_c": Php8Language(php8_protobuf_c=True),
     "java": JavaLanguage(),
     "python": PythonLanguage(),
     "python_asyncio": PythonAsyncIOLanguage(),

--- a/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
@@ -143,7 +143,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7
+    language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -161,7 +161,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7_protobuf_c
+    language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:

--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -91,7 +91,7 @@ spec:
       - bash
       image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
       name: main
-  - language: php7
+  - language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -101,9 +101,9 @@ spec:
         /run_scripts/run_worker.sh
       command:
       - bash
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
-  - language: php7_protobuf_c
+  - language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:
@@ -113,7 +113,7 @@ spec:
         /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
   - language: python
     pool: ${client_pool}

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
@@ -192,7 +192,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7
+    language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -231,7 +231,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7_protobuf_c
+    language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
@@ -149,7 +149,7 @@ spec:
         tcpSocket:
           port: 10000
       name: sidecar
-  - language: php7
+  - language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -159,7 +159,7 @@ spec:
         /run_scripts/run_worker.sh
       command:
       - bash
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -182,7 +182,7 @@ spec:
         tcpSocket:
           port: 10000
       name: sidecar
-  - language: php7_protobuf_c
+  - language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:
@@ -192,7 +192,7 @@ spec:
         /run_scripts/run_protobuf_c_worker.sh
       command:
       - bash
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
@@ -173,7 +173,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7
+    language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -208,7 +208,7 @@ spec:
     clone:
       gitRef: master
       repo: https://github.com/grpc/grpc.git
-    language: php7_protobuf_c
+    language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
@@ -133,7 +133,7 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
-  - language: php7
+  - language: php8
     pool: ${client_pool}
     run:
     - args:
@@ -146,7 +146,7 @@ spec:
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path
@@ -162,7 +162,7 @@ spec:
         tcpSocket:
           port: 10000
       name: xds-server
-  - language: php7_protobuf_c
+  - language: php8_protobuf_c
     pool: ${client_pool}
     run:
     - args:
@@ -175,7 +175,7 @@ spec:
       env:
       - name: GRPC_XDS_BOOTSTRAP
         value: /bootstrap/bootstrap.json
-      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      image: ${prebuilt_image_prefix}/php8:${prebuilt_image_tag}
       name: main
     - args:
       - -default-config-path


### PR DESCRIPTION
Following the PHP benchmark build fix in https://github.com/grpc/test-infra/pull/425, this PR bumps the PHP version to 8 and re-enables the corresponding CI tests.

## Tested
* Ad-hoc run with only C++ and php8 passes: 
https://source.cloud.google.com/results/invocations/977b6703-2e4c-40c6-9439-5f52130fc2cd
* `python3 tools/run_tests/run_performance_tests.py -l php8 c++ --category smoketest -r ".*php.*"` passes, after configuring php8 build tools.