### PR TITLE
[Python] Add catch for `google.protobuf.message.DecodeError` in rpc_status.from_call Metadata Parsing

### DIFF
--- a/src/python/grpcio_status/grpc_status/__init__.py
+++ b/src/python/grpcio_status/grpc_status/__init__.py
@@ -11,3 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Reference implementation for status mapping in gRPC Python."""
+
+from ._common import StatusDetailsMetadataDecodeError
+from ._common import StatusDetailsMetadataValueError
+
+__all__ = [
+    "StatusDetailsMetadataValueError",
+    "StatusDetailsMetadataDecodeError",
+]

--- a/src/python/grpcio_status/grpc_status/__init__.py
+++ b/src/python/grpcio_status/grpc_status/__init__.py
@@ -18,6 +18,6 @@ from ._common import StatusDetailsMetadataDecodeError
 from ._common import StatusDetailsMetadataValueError
 
 __all__ = [
-    "StatusDetailsMetadataValueError",
     "StatusDetailsMetadataDecodeError",
+    "StatusDetailsMetadataValueError",
 ]

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 """Reference implementation for status mapping in gRPC Python."""
 
+import google.protobuf.message
 from google.rpc import status_pb2
 from grpc.experimental import aio
 
 from ._common import GRPC_DETAILS_METADATA_KEY
+from ._common import StatusDetailsMetadataDecodeError
+from ._common import StatusDetailsMetadataValueError
 from ._common import code_to_grpc_status_code
 
 
@@ -29,7 +32,53 @@ async def from_call(call: aio.Call):
       call: An grpc.aio.Call instance.
 
     Returns:
-      A google.rpc.status.Status message representing the status of the RPC.
+      A google.rpc.status.Status message representing the status of the RPC, or
+      None if no status details metadata is found in the call.
+
+    Raises:
+      StatusDetailsMetadataDecodeError: If the binary metadata in
+        'grpc-status-details-bin' cannot be decoded into a Status proto.
+      StatusDetailsMetadataValueError: If the gRPC call's code or details are
+        inconsistent with the status code and message inside of the
+        google.rpc.status.Status.
+
+    Note:
+      Both StatusDetailsMetadataDecodeError and StatusDetailsMetadataValueError
+      inherit from ValueError (and StatusDetailsMetadataDecodeError also
+      inherits from google.protobuf.message.DecodeError). Therefore, callers
+      can catch ValueError as a catch-all for any status details error.
+
+    Examples:
+      Catching specific error types:
+      ```python
+      try:
+          status = await rpc_status.aio.from_call(call)
+      except rpc_status.StatusDetailsMetadataDecodeError:
+          # Handle malformed or corrupted metadata
+          ...
+      except rpc_status.StatusDetailsMetadataValueError:
+          # Handle inconsistent status code or message
+          ...
+      ```
+
+      Catch-all solution catching any status details error:
+      ```python
+      try:
+          status = await rpc_status.aio.from_call(call)
+      except ValueError:
+          # Catches both StatusDetailsMetadataDecodeError and
+          # StatusDetailsMetadataValueError
+          ...
+      ```
+
+      Catching DecodeError directly:
+      ```python
+      try:
+          status = await rpc_status.aio.from_call(call)
+      except google.protobuf.message.DecodeError:
+          # StatusDetailsMetadataDecodeError also inherits from DecodeError
+          ...
+      ```
     """
     code = await call.code()
     details = await call.details()
@@ -38,14 +87,17 @@ async def from_call(call: aio.Call):
         return None
     for key, value in trailing_metadata:
         if key == GRPC_DETAILS_METADATA_KEY:
-            rich_status = status_pb2.Status.FromString(value)
+            try:
+                rich_status = status_pb2.Status.FromString(value)
+            except google.protobuf.message.DecodeError as decode_err:
+                raise StatusDetailsMetadataDecodeError(decode_err) from decode_err
             if code.value[0] != rich_status.code:
-                raise ValueError(
+                raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"
                     % (code_to_grpc_status_code(rich_status.code), code)
                 )
             if details != rich_status.message:
