### PR TITLE
[CI] Remove unused references to msvc 2019 from tests.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -158,7 +158,7 @@ installed to be able to compile the C/C++ sources.
 > cd cmake
 > md build
 > cd build
-> call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
+> call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" x64
 > cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 ..\..
 > cmake --build .
 ```

--- a/tools/run_tests/artifacts/build_artifact_protoc.bat
+++ b/tools/run_tests/artifacts/build_artifact_protoc.bat
@@ -27,7 +27,7 @@ if "%GRPC_PROTOC_BUILD_COMPILER_JOBS%"=="" (
   set GRPC_PROTOC_BUILD_COMPILER_JOBS=2
 )
 
-@rem set cl.exe build environment to build with VS2019 tooling
+@rem set cl.exe build environment to build with VS2022 tooling
 @rem this is required for Ninja build to work
 call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
 @rem restore command echo

--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -21,14 +21,6 @@ mkdir install
 cd ..
 set "INSTALL_PATH=%~dp0\cmake\install"
 
-If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
-  @rem set cl.exe build environment to build with VS2019 tooling
-  @rem this is required for Ninja build to work
-  call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %GRPC_BUILD_VS_TOOLS_ARCHITECTURE%
-  @rem restore command echo
-  echo on
-)
-
 If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2022" (
   @rem set cl.exe build environment to build with VS2022 tooling
   @rem this is required for Ninja build to work
@@ -40,20 +32,6 @@ If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2022" (
 @rem Setting the env variable to a single space translates to passing no argument
 @rem when evaluated on the command line.
 set "CMAKE_SYSTEM_VERSION_ARG= "
-
-If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
-  @rem Always use the newest Windows 10 SDK available.
-  @rem A new-enough Windows 10 SDK that supports C++11's stdalign.h is required
-  @rem for a successful build.
-  @rem By default cmake together with Visual Studio generator
-  @rem pick a version of Win SDK that matches the Windows version,
-  @rem even when a newer version of the SDK available.
-  @rem Setting CMAKE_SYSTEM_VERSION=10.0 changes this behavior
-  @rem to pick the newest Windows SDK available.
-  @rem When using Ninja generator, this problem doesn't happen.
-  @rem See b/275694647 and https://gitlab.kitware.com/cmake/cmake/-/issues/16202#note_140259
-  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0"
-)
 
 If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 17 2022" (
   @rem The same as above.


### PR DESCRIPTION
Per oss [policy](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md#compilers-tools-build-systems) we support msvc >= 2022