### PR TITLE
[core] Deregister server node at destroy for channelz listings

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -133,14 +133,17 @@ using AcceptorPtr = std::unique_ptr<grpc_tcp_server_acceptor, AcceptorDeleter>;
 //
 
 NewChttp2ServerListener::ActiveConnection::HandshakingState::HandshakingState(
-    RefCountedPtr<ActiveConnection> connection_ref, grpc_tcp_server* tcp_server,
-    grpc_pollset* accepting_pollset, AcceptorPtr acceptor,
-    const ChannelArgs& args, OrphanablePtr<grpc_endpoint> endpoint)
+    RefCountedPtr<ActiveConnection> connection_ref,
+    RefCountedPtr<Server::ListenerInterface> listener_ref,
+    grpc_tcp_server* tcp_server, grpc_pollset* accepting_pollset,
+    AcceptorPtr acceptor, const ChannelArgs& args,
+    OrphanablePtr<grpc_endpoint> endpoint)
     : InternallyRefCounted(
           GRPC_TRACE_FLAG_ENABLED(chttp2_server_refcount)
               ? "NewChttp2ServerListener::ActiveConnection::HandshakingState"
               : nullptr),
       connection_(std::move(connection_ref)),
+      listener_(std::move(listener_ref)),
       tcp_server_(tcp_server),
       accepting_pollset_(accepting_pollset),
       acceptor_(std::move(acceptor)),
@@ -345,6 +348,7 @@ void NewChttp2ServerListener::ActiveConnection::HandshakingState::
 
 NewChttp2ServerListener::ActiveConnection::ActiveConnection(
     RefCountedPtr<Server::ListenerState> listener_state,
+    RefCountedPtr<Server::ListenerInterface> listener_ref,
     grpc_tcp_server* tcp_server, grpc_pollset* accepting_pollset,
     AcceptorPtr acceptor, const ChannelArgs& args, MemoryOwner memory_owner,
     OrphanablePtr<grpc_endpoint> endpoint)
@@ -355,8 +359,9 @@ NewChttp2ServerListener::ActiveConnection::ActiveConnection(
       work_serializer_(
           args.GetObjectRef<grpc_event_engine::experimental::EventEngine>()),
       state_(memory_owner.MakeOrphanable<HandshakingState>(
-          RefAsSubclass<ActiveConnection>(), tcp_server, accepting_pollset,
-          std::move(acceptor), args, std::move(endpoint))) {
+          RefAsSubclass<ActiveConnection>(), std::move(listener_ref),
+          tcp_server, accepting_pollset, std::move(acceptor), args,
+          std::move(endpoint))) {
   GRPC_CLOSURE_INIT(&on_close_, ActiveConnection::OnClose, this,
                     grpc_schedule_on_exec_ctx);
 }
@@ -645,6 +650,7 @@ void NewChttp2ServerListener::OnAccept(
       return;
     }
   }
+  RefCountedPtr<Server::ListenerInterface> listener_ref;
   {
     // The ref for the tcp_server need to be taken in the critical region
     // after having made sure that the listener has not been Orphaned, so as
@@ -661,13 +667,20 @@ void NewChttp2ServerListener::OnAccept(
     if (self->tcp_server_ != nullptr) {
       grpc_tcp_server_ref(self->tcp_server_);
     }
+    // This protects passive listeners who do not have the `tcp_server` from
+    // a race condition between the server shutdown and the handshake performed.
+    // Reference to the listener is held by the connection until its handshake
+    // is done. While handshake is still alive, the listener cannot be destroyed
+    // meaning `Server::MaybeFinishShutdown()` call will be postponed making
+    // mentioned race impossible.
+    listener_ref = self->Ref();
   }
   auto memory_owner =
       self->listener_state_->memory_quota()->CreateMemoryOwner();
   auto connection = memory_owner.MakeOrphanable<ActiveConnection>(
-      self->listener_state_, self->tcp_server_, accepting_pollset,
-      std::move(acceptor), self->args_, std::move(memory_owner),
-      std::move(endpoint));
+      self->listener_state_, std::move(listener_ref), self->tcp_server_,
+      accepting_pollset, std::move(acceptor), self->args_,
+      std::move(memory_owner), std::move(endpoint));
   RefCountedPtr<ActiveConnection> connection_ref =
       connection->RefAsSubclass<ActiveConnection>();
   std::optional<ChannelArgs> new_args =

