### PR TITLE
[Backport][v1.83.x][Python] Fix the StatusCode Enums to be int

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -262,35 +262,41 @@ class StatusCode(enum.Enum):
       DATA_LOSS: Unrecoverable data loss or corruption.
     """
 
-    OK = (_cygrpc.StatusCode.ok, "ok")
-    CANCELLED = (_cygrpc.StatusCode.cancelled, "cancelled")
-    UNKNOWN = (_cygrpc.StatusCode.unknown, "unknown")
-    INVALID_ARGUMENT = (_cygrpc.StatusCode.invalid_argument, "invalid argument")
+    OK = (int(_cygrpc.StatusCode.ok), "ok")
+    CANCELLED = (int(_cygrpc.StatusCode.cancelled), "cancelled")
+    UNKNOWN = (int(_cygrpc.StatusCode.unknown), "unknown")
+    INVALID_ARGUMENT = (
+        int(_cygrpc.StatusCode.invalid_argument),
+        "invalid argument",
+    )
     DEADLINE_EXCEEDED = (
-        _cygrpc.StatusCode.deadline_exceeded,
+        int(_cygrpc.StatusCode.deadline_exceeded),
         "deadline exceeded",
     )
-    NOT_FOUND = (_cygrpc.StatusCode.not_found, "not found")
-    ALREADY_EXISTS = (_cygrpc.StatusCode.already_exists, "already exists")
+    NOT_FOUND = (int(_cygrpc.StatusCode.not_found), "not found")
+    ALREADY_EXISTS = (int(_cygrpc.StatusCode.already_exists), "already exists")
     PERMISSION_DENIED = (
-        _cygrpc.StatusCode.permission_denied,
+        int(_cygrpc.StatusCode.permission_denied),
         "permission denied",
     )
     RESOURCE_EXHAUSTED = (
-        _cygrpc.StatusCode.resource_exhausted,
+        int(_cygrpc.StatusCode.resource_exhausted),
         "resource exhausted",
     )
     FAILED_PRECONDITION = (
-        _cygrpc.StatusCode.failed_precondition,
+        int(_cygrpc.StatusCode.failed_precondition),
         "failed precondition",
     )
-    ABORTED = (_cygrpc.StatusCode.aborted, "aborted")
-    OUT_OF_RANGE = (_cygrpc.StatusCode.out_of_range, "out of range")
-    UNIMPLEMENTED = (_cygrpc.StatusCode.unimplemented, "unimplemented")
-    INTERNAL = (_cygrpc.StatusCode.internal, "internal")
-    UNAVAILABLE = (_cygrpc.StatusCode.unavailable, "unavailable")
-    DATA_LOSS = (_cygrpc.StatusCode.data_loss, "data loss")
-    UNAUTHENTICATED = (_cygrpc.StatusCode.unauthenticated, "unauthenticated")
+    ABORTED = (int(_cygrpc.StatusCode.aborted), "aborted")
+    OUT_OF_RANGE = (int(_cygrpc.StatusCode.out_of_range), "out of range")
+    UNIMPLEMENTED = (int(_cygrpc.StatusCode.unimplemented), "unimplemented")
+    INTERNAL = (int(_cygrpc.StatusCode.internal), "internal")
+    UNAVAILABLE = (int(_cygrpc.StatusCode.unavailable), "unavailable")
+    DATA_LOSS = (int(_cygrpc.StatusCode.data_loss), "data loss")
+    UNAUTHENTICATED = (
+        int(_cygrpc.StatusCode.unauthenticated),
+        "unauthenticated",
+    )
 
 
 #############################  gRPC Status  ################################

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -77,16 +77,6 @@ class StatusCode(enum.IntEnum):
   unavailable = GRPC_STATUS_UNAVAILABLE
   data_loss = GRPC_STATUS_DATA_LOSS
 
-  # Typeguard cannot identify `_cygrpc.StatusCode` values as integers unless
-  # the class inherits from `enum.IntEnum`. However, doing so breaks the
-  # pickling of `grpc.StatusCode` because it then embeds instances of
-  # `_cygrpc.StatusCode` instead of plain integers. This leads to a
-  # PicklingError: Can't pickle : import of module '_cython.cygrpc' failed.
-  # To resolve this, we implement the pickling interface and ensure
-  # `_cygrpc.StatusCode` values are pickled as pure integers. Test:
-  # grpcio_tests.tests_aio.unit.aio_rpc_error_test.TestAioRpcError.test_pickle
-  def __reduce_ex__(self, proto):
-     return (int, (self.value,))
 
 class CallError:
   ok = GRPC_CALL_OK

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -38,6 +38,7 @@
   "tests.unit._api_test.AllTest",
   "tests.unit._api_test.ChannelConnectivityTest",
   "tests.unit._api_test.ChannelTest",
+  "tests.unit._api_test.StatusCodeTest",
   "tests.unit._auth_context_test.AuthContextTest",
   "tests.unit._auth_test.AccessTokenAuthMetadataPluginTest",
   "tests.unit._auth_test.GoogleCallCredentialsTest",

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -97,6 +97,80 @@ class AllTest(unittest.TestCase):
         )
 
 
+class StatusCodeTest(unittest.TestCase):
+    def test_status_code_type(self):
+        self.assertIs(type(grpc.StatusCode.OK.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.CANCELLED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.UNKNOWN.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.INVALID_ARGUMENT.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.DEADLINE_EXCEEDED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.NOT_FOUND.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.ALREADY_EXISTS.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.PERMISSION_DENIED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.RESOURCE_EXHAUSTED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.FAILED_PRECONDITION.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.ABORTED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.OUT_OF_RANGE.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.UNIMPLEMENTED.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.INTERNAL.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.UNAVAILABLE.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.DATA_LOSS.value[0]), int)
+        self.assertIs(type(grpc.StatusCode.UNAUTHENTICATED.value[0]), int)
+
+    def test_status_code_str_serialization(self):
+        self.assertEqual(str(grpc.StatusCode.OK.value), "(0, 'ok')")
+        self.assertEqual(
+            str(grpc.StatusCode.CANCELLED.value), "(1, 'cancelled')"
+        )
+        self.assertEqual(str(grpc.StatusCode.UNKNOWN.value), "(2, 'unknown')")
+        self.assertEqual(
+            str(grpc.StatusCode.INVALID_ARGUMENT.value),
+            "(3, 'invalid argument')",
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.DEADLINE_EXCEEDED.value),
+            "(4, 'deadline exceeded')",
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.NOT_FOUND.value), "(5, 'not found')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.ALREADY_EXISTS.value), "(6, 'already exists')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.PERMISSION_DENIED.value),
+            "(7, 'permission denied')",
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.RESOURCE_EXHAUSTED.value),
+            "(8, 'resource exhausted')",
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.FAILED_PRECONDITION.value),
+            "(9, 'failed precondition')",
+        )
+        self.assertEqual(str(grpc.StatusCode.ABORTED.value), "(10, 'aborted')")
+        self.assertEqual(
+            str(grpc.StatusCode.OUT_OF_RANGE.value), "(11, 'out of range')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.UNIMPLEMENTED.value), "(12, 'unimplemented')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.INTERNAL.value), "(13, 'internal')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.UNAVAILABLE.value), "(14, 'unavailable')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.DATA_LOSS.value), "(15, 'data loss')"
+        )
+        self.assertEqual(
+            str(grpc.StatusCode.UNAUTHENTICATED.value),
+            "(16, 'unauthenticated')",
+        )
+
+
 class ChannelConnectivityTest(unittest.TestCase):
     def testChannelConnectivity(self):
         self.assertSequenceEqual(


### PR DESCRIPTION
Backport of #43167 to v1.83.x.
---
# Description

Fixes #43166


# Testing

```
>>> import grpc
>>> grpc.StatusCode.OK.value[0]
0
>>> str(grpc.StatusCode.OK.value[0])
'0'
>>>
```

Added test case for this as well.

