### PR TITLE
[Python] Release Python 3.15 wheels publicly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -46,3 +46,4 @@ src/core/ext/upb-gen/** linguist-generated=true
 src/core/ext/upbdefs-gen/** linguist-generated=true
 third_party/upb/upb/** linguist-generated=true
 third_party/utf8_range/** linguist-generated=true
+**/python_version.py linguist-generated=true

--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -22,6 +22,7 @@ settings:
   - '3.12'
   - '3.13'
   - '3.14'
+  - '3.15'
   version: 1.84.0-dev
 configs:
   asan:

--- a/py_xds_protos/python_version.py
+++ b/py_xds_protos/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/py_xds_protos/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio/python_version.py
+++ b/src/python/grpcio/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_admin/python_version.py
+++ b/src/python/grpcio_admin/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_admin/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_channelz/python_version.py
+++ b/src/python/grpcio_channelz/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_channelz/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_csds/python_version.py
+++ b/src/python/grpcio_csds/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_csds/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_csm_observability/python_version.py
+++ b/src/python/grpcio_csm_observability/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_csm_observability/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_health_checking/python_version.py
+++ b/src/python/grpcio_health_checking/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_health_checking/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_observability/python_version.py
+++ b/src/python/grpcio_observability/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_observability/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_reflection/python_version.py
+++ b/src/python/grpcio_reflection/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_reflection/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_status/python_version.py
+++ b/src/python/grpcio_status/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_status/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_testing/python_version.py
+++ b/src/python/grpcio_testing/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_testing/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/src/python/grpcio_tests/python_version.py
+++ b/src/python/grpcio_tests/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_tests/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/tools/distrib/python/grpcio_tools/python_version.py
+++ b/tools/distrib/python/grpcio_tools/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpcio_tools/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.14"
+MAX_PYTHON_VERSION = "3.15"

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -211,17 +211,6 @@ class PythonPackage:
                 environ["ARTIFACT_PREFIX"] = "python_manylinux2014_aarch64_"
             environ["EXCLUDE_PATTERNS"] = ""
 
-        # TODO(asheshvidyut): remove the below check when we want to release
-        # 3.15 wheels i.e. when wheels are created from Python-3.15 release candidate
-        job_name = os.getenv("KOKORO_JOB_NAME", "")
-        if (
-            job_name
-            == "grpc/core/master/linux/release/grpc_collect_all_packages"
-        ):
-            environ[
-                "EXCLUDE_PATTERNS"
-            ] += " python_*cp315* python_*python3.15* python_*Python315*"
-
         return create_docker_jobspec(
             self.name,
             dockerfile_dir,


### PR DESCRIPTION
The last PR in the series of adding Python 3.15 support. This adds public facing metadata and enables built wheels to be included in the CI job for release.

Pre-requisite to merge before this PR:
* https://github.com/grpc/grpc/pull/43255