-                raise ValueError(
+                raise StatusDetailsMetadataValueError(
                     "Message in Status proto (%s) doesn't match status details"
                     " (%s)" % (rich_status.message, details)
                 )

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -53,10 +53,10 @@ async def from_call(call: aio.Call):
       ```python
       try:
           status = await rpc_status.aio.from_call(call)
-      except rpc_status.StatusDetailsMetadataDecodeError:
+      except grpc_status.StatusDetailsMetadataDecodeError:
           # Handle malformed or corrupted metadata
           ...
-      except rpc_status.StatusDetailsMetadataValueError:
+      except grpc_status.StatusDetailsMetadataValueError:
           # Handle inconsistent status code or message
           ...
       ```

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -90,7 +90,9 @@ async def from_call(call: aio.Call):
             try:
                 rich_status = status_pb2.Status.FromString(value)
             except google.protobuf.message.DecodeError as decode_err:
-                raise StatusDetailsMetadataDecodeError(decode_err) from decode_err
+                raise StatusDetailsMetadataDecodeError(
+                    decode_err
+                ) from decode_err
             if code.value[0] != rich_status.code:
                 raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -91,7 +91,7 @@ async def from_call(call: aio.Call):
                 rich_status = status_pb2.Status.FromString(value)
             except google.protobuf.message.DecodeError as decode_err:
                 raise StatusDetailsMetadataDecodeError(
-                    decode_err
+                    *decode_err.args
                 ) from decode_err
             if code.value[0] != rich_status.code:
                 raise StatusDetailsMetadataValueError(

--- a/src/python/grpcio_status/grpc_status/_async.py
+++ b/src/python/grpcio_status/grpc_status/_async.py
@@ -93,10 +93,15 @@ async def from_call(call: aio.Call):
                 raise StatusDetailsMetadataDecodeError(
                     *decode_err.args
                 ) from decode_err
-            if code.value[0] != rich_status.code:
+
+            # Validate that the status code in the proto is a valid gRPC status
+            # code. Raises StatusDetailsMetadataValueError if code is invalid.
+            status_code = code_to_grpc_status_code(rich_status.code)
+
+            if code != status_code:
                 raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"
-                    % (code_to_grpc_status_code(rich_status.code), code)
+                    % (status_code, code)
                 )
             if details != rich_status.message:
                 raise StatusDetailsMetadataValueError(

--- a/src/python/grpcio_status/grpc_status/_common.py
+++ b/src/python/grpcio_status/grpc_status/_common.py
@@ -13,11 +13,22 @@
 # limitations under the License.
 """Reference implementation for status mapping in gRPC Python."""
 
+import google.protobuf.message
 import grpc
 
 _CODE_TO_GRPC_CODE_MAPPING = {x.value[0]: x for x in grpc.StatusCode}
 
 GRPC_DETAILS_METADATA_KEY = "grpc-status-details-bin"
+
+
+class StatusDetailsMetadataValueError(ValueError):
+    pass
+
+
+class StatusDetailsMetadataDecodeError(
+    google.protobuf.message.DecodeError, StatusDetailsMetadataValueError
+):
+    pass
 
 
 def code_to_grpc_status_code(code):

--- a/src/python/grpcio_status/grpc_status/_common.py
+++ b/src/python/grpcio_status/grpc_status/_common.py
@@ -22,13 +22,24 @@ GRPC_DETAILS_METADATA_KEY = "grpc-status-details-bin"
 
 
 class StatusDetailsMetadataValueError(ValueError):
-    pass
+    """Raised when status details metadata is invalid or inconsistent.
+
+    This error is raised when the status code or message inside the Status proto
+    does not match the gRPC call's status code or details, or when an invalid
+    status code is encountered. It also acts as the base class for
+    StatusDetailsMetadataDecodeError.
+    """
 
 
 class StatusDetailsMetadataDecodeError(
     google.protobuf.message.DecodeError, StatusDetailsMetadataValueError
 ):
-    pass
+    """Raised when binary metadata 'grpc-status-details-bin' can't be decoded.
+
+    Inherits from both google.protobuf.message.DecodeError and
+    StatusDetailsMetadataValueError (and therefore ValueError) for backwards
+    compatibility.
+    """
 
 
 def code_to_grpc_status_code(code):

--- a/src/python/grpcio_status/grpc_status/_common.py
+++ b/src/python/grpcio_status/grpc_status/_common.py
@@ -46,4 +46,4 @@ def code_to_grpc_status_code(code):
     try:
         return _CODE_TO_GRPC_CODE_MAPPING[code]
     except KeyError:
-        raise ValueError("Invalid status code %s" % code)
+        raise StatusDetailsMetadataValueError("Invalid status code %s" % code)

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -32,6 +32,7 @@ class _Status(
 ):
     pass
 
+
 def from_call(call):
     """Returns a google.rpc.status.Status message corresponding to a given grpc.Call.
 
@@ -96,7 +97,9 @@ def from_call(call):
             try:
                 rich_status = status_pb2.Status.FromString(value)
             except google.protobuf.message.DecodeError as decode_err:
-                raise StatusDetailsMetadataDecodeError(decode_err) from decode_err
+                raise StatusDetailsMetadataDecodeError(
+                    decode_err
+                ) from decode_err
             if call.code().value[0] != rich_status.code:
                 raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -62,7 +62,7 @@ def from_call(call):
       Catching specific error types:
       ```python
       try:
-          status = grpc_status.from_call(call)
+          status = rpc_status.from_call(call)
       except grpc_status.StatusDetailsMetadataDecodeError:
           # Handle malformed or corrupted metadata
           ...
@@ -74,7 +74,7 @@ def from_call(call):
       Catch-all solution catching any status details error:
       ```python
       try:
-          status = grpc_status.from_call(call)
+          status = rpc_status.from_call(call)
       except ValueError:
           # Catches both StatusDetailsMetadataDecodeError and
           # StatusDetailsMetadataValueError
@@ -84,7 +84,7 @@ def from_call(call):
       Catching DecodeError directly:
       ```python
       try:
-          status = grpc_status.from_call(call)
+          status = rpc_status.from_call(call)
       except google.protobuf.message.DecodeError:
           # StatusDetailsMetadataDecodeError also inherits from DecodeError
           ...

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -98,7 +98,7 @@ def from_call(call):
                 rich_status = status_pb2.Status.FromString(value)
             except google.protobuf.message.DecodeError as decode_err:
                 raise StatusDetailsMetadataDecodeError(
-                    decode_err
+                    *decode_err.args
                 ) from decode_err
             if call.code().value[0] != rich_status.code:
                 raise StatusDetailsMetadataValueError(

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -16,10 +16,13 @@
 import collections
 import sys
 
+import google.protobuf.message
 from google.rpc import status_pb2
 import grpc
 
 from ._common import GRPC_DETAILS_METADATA_KEY
+from ._common import StatusDetailsMetadataDecodeError
+from ._common import StatusDetailsMetadataValueError
 from ._common import code_to_grpc_status_code
 
 
@@ -28,7 +31,6 @@ class _Status(
     grpc.Status,
 ):
     pass
-
 
 def from_call(call):
     """Returns a google.rpc.status.Status message corresponding to a given grpc.Call.
@@ -39,24 +41,69 @@ def from_call(call):
       call: A grpc.Call instance.
 
     Returns:
-      A google.rpc.status.Status message representing the status of the RPC.
+      A google.rpc.status.Status message representing the status of the RPC, or
+      None if no status details metadata is found in the call.
 
     Raises:
-      ValueError: If the gRPC call's code or details are inconsistent with the
-        status code and message inside of the google.rpc.status.Status.
+      StatusDetailsMetadataDecodeError: If the binary metadata in
+        'grpc-status-details-bin' cannot be decoded into a Status proto.
+      StatusDetailsMetadataValueError: If the gRPC call's code or details are
+        inconsistent with the status code and message inside of the
+        google.rpc.status.Status.
+
+    Note:
+      Both StatusDetailsMetadataDecodeError and StatusDetailsMetadataValueError
+      inherit from ValueError (and StatusDetailsMetadataDecodeError also
+      inherits from google.protobuf.message.DecodeError). Therefore, callers
+      can catch ValueError as a catch-all for any status details error.
+
+    Examples:
+      Catching specific error types:
+      ```python
+      try:
+          status = rpc_status.from_call(call)
+      except rpc_status.StatusDetailsMetadataDecodeError:
+          # Handle malformed or corrupted metadata
+          ...
+      except rpc_status.StatusDetailsMetadataValueError:
+          # Handle inconsistent status code or message
+          ...
+      ```
+
+      Catch-all solution catching any status details error:
+      ```python
+      try:
+          status = rpc_status.from_call(call)
+      except ValueError:
+          # Catches both StatusDetailsMetadataDecodeError and
+          # StatusDetailsMetadataValueError
+          ...
+      ```
+
+      Catching DecodeError directly:
+      ```python
+      try:
+          status = rpc_status.from_call(call)
+      except google.protobuf.message.DecodeError:
+          # StatusDetailsMetadataDecodeError also inherits from DecodeError
+          ...
+      ```
     """
     if call.trailing_metadata() is None:
         return None
     for key, value in call.trailing_metadata():
         if key == GRPC_DETAILS_METADATA_KEY:
-            rich_status = status_pb2.Status.FromString(value)
+            try:
+                rich_status = status_pb2.Status.FromString(value)
+            except google.protobuf.message.DecodeError as decode_err:
+                raise StatusDetailsMetadataDecodeError(decode_err) from decode_err
             if call.code().value[0] != rich_status.code:
-                raise ValueError(
+                raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"
                     % (code_to_grpc_status_code(rich_status.code), call.code())
                 )
             if call.details() != rich_status.message:
-                raise ValueError(
+                raise StatusDetailsMetadataValueError(
                     "Message in Status proto (%s) doesn't match status details"
                     " (%s)" % (rich_status.message, call.details())
                 )

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -62,11 +62,11 @@ def from_call(call):
       Catching specific error types:
       ```python
       try:
-          status = rpc_status.from_call(call)
-      except rpc_status.StatusDetailsMetadataDecodeError:
+          status = grpc_status.from_call(call)
+      except grpc_status.StatusDetailsMetadataDecodeError:
           # Handle malformed or corrupted metadata
           ...
-      except rpc_status.StatusDetailsMetadataValueError:
+      except grpc_status.StatusDetailsMetadataValueError:
           # Handle inconsistent status code or message
           ...
       ```
@@ -74,7 +74,7 @@ def from_call(call):
       Catch-all solution catching any status details error:
       ```python
       try:
-          status = rpc_status.from_call(call)
+          status = grpc_status.from_call(call)
       except ValueError:
           # Catches both StatusDetailsMetadataDecodeError and
           # StatusDetailsMetadataValueError
@@ -84,7 +84,7 @@ def from_call(call):
       Catching DecodeError directly:
       ```python
       try:
-          status = rpc_status.from_call(call)
+          status = grpc_status.from_call(call)
       except google.protobuf.message.DecodeError:
           # StatusDetailsMetadataDecodeError also inherits from DecodeError
           ...

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -100,10 +100,15 @@ def from_call(call):
                 raise StatusDetailsMetadataDecodeError(
                     *decode_err.args
                 ) from decode_err
-            if call.code().value[0] != rich_status.code:
+
+            # Validate that the status code in the proto is a valid gRPC status
+            # code. Raises StatusDetailsMetadataValueError if code is invalid.
+            status_code = code_to_grpc_status_code(rich_status.code)
+
+            if call.code() != status_code:
                 raise StatusDetailsMetadataValueError(
                     "Code in Status proto (%s) doesn't match status code (%s)"
-                    % (code_to_grpc_status_code(rich_status.code), call.code())
+                    % (status_code, call.code())
                 )
             if call.details() != rich_status.message:
                 raise StatusDetailsMetadataValueError(

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -234,7 +234,7 @@ class StatusTest(unittest.TestCase):
             ValueError,
         ):
             with self.subTest(exc_type=exc_type):
-                self.assertRaises(exc_type, grpc_status.from_call, rpc_error)
+                self.assertRaises(exc_type, rpc_status.from_call, rpc_error)
 
     def test_exception_inheritance(self):
         self.assertTrue(

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -31,6 +31,7 @@ import logging
 import traceback
 
 import grpc
+import grpc_status
 from grpc_status import rpc_status
 
 from tests.unit import test_common
@@ -227,24 +228,24 @@ class StatusTest(unittest.TestCase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.INTERNAL)
 
         for exc_type in (
-            rpc_status.StatusDetailsMetadataDecodeError,
+            grpc_status.StatusDetailsMetadataDecodeError,
             google.protobuf.message.DecodeError,
-            rpc_status.StatusDetailsMetadataValueError,
+            grpc_status.StatusDetailsMetadataValueError,
             ValueError,
         ):
             with self.subTest(exc_type=exc_type):
-                self.assertRaises(exc_type, rpc_status.from_call, rpc_error)
+                self.assertRaises(exc_type, grpc_status.from_call, rpc_error)
 
     def test_exception_inheritance(self):
         self.assertTrue(
-            issubclass(rpc_status.StatusDetailsMetadataValueError, ValueError)
+            issubclass(grpc_status.StatusDetailsMetadataValueError, ValueError)
         )
         self.assertTrue(
-            issubclass(rpc_status.StatusDetailsMetadataDecodeError, ValueError)
+            issubclass(grpc_status.StatusDetailsMetadataDecodeError, ValueError)
         )
         self.assertTrue(
             issubclass(
-                rpc_status.StatusDetailsMetadataDecodeError,
+                grpc_status.StatusDetailsMetadataDecodeError,
                 google.protobuf.message.DecodeError,
             )
         )

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -34,6 +34,7 @@ import grpc
 from grpc_status import rpc_status
 
 from tests.unit import test_common
+import google.protobuf.message
 
 from google.protobuf import any_pb2
 from google.rpc import code_pb2, status_pb2, error_details_pb2
@@ -43,6 +44,7 @@ _STATUS_NOT_OK = "/test/StatusNotOk"
 _ERROR_DETAILS = "/test/ErrorDetails"
 _INCONSISTENT = "/test/Inconsistent"
 _INVALID_CODE = "/test/InvalidCode"
+_MALFORMED_DETAILS = "/test/MalformedDetails"
 
 _REQUEST = b"\x00\x00\x00"
 _RESPONSE = b"\x01\x01\x01"
@@ -98,6 +100,14 @@ def _invalid_code_unary_unary(request, servicer_context):
     servicer_context.abort_with_status(rpc_status.to_status(rich_status))
 
 
+def _malformed_details_unary_unary(request, servicer_context):
+    servicer_context.set_code(grpc.StatusCode.INTERNAL)
+    servicer_context.set_details("Internal error")
+    servicer_context.set_trailing_metadata(
+        ((_GRPC_DETAILS_METADATA_KEY, b"\xff\xff"),)
+    )
+
+
 class _GenericHandler(grpc.GenericRpcHandler):
     def service(self, handler_call_details):
         if handler_call_details.method == _STATUS_OK:
@@ -115,6 +125,10 @@ class _GenericHandler(grpc.GenericRpcHandler):
         elif handler_call_details.method == _INVALID_CODE:
             return grpc.unary_unary_rpc_method_handler(
                 _invalid_code_unary_unary
+            )
+        elif handler_call_details.method == _MALFORMED_DETAILS:
+            return grpc.unary_unary_rpc_method_handler(
+                _malformed_details_unary_unary
             )
         else:
             return None
@@ -185,8 +199,12 @@ class StatusTest(unittest.TestCase):
         rpc_error = exception_context.exception
         self.assertEqual(rpc_error.code(), grpc.StatusCode.NOT_FOUND)
 
-        # Code/Message validation failed
-        self.assertRaises(ValueError, rpc_status.from_call, rpc_error)
+        for exc_type in (
+            rpc_status.StatusDetailsMetadataValueError,
+            ValueError,
+        ):
+            with self.subTest(exc_type=exc_type):
+                self.assertRaises(exc_type, rpc_status.from_call, rpc_error)
 
     def test_invalid_code(self):
         with self.assertRaises(grpc.RpcError) as exception_context:
@@ -198,6 +216,38 @@ class StatusTest(unittest.TestCase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.UNKNOWN)
         # Invalid status code exception raised during conversion
         self.assertIn("Invalid status code", rpc_error.details())
+
+    def test_malformed_details(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(
+                _MALFORMED_DETAILS,
+                _registered_method=True,
+            ).with_call(_REQUEST)
+        rpc_error = exception_context.exception
+        self.assertEqual(rpc_error.code(), grpc.StatusCode.INTERNAL)
+
+        for exc_type in (
+            rpc_status.StatusDetailsMetadataDecodeError,
+            google.protobuf.message.DecodeError,
+            rpc_status.StatusDetailsMetadataValueError,
+            ValueError,
+        ):
+            with self.subTest(exc_type=exc_type):
+                self.assertRaises(exc_type, rpc_status.from_call, rpc_error)
+
+    def test_exception_inheritance(self):
+        self.assertTrue(
+            issubclass(rpc_status.StatusDetailsMetadataValueError, ValueError)
+        )
+        self.assertTrue(
+            issubclass(rpc_status.StatusDetailsMetadataDecodeError, ValueError)
+        )
+        self.assertTrue(
+            issubclass(
+                rpc_status.StatusDetailsMetadataDecodeError,
+                google.protobuf.message.DecodeError,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -201,7 +201,7 @@ class StatusTest(unittest.TestCase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.NOT_FOUND)
 
         for exc_type in (
-            rpc_status.StatusDetailsMetadataValueError,
+            grpc_status.StatusDetailsMetadataValueError,
             ValueError,
         ):
             with self.subTest(exc_type=exc_type):

--- a/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
+++ b/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
@@ -17,6 +17,7 @@ import logging
 import traceback
 import unittest
 
+import google.protobuf.message
 from google.protobuf import any_pb2
 from google.rpc import code_pb2
 from google.rpc import error_details_pb2
@@ -32,6 +33,7 @@ _STATUS_NOT_OK = "/test/StatusNotOk"
 _ERROR_DETAILS = "/test/ErrorDetails"
 _INCONSISTENT = "/test/Inconsistent"
 _INVALID_CODE = "/test/InvalidCode"
+_MALFORMED_DETAILS = "/test/MalformedDetails"
 
 _REQUEST = b"\x00\x00\x00"
 _RESPONSE = b"\x01\x01\x01"
@@ -87,6 +89,14 @@ async def _invalid_code_unary_unary(request, servicer_context):
     await servicer_context.abort_with_status(rpc_status.to_status(rich_status))
 
 
+async def _malformed_details_unary_unary(request, servicer_context):
+    servicer_context.set_code(grpc.StatusCode.INTERNAL)
+    servicer_context.set_details("Internal error")
+    servicer_context.set_trailing_metadata(
+        ((_GRPC_DETAILS_METADATA_KEY, b"\xff\xff"),)
+    )
+
+
 class _GenericHandler(grpc.GenericRpcHandler):
     def service(self, handler_call_details):
         if handler_call_details.method == _STATUS_OK:
@@ -104,6 +114,10 @@ class _GenericHandler(grpc.GenericRpcHandler):
         elif handler_call_details.method == _INVALID_CODE:
             return grpc.unary_unary_rpc_method_handler(
                 _invalid_code_unary_unary
+            )
+        elif handler_call_details.method == _MALFORMED_DETAILS:
+            return grpc.unary_unary_rpc_method_handler(
+                _malformed_details_unary_unary
             )
         else:
             return None
@@ -165,9 +179,13 @@ class StatusTest(AioTestBase):
         rpc_error = exception_context.exception
         self.assertEqual(rpc_error.code(), grpc.StatusCode.NOT_FOUND)
 
-        # Code/Message validation failed
-        with self.assertRaises(ValueError):
-            await rpc_status.aio.from_call(call)
+        for exc_type in (
+            rpc_status.StatusDetailsMetadataValueError,
+            ValueError,
+        ):
+            with self.subTest(exc_type=exc_type):
+                with self.assertRaises(exc_type):
+                    await rpc_status.aio.from_call(call)
 
     async def test_invalid_code(self):
         with self.assertRaises(aio.AioRpcError) as exception_context:
@@ -176,6 +194,37 @@ class StatusTest(AioTestBase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.UNKNOWN)
         # Invalid status code exception raised during conversion
         self.assertIn("Invalid status code", rpc_error.details())
+
+    async def test_malformed_details(self):
+        call = self._channel.unary_unary(_MALFORMED_DETAILS)(_REQUEST)
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+        rpc_error = exception_context.exception
+        self.assertEqual(rpc_error.code(), grpc.StatusCode.INTERNAL)
+
+        for exc_type in (
+            rpc_status.StatusDetailsMetadataDecodeError,
+            google.protobuf.message.DecodeError,
+            rpc_status.StatusDetailsMetadataValueError,
+            ValueError,
+        ):
+            with self.subTest(exc_type=exc_type):
+                with self.assertRaises(exc_type):
+                    await rpc_status.aio.from_call(call)
+
+    def test_exception_inheritance(self):
+        self.assertTrue(
+            issubclass(rpc_status.StatusDetailsMetadataValueError, ValueError)
+        )
+        self.assertTrue(
+            issubclass(rpc_status.StatusDetailsMetadataDecodeError, ValueError)
+        )
+        self.assertTrue(
+            issubclass(
+                rpc_status.StatusDetailsMetadataDecodeError,
+                google.protobuf.message.DecodeError,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
+++ b/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
@@ -17,8 +17,8 @@ import logging
 import traceback
 import unittest
 
-import google.protobuf.message
 from google.protobuf import any_pb2
+import google.protobuf.message
 from google.rpc import code_pb2
 from google.rpc import error_details_pb2
 from google.rpc import status_pb2

--- a/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
+++ b/src/python/grpcio_tests/tests_aio/status/grpc_status_test.py
@@ -24,6 +24,7 @@ from google.rpc import error_details_pb2
 from google.rpc import status_pb2
 import grpc
 from grpc.experimental import aio
+import grpc_status
 from grpc_status import rpc_status
 
 from tests_aio.unit._test_base import AioTestBase
@@ -180,7 +181,7 @@ class StatusTest(AioTestBase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.NOT_FOUND)
 
         for exc_type in (
-            rpc_status.StatusDetailsMetadataValueError,
+            grpc_status.StatusDetailsMetadataValueError,
             ValueError,
         ):
             with self.subTest(exc_type=exc_type):
@@ -203,9 +204,9 @@ class StatusTest(AioTestBase):
         self.assertEqual(rpc_error.code(), grpc.StatusCode.INTERNAL)
 
         for exc_type in (
-            rpc_status.StatusDetailsMetadataDecodeError,
+            grpc_status.StatusDetailsMetadataDecodeError,
             google.protobuf.message.DecodeError,
-            rpc_status.StatusDetailsMetadataValueError,
+            grpc_status.StatusDetailsMetadataValueError,
             ValueError,
         ):
             with self.subTest(exc_type=exc_type):
@@ -214,14 +215,14 @@ class StatusTest(AioTestBase):
 
     def test_exception_inheritance(self):
         self.assertTrue(
-            issubclass(rpc_status.StatusDetailsMetadataValueError, ValueError)
+            issubclass(grpc_status.StatusDetailsMetadataValueError, ValueError)
         )
         self.assertTrue(
-            issubclass(rpc_status.StatusDetailsMetadataDecodeError, ValueError)
+            issubclass(grpc_status.StatusDetailsMetadataDecodeError, ValueError)
         )
         self.assertTrue(
             issubclass(
-                rpc_status.StatusDetailsMetadataDecodeError,
+                grpc_status.StatusDetailsMetadataDecodeError,
                 google.protobuf.message.DecodeError,
             )
         )


### PR DESCRIPTION
When parsing `grpc-status-details-bin` in `rpc_status.from_call` / `rpc_status.aio.from_call`, malformed metadata raises `google.protobuf.message.DecodeError`. This will cause uncaught crashes for callers expecting only the documented `ValueError` for invalid status details.

While adding a simple try catch for `DecodeError` can solve the problem, it will break for users who may already be catching `google.protobuf.message.DecodeError` explicitly in their code. Hence the solution must be such that it doesn't break users who are already catching `DecodeError` while also preventing crashes for users who don't catch it. 

Hence, we introduce two custom exception classes:
```python
class StatusDetailsMetadataValueError(ValueError):
    """Raised when status details metadata is invalid or inconsistent."""
    pass
class StatusDetailsMetadataDecodeError(
    google.protobuf.message.DecodeError,
    StatusDetailsMetadataValueError,
):
    """Raised when status details binary metadata cannot be decoded."""
    pass
```

By using multiple inheritance (`DecodeError` + `ValueError`), this change should work as follows:

* Callers catching ValueError can now automatically catch decode errors as well, making ValueError a reliable catch-all for status details issues.
* Callers already catching DecodeError can continue to catch decode errors as before without their except blocks breaking or becoming dead code.
* Callers can optionally catch StatusDetailsMetadataDecodeError or StatusDetailsMetadataValueError directly to distinguish decode failures from code/message mismatches.