--- a/src/core/ext/transport/chttp2/server/chttp2_server.h
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.h
@@ -69,6 +69,7 @@ class NewChttp2ServerListener : public Server::ListenerInterface {
     class HandshakingState : public InternallyRefCounted<HandshakingState> {
      public:
       HandshakingState(RefCountedPtr<ActiveConnection> connection_ref,
+                       RefCountedPtr<Server::ListenerInterface> listener_ref,
                        grpc_tcp_server* tcp_server,
                        grpc_pollset* accepting_pollset, AcceptorPtr acceptor,
                        const ChannelArgs& args,
@@ -90,6 +91,7 @@ class NewChttp2ServerListener : public Server::ListenerInterface {
       void OnHandshakeDoneLocked(absl::StatusOr<HandshakerArgs*> result);
 
       RefCountedPtr<ActiveConnection> const connection_;
+      RefCountedPtr<Server::ListenerInterface> const listener_;
       grpc_tcp_server* const tcp_server_;
       grpc_pollset* const accepting_pollset_;
       const AcceptorPtr acceptor_;
@@ -104,6 +106,7 @@ class NewChttp2ServerListener : public Server::ListenerInterface {
     };
 
     ActiveConnection(RefCountedPtr<Server::ListenerState> listener_state,
+                     RefCountedPtr<Server::ListenerInterface> listener_ref,
                      grpc_tcp_server* tcp_server,
                      grpc_pollset* accepting_pollset, AcceptorPtr acceptor,
                      const ChannelArgs& args, MemoryOwner memory_owner,

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1607,6 +1607,8 @@ void Server::Orphan() {
     GRPC_CHECK(listeners_destroyed_ == listener_states_.size());
   }
   listener_states_.clear();
+  SourceDestructing();
+  channelz_node_.reset();
   Unref();
 }
 

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1331,8 +1331,7 @@ grpc_error_handle Server::SetupTransport(
     }
     t->StartConnectivityWatch(MakeOrphanable<TransportConnectivityWatcher>(
         t->RefAsSubclass<ServerTransport>(), Ref()));
-    if (auto socket_node = transport->GetSocketNode();
-        socket_node != nullptr && channelz_node_ != nullptr) {
+    if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
       socket_node->AddParent(channelz_node_.get());
     }
     GRPC_TRACE_LOG(server_channel, INFO) << "Adding connection";
@@ -1362,10 +1361,7 @@ grpc_error_handle Server::SetupTransport(
       cq_idx = static_cast<size_t>(rand()) % std::max<size_t>(1, cqs_.size());
     }
     if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
-      MutexLock lock(&mu_global_);
-      if (channelz_node_ != nullptr) {
-        socket_node->AddParent(channelz_node_.get());
-      }
+      socket_node->AddParent(channelz_node_.get());
     }
 
     // Keep a local reference to the channel alive during setup to prevent
@@ -1609,13 +1605,7 @@ void Server::Orphan() {
   }
   listener_states_.clear();
   SourceDestructing();
-  // channelz node reset needs to be done without keeping the mutex
-  RefCountedPtr<channelz::ServerNode> channelz_node_to_release;
-  {
-    MutexLock lock(&mu_global_);
-    channelz_node_to_release = std::move(channelz_node_);
-  }
-  channelz_node_to_release.reset();
+  channelz_node_.reset();
   Unref();
 }
 

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1331,7 +1331,8 @@ grpc_error_handle Server::SetupTransport(
     }
     t->StartConnectivityWatch(MakeOrphanable<TransportConnectivityWatcher>(
         t->RefAsSubclass<ServerTransport>(), Ref()));
-    if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
+    if (auto socket_node = transport->GetSocketNode();
+        socket_node != nullptr && channelz_node_ != nullptr) {
       socket_node->AddParent(channelz_node_.get());
     }
     GRPC_TRACE_LOG(server_channel, INFO) << "Adding connection";
@@ -1363,7 +1364,10 @@ grpc_error_handle Server::SetupTransport(
     intptr_t channelz_socket_uuid = 0;
     if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
       channelz_socket_uuid = socket_node->uuid();
-      socket_node->AddParent(channelz_node_.get());
+      MutexLock lock(&mu_global_);
+      if (channelz_node_ != nullptr) {
+        socket_node->AddParent(channelz_node_.get());
+      }
     }
 
     // Keep a local reference to the channel alive during setup to prevent
@@ -1608,7 +1612,13 @@ void Server::Orphan() {
   }
   listener_states_.clear();
   SourceDestructing();
-  channelz_node_.reset();
+  // channelz node reset needs to be done without keeping the mutex
+  RefCountedPtr<channelz::ServerNode> channelz_node_to_release;
+  {
+    MutexLock lock(&mu_global_);
+    channelz_node_to_release = std::move(channelz_node_);
+  }
+  channelz_node_to_release.reset();
   Unref();
 }
 

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1361,9 +1361,7 @@ grpc_error_handle Server::SetupTransport(
       // Completion queue not found.  Pick a random one to publish new calls to.
       cq_idx = static_cast<size_t>(rand()) % std::max<size_t>(1, cqs_.size());
     }
-    intptr_t channelz_socket_uuid = 0;
     if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
-      channelz_socket_uuid = socket_node->uuid();
       MutexLock lock(&mu_global_);
       if (channelz_node_ != nullptr) {
         socket_node->AddParent(channelz_node_.get());
@@ -1373,8 +1371,7 @@ grpc_error_handle Server::SetupTransport(
     // Keep a local reference to the channel alive during setup to prevent
     // premature destruction if the transport fails concurrently.
     RefCountedPtr<Channel> channel_keep_alive = *channel;
-    chand->InitTransport(Ref(), std::move(*channel), cq_idx, transport,
-                         channelz_socket_uuid);
+    chand->InitTransport(Ref(), std::move(*channel), cq_idx, transport);
 
     auto* parent_arena =
         args.GetPointer<Arena>(GRPC_ARG_SERVER_INTERNAL_PARENT_CALL_ARENA);
@@ -1752,12 +1749,10 @@ Server::ChannelData::~ChannelData() {
 
 void Server::ChannelData::InitTransport(RefCountedPtr<Server> server,
                                         RefCountedPtr<Channel> channel,
-                                        size_t cq_idx, Transport* transport,
-                                        intptr_t channelz_socket_uuid) {
+                                        size_t cq_idx, Transport* transport) {
   server_ = std::move(server);
   channel_ = std::move(channel);
   cq_idx_ = cq_idx;
-  channelz_socket_uuid_ = channelz_socket_uuid;
   // Publish channel.
   {
     MutexLock lock(&server_->mu_global_);

--- a/src/core/server/server.h
+++ b/src/core/server/server.h
@@ -439,7 +439,7 @@ class Server : public ServerInterface,
 
     void InitTransport(RefCountedPtr<Server> server,
                        RefCountedPtr<Channel> channel, size_t cq_idx,
-                       Transport* transport, intptr_t channelz_socket_uuid);
+                       Transport* transport);
 
     RefCountedPtr<Server> server() const { return server_; }
     Channel* channel() const { return channel_.get(); }
@@ -472,7 +472,6 @@ class Server : public ServerInterface,
     size_t cq_idx_;
     std::optional<std::list<ChannelData*>::iterator> list_position_;
     grpc_closure finish_destroy_channel_closure_;
-    intptr_t channelz_socket_uuid_;
 
     RefCountedPtr<Arena> parent_arena_;
   };

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -682,6 +682,7 @@ TEST(ServerDeregistrationTest, DestroyedServerNotListedWhileRefsRemain) {
     ASSERT_NE(node, nullptr);
 
     uuid = node->uuid();
+    // NOLINTNEXTLINE - false detection of redundant namespace qualifier
     draining_ref = grpc_core::testing::ServerTestPeer(core_server).TakeRef();
   }  // ~ServerFixture() will call grpc_server_destroy
 

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -73,8 +73,8 @@ class ServerTestPeer {
  private:
   Server* server_;
 };
-}
-}
+}  // namespace testing
+}  // namespace grpc_core
 
 namespace grpc_core {
 namespace channelz {

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -76,6 +76,8 @@ class ServerTestPeer {
 }  // namespace testing
 }  // namespace grpc_core
 
+using grpc_core::testing::ServerTestPeer;
+
 namespace grpc_core {
 namespace channelz {
 namespace testing {
@@ -704,8 +706,7 @@ TEST(ServerDeregistrationTest, DestroyedServerNotListedWhileRefsRemain) {
     ASSERT_NE(node, nullptr);
 
     uuid = node->uuid();
-    // NOLINTNEXTLINE - false detection of redundant namespace qualifier
-    draining_ref = grpc_core::testing::ServerTestPeer(core_server).TakeRef();
+    draining_ref = ServerTestPeer(core_server).TakeRef();
   }  // ~ServerFixture() will call grpc_server_destroy
 
   char* json_str = grpc_channelz_get_servers(0);

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -64,6 +64,19 @@
 using grpc_event_engine::experimental::GetDefaultEventEngine;
 
 namespace grpc_core {
+namespace testing {
+class ServerTestPeer {
+ public:
+  explicit ServerTestPeer(Server* server) : server_(server) {}
+  RefCountedPtr<Server> TakeRef() { return server_->Ref(); }
+
+ private:
+  Server* server_;
+};
+}
+}
+
+namespace grpc_core {
 namespace channelz {
 namespace testing {
 
@@ -655,6 +668,34 @@ TEST(ChannelzTextEncodeTest, BasicTraceEvent) {
       channelz::TextEncode(reinterpret_cast<upb_Message*>(event),
                            grpc_channelz_v2_TraceEvent_getmsgdef);
   EXPECT_NE(encoded.length(), 0) << encoded;
+}
+
+TEST(ServerDeregistrationTest, DestroyedServerNotListedWhileRefsRemain) {
+  ExecCtx ctx;
+  RefCountedPtr<Server> draining_ref;
+  intptr_t uuid;
+  {
+    ServerFixture server;
+    Server* core_server = Server::FromC(server.server());
+
+    ServerNode* node = core_server->channelz_node();
+    ASSERT_NE(node, nullptr);
+
+    uuid = node->uuid();
+    draining_ref = grpc_core::testing::ServerTestPeer(core_server).TakeRef();
+  }  // ~ServerFixture() will call grpc_server_destroy
+
+  char* json_str = grpc_channelz_get_servers(0);
+  ASSERT_NE(json_str, nullptr);
+
+  const std::string key_value_pair =
+      "\"serverId\":\"" + std::to_string(uuid) + "\"";
+  EXPECT_FALSE(absl::StrContains(json_str, key_value_pair))
+      << "destroyed server " << uuid
+      << " still listed by GetServers(): " << json_str;
+
+  gpr_free(json_str);
+  draining_ref.reset();
 }
 
 }  // namespace testing

--- a/test/core/transport/chttp2/chttp2_server_listener_test.cc
+++ b/test/core/transport/chttp2/chttp2_server_listener_test.cc
@@ -17,6 +17,7 @@
 //
 
 #include <grpc/grpc.h>
+#include <grpc/passive_listener.h>
 
 #include <thread>
 
@@ -36,6 +37,7 @@
 #include "test/core/test_util/test_config.h"
 #include "test/core/test_util/tls_utils.h"
 #include "gtest/gtest.h"
+#include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/notification.h"
 
@@ -77,6 +79,10 @@ class ActiveConnectionTestPeer {
   void OnClose() {
     NewChttp2ServerListener::ActiveConnection::OnClose(connection_,
                                                        absl::OkStatus());
+  }
+
+  void ScheduleOnWorkSerializer(absl::AnyInvocable<void()> cb) {
+    connection_->work_serializer_.Run(std::move(cb), DEBUG_LOCATION);
   }
 
   NewChttp2ServerListener::ActiveConnection::HandshakingState*
@@ -167,6 +173,17 @@ class ListenerStateTestPeer {
     return listener_state_->connections_.size();
   }
 
+  // Returns the single tracked connection or nullptr if there is not exactly
+  // one connection being tracked.
+  RefCountedPtr<NewChttp2ServerListener::ActiveConnection>
+  GetSingleConnection() {
+    MutexLock lock(&listener_state_->mu_);
+    if (listener_state_->connections_.size() != 1) return nullptr;
+    return DownCast<NewChttp2ServerListener::ActiveConnection*>(
+               listener_state_->connections_.begin()->get())
+        ->RefAsSubclass<NewChttp2ServerListener::ActiveConnection>();
+  }
+
  private:
   Server::ListenerState* listener_state_;
 };
@@ -225,6 +242,26 @@ class Chttp2ServerListenerTest : public ::testing::Test {
     listener_ = DownCast<NewChttp2ServerListener*>(listener_state_->listener());
   }
 
+  void SetUpServerWithPassiveListener(
+      const RefCountedPtr<grpc_server_credentials>& creds =
+          MakeRefCounted<InsecureServerCredentials>()) {
+    args_ = CoreConfiguration::Get()
+                .channel_args_preconditioning()
+                .PreconditionChannelArgs(nullptr);
+    server_ = MakeOrphanable<Server>(args_);
+    passive_listener_ = std::make_shared<experimental::PassiveListenerImpl>();
+    auto status = grpc_server_add_passive_listener(server_.get(), creds.get(),
+                                                   passive_listener_);
+    ASSERT_TRUE(status.ok());
+
+    cq_ = grpc_completion_queue_create_for_next(/*reserved=*/nullptr);
+    server_->RegisterCompletionQueue(cq_);
+    grpc_server_start(server_->c_ptr());
+    listener_state_ =
+        ServerTestPeer(server_.get()).listener_states().front().get();
+    listener_ = DownCast<NewChttp2ServerListener*>(listener_state_->listener());
+  }
+
   void TearDown() override {
     CqVerifier cqv(cq_);
     grpc_server_shutdown_and_notify(server_->c_ptr(), cq_, CqVerifier::tag(-1));
@@ -244,6 +281,7 @@ class Chttp2ServerListenerTest : public ::testing::Test {
   Server::ListenerState* listener_state_;
   NewChttp2ServerListener* listener_;
   grpc_completion_queue* cq_ = nullptr;
+  std::shared_ptr<experimental::PassiveListenerImpl> passive_listener_;
 };
 
 TEST_F(Chttp2ServerListenerTest, Basic) {
@@ -351,7 +389,7 @@ TEST_F(Chttp2ActiveConnectionTest, CloseWithoutHandshakeStarting) {
   ASSERT_TRUE(listener_state_->connection_quota()->AllowIncomingConnection(
       listener_state_->memory_quota(), "peer"));
   auto connection = MakeOrphanable<NewChttp2ServerListener::ActiveConnection>(
-      listener_state_->Ref(), /*tcp_server=*/nullptr,
+      listener_state_->Ref(), /*listener_ref=*/nullptr, /*tcp_server=*/nullptr,
       /*accepting_pollset=*/nullptr,
       /*acceptor=*/nullptr, args_,
       listener_state_->memory_quota()->CreateMemoryOwner(), nullptr);
@@ -405,7 +443,7 @@ TEST_F(Chttp2ActiveConnectionTest, CloseDuringHandshake) {
   ASSERT_TRUE(listener_state_->connection_quota()->AllowIncomingConnection(
       listener_state_->memory_quota(), "peer"));
   auto connection = MakeOrphanable<NewChttp2ServerListener::ActiveConnection>(
-      listener_state_->Ref(), /*tcp_server=*/nullptr,
+      listener_state_->Ref(), /*listener_ref=*/nullptr, /*tcp_server=*/nullptr,
       /*accepting_pollset=*/nullptr,
       /*acceptor=*/nullptr, args_,
       listener_state_->memory_quota()->CreateMemoryOwner(), nullptr);
@@ -432,7 +470,7 @@ TEST_F(Chttp2ActiveConnectionTest, CloseAfterHandshakeButBeforeSettingsFrame) {
   ASSERT_TRUE(listener_state_->connection_quota()->AllowIncomingConnection(
       listener_state_->memory_quota(), "peer"));
   auto connection = MakeOrphanable<NewChttp2ServerListener::ActiveConnection>(
-      listener_state_->Ref(), /*tcp_server=*/nullptr,
+      listener_state_->Ref(), /*listener_ref=*/nullptr, /*tcp_server=*/nullptr,
       /*accepting_pollset=*/nullptr,
       /*acceptor=*/nullptr, args_,
       listener_state_->memory_quota()->CreateMemoryOwner(),
@@ -482,7 +520,7 @@ TEST_F(Chttp2ActiveConnectionTest, CloseAfterSettingsFrame) {
   ASSERT_TRUE(listener_state_->connection_quota()->AllowIncomingConnection(
       listener_state_->memory_quota(), "peer"));
   auto connection = MakeOrphanable<NewChttp2ServerListener::ActiveConnection>(
-      listener_state_->Ref(), /*tcp_server=*/nullptr,
+      listener_state_->Ref(), /*listener_ref=*/nullptr, /*tcp_server=*/nullptr,
       /*accepting_pollset=*/nullptr,
       /*acceptor=*/nullptr, args_,
       listener_state_->memory_quota()->CreateMemoryOwner(),
@@ -523,6 +561,42 @@ TEST_F(Chttp2ActiveConnectionTest, CloseAfterSettingsFrame) {
     // If the test turns out to be flaky, convert this to a sleep.
     std::this_thread::yield();
   }
+}
+
+TEST_F(Chttp2ActiveConnectionTest, PassiveListenerShutdownWaitsForHandshake) {
+  SetUpServerWithPassiveListener(CreateSecureServerCredentials());
+  listener_state_->connection_quota()->SetMaxIncomingConnections(10);
+  // accept a connection whose handshake will stall
+  auto mock_endpoint_controller =
+      grpc_event_engine::experimental::MockEndpointController::Create(
+          args_.GetObjectRef<EventEngine>());
+  Chttp2ServerListenerTestPeer(listener_).OnAccept(
+      /*tcp=*/mock_endpoint_controller->TakeCEndpoint(),
+      /*accepting_pollset=*/nullptr,
+      /*server_acceptor=*/nullptr);
+  auto connection =
+      ListenerStateTestPeer(listener_state_).GetSingleConnection();
+  ASSERT_NE(connection, nullptr);
+
+  // block the connection's WorkSerializer so that server shutdown must await
+  // for handshake completion
+  absl::Notification release_handshake;
+  ActiveConnectionTestPeer(connection.get()).ScheduleOnWorkSerializer([&]() {
+    release_handshake.WaitForNotification();
+  });
+
+  grpc_server_shutdown_and_notify(server_->c_ptr(), cq_, CqVerifier::tag(1));
+  CqVerifier cqv(cq_);
+  cqv.VerifyEmpty(Duration::Seconds(2 * grpc_test_slowdown_factor()));
+
+  // once the handshake is completed, server shutdown completes
+  release_handshake.Notify();
+  mock_endpoint_controller->TriggerReadEvent(
+      grpc_event_engine::experimental::Slice::FromCopiedString(
+          "not a valid ClientHello"));
+  mock_endpoint_controller->NoMoreReads();
+  cqv.Expect(CqVerifier::tag(1), true);
+  cqv.Verify();
 }
 
 }  // namespace


### PR DESCRIPTION
## Context
While screening gRPC Python on free-threaded CPython 3.14, I found that `GetServers()` (from channelz API) can return a server **after** `grpc_server_destroy()` has completed. **Root cause**: the channelz `ServerNode` is deregistered when its last strong ref drops, which happens in `~Server()`. The gap is milliseconds; under GIL it is almost never observable (1 failure out of 3000 runs), while free-threading mode amplifies observations (~4 failures per 1000 runs).

## Questions
1. Should a server remain listed after `grpc_server_destroy()` call?

## Proposed solution
1. Implemented a unit test, which fails 50 out of 50 runs without the source code change.
**Arrange**: hold strong ref to the server, **Act**: call `grpc_server_destroy()`, **Check**: the `GetServers()` listing no longer contains the server - even though the ref is still held
2. Added two extra calls to `Server::Orphan()`, which will do the clean-up expected from the unit test assertions.
3. Removed unused class member `channelz_socket_uuid_` from `Server::ChannelData`
4. Added extra listener reference to `HandshakingState` object. Reference is needed due to the possible race between server shutdown and a handshake performed. Timeline as follows:
```
Test thread                                        Event engine thread
AcceptConnectedFd(fd)    ------------->            handshake starts on the new connection
Server::Shutdown()
    grpc_server_destroy()
        Orphan()
            channelz_node_.reset()
Test body done, all asserts green
                                                   handshake completes
                                                       OnHandshakeDoneLocked()
                                                           Server::SetupTransport()
                                                               channelz_node is nullptr
                                                                   SIGSEGV
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

