### PR TITLE
[Python] Declare the grpc.experimental import to type checkers

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -692,6 +692,14 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
   if (config.grpc_tools_version.size() > 0) {
     out->Print(var, "import warnings\n");
   }
+  // The experimental service class calls grpc.experimental.*, which is bound only once the caller
+  // imports it explicitly. Declaring that import to the type checker alone leaves the deliberate
+  // runtime AttributeError intact while letting the generated module type-check.
+  if (file->service_count() > 0) {
+    out->Print("import typing\n");
+    out->Print("if typing.TYPE_CHECKING:\n");
+    out->Print("    import grpc.experimental\n");
+  }
   if (generate_in_pb2_grpc) {
     out->Print("\n");
     StringPairSet imports_set;


### PR DESCRIPTION
### Problem

The generated `_pb2_grpc.py` imports only `grpc`, then calls `grpc.experimental.unary_unary` from the experimental service class:

```python
# src/compiler/python_generator.cc:646
return grpc.experimental.unary_unary(
```

`grpc.experimental` is a submodule, not bound on the `grpc` package until it is imported explicitly. So a type checker reading the generated module reports one error per rpc:

```
error: "experimental" is not a known attribute of module "grpc" (reportAttributeAccessIssue)
```

This was reported in #39555 and closed as working-as-intended, and I agree with that call: the `AttributeError` is a deliberate opt-in gate, and the checker is correctly describing what the code does. The gap is narrower — the checker has no way to learn the precondition, so the only remedies available to users are to exclude the generated files from checking (as the reporter did) or to suppress the rule wholesale.

### Change

Declare the import to the type checker only:

```python
import typing
if typing.TYPE_CHECKING:
    import grpc.experimental
```

Nothing is imported at run time, so the opt-in gate is unchanged. Verified against a module generated with this change:

```
grpc.experimental present after importing the generated module: False
Hello.SayHello(request, target)  ->  AttributeError: module 'grpc' has no attribute 'experimental'
after an explicit `import grpc.experimental`:  resolves
```

pyright goes from one error per rpc to none on the same file.

Emitted only when the file declares a service. `PrintPreamble` also runs for message-only protos — `protos/invocation_testing/split_messages/sub/messages.proto` in the existing test corpus is one — which generate no experimental class and would otherwise carry an unused import.

### Notes

- Every generated `_pb2_grpc.py` gains two lines, so golden/expected outputs will need regenerating.
- Both `grpc_2_0` and `grpc_1_0` paths go through `PrintPreamble`; in the `grpc_1_0` case the block is emitted inside the existing indent scope, which `Printer` handles.
- This addresses the type-checking half of #39555 without reopening the runtime-behaviour question settled there.