### PR TITLE
rename db_path to db in RouteGuide RunServer (#30351)

### DIFF
--- a/examples/cpp/route_guide/route_guide_callback_server.cc
+++ b/examples/cpp/route_guide/route_guide_callback_server.cc
@@ -311,9 +311,9 @@ class RouteGuideImpl final : public RouteGuide::CallbackService {
   std::vector<RouteNote> received_notes_ ABSL_GUARDED_BY(mu_);
 };
 
-void RunServer(const std::string& db_path) {
+void RunServer(const std::string& db) {
   std::string server_address("0.0.0.0:50051");
-  RouteGuideImpl service(db_path);
+  RouteGuideImpl service(db);
 
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());

--- a/examples/cpp/route_guide/route_guide_server.cc
+++ b/examples/cpp/route_guide/route_guide_server.cc
@@ -171,9 +171,9 @@ class RouteGuideImpl final : public RouteGuide::Service {
   std::vector<RouteNote> received_notes_;
 };
 
-void RunServer(const std::string& db_path) {
+void RunServer(const std::string& db) {
   std::string server_address("0.0.0.0:50051");
-  RouteGuideImpl service(db_path);
+  RouteGuideImpl service(db);
 
   ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());


### PR DESCRIPTION
Resolves #30351 by renaming the misleading parameter name 'db_path' in RunServer to 'db' in both route_guide_server.cc and route_guide_callback_server.cc, since the variable contains the JSON string content of the database rather than a file path.





