### PR TITLE
[Python] Channelz test suite fixes

### DIFF
--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -15,6 +15,7 @@
 
 from concurrent import futures
 import ipaddress
+import time
 import unittest
 
 import grpc
@@ -320,13 +321,15 @@ class ChannelzServicerTest(unittest.TestCase):
         for i in range(k_failed):
             self._send_failed_unary_unary(0)
 
-        while True:
+        for _ in range(100):
             resp = self._get_server_by_ref_id(self._pairs[0].server_ref_id)
             if (
                 resp.data.calls_started
                 == resp.data.calls_succeeded + resp.data.calls_failed
             ):
                 break
+            time.sleep(0.01)
+
         self.assertEqual(resp.data.calls_started, k_success + k_failed)
         self.assertEqual(resp.data.calls_succeeded, k_success)
         self.assertEqual(resp.data.calls_failed, k_failed)
@@ -414,7 +417,7 @@ class ChannelzServicerTest(unittest.TestCase):
         # Subchannel exists
         self.assertGreater(len(gc_resp.channel.subchannel_ref), 0)
 
-        while True:
+        for _ in range(100):
             gsc_resp = self._channelz_stub.GetSubchannel(
                 channelz_pb2.GetSubchannelRequest(
                     subchannel_id=gc_resp.channel.subchannel_ref[
@@ -428,13 +431,15 @@ class ChannelzServicerTest(unittest.TestCase):
                 + gsc_resp.subchannel.data.calls_failed
             ):
                 break
+            time.sleep(0.01)
+
         self.assertEqual(gsc_resp.subchannel.data.calls_started, 1)
         self.assertEqual(gsc_resp.subchannel.data.calls_failed, 0)
         self.assertEqual(gsc_resp.subchannel.data.calls_succeeded, 1)
         # Socket exists
         self.assertEqual(len(gsc_resp.subchannel.socket_ref), 1)
 
-        while True:
+        for _ in range(100):
             gs_resp = self._channelz_stub.GetSocket(
                 channelz_pb2.GetSocketRequest(
                     socket_id=gsc_resp.subchannel.socket_ref[0].socket_id
@@ -446,6 +451,8 @@ class ChannelzServicerTest(unittest.TestCase):
                 + gs_resp.socket.data.streams_failed
             ):
                 break
+            time.sleep(0.01)
+
         self.assertEqual(gs_resp.socket.data.streams_started, 1)
         self.assertEqual(gs_resp.socket.data.streams_succeeded, 1)
         self.assertEqual(gs_resp.socket.data.streams_failed, 0)
@@ -461,13 +468,15 @@ class ChannelzServicerTest(unittest.TestCase):
         self._send_successful_unary_unary(0)
         self._send_failed_unary_unary(0)
 
-        while True:
+        for _ in range(100):
             gs_resp = self._get_server_by_ref_id(self._pairs[0].server_ref_id)
             if (
                 gs_resp.data.calls_started
                 == gs_resp.data.calls_succeeded + gs_resp.data.calls_failed
             ):
                 break
+            time.sleep(0.01)
+
         self.assertEqual(gs_resp.data.calls_started, 2)
         self.assertEqual(gs_resp.data.calls_succeeded, 1)
         self.assertEqual(gs_resp.data.calls_failed, 1)

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -325,7 +325,6 @@ class ChannelzServicerTest(unittest.TestCase):
             if (
                 resp.data.calls_started
                 == resp.data.calls_succeeded + resp.data.calls_failed
-
             ):
                 break
         self.assertEqual(resp.data.calls_started, k_success + k_failed)

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -295,9 +295,17 @@ class ChannelzServicerTest(unittest.TestCase):
         for i in range(k_failed):
             self._send_failed_unary_unary(0)
 
-        resp = self._channelz_stub.GetServers(
-            channelz_pb2.GetServersRequest(start_server_id=0)
-        )
+        while True:
+            resp = self._channelz_stub.GetServers(
+                channelz_pb2.GetServersRequest(start_server_id=0)
+            )
+            if (
+                resp.server[0].calls_started
+                == resp.server[0].data.calls_succeeded
+                + resp.server[0].data.calls_failed
+
+            ):
+                break
         self.assertEqual(len(resp.server), 1)
         self.assertEqual(
             resp.server[0].data.calls_started, k_success + k_failed
@@ -435,9 +443,16 @@ class ChannelzServicerTest(unittest.TestCase):
         self._send_successful_unary_unary(0)
         self._send_failed_unary_unary(0)
 
-        gs_resp = self._channelz_stub.GetServers(
-            channelz_pb2.GetServersRequest(start_server_id=0)
-        )
+        while True:
+            gs_resp = self._channelz_stub.GetServers(
+                channelz_pb2.GetServersRequest(start_server_id=0)
+            )
+            if (
+                gs_resp.server[0].data.calls_started
+                == gs_resp.server[0].data.calls_succeeded
+                + gs_resp.server[0].data.calls_failed
+            ):
+                break
         self.assertEqual(len(gs_resp.server), 1)
         self.assertEqual(gs_resp.server[0].data.calls_started, 2)
         self.assertEqual(gs_resp.server[0].data.calls_succeeded, 1)

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -80,10 +80,23 @@ class _ChannelServerPair:
         self.channel = grpc.insecure_channel(
             "localhost:%d" % port, _ENABLE_CHANNELZ
         )
+        self.server_ref_id = None
+
+    def bind_channelz(self, channelz_stub):
+        resp = channelz_stub.GetServers(
+            channelz_pb2.GetServersRequest(start_server_id=0)
+        )
+        self.server_ref_id = resp.server[-1].ref.server_id
 
 
-def _generate_channel_server_pairs(n):
-    return [_ChannelServerPair() for i in range(n)]
+def _generate_channel_server_pairs(n, channelz_stub=None):
+    pairs = []
+    for _ in range(n):
+        pair = _ChannelServerPair()
+        if channelz_stub is not None:
+            pair.bind_channelz(channelz_stub)
+        pairs.append(pair)
+    return pairs
 
 
 def _close_channel_server_pairs(pairs):
@@ -160,6 +173,15 @@ class ChannelzServicerTest(unittest.TestCase):
         self._server.stop(None)
         self._channel.close()
         _close_channel_server_pairs(self._pairs)
+
+    def _get_server_by_ref_id(self, ref_id):
+        """Server id may not be consecutive"""
+        resp = self._channelz_stub.GetServers(
+            channelz_pb2.GetServersRequest(start_server_id=ref_id)
+        )
+        self.assertEqual(len(resp.server), 1)
+        self.assertEqual(ref_id, resp.server[0].ref.server_id)
+        return resp.server[0]
 
     def test_get_top_channels_basic(self):
         self._pairs = _generate_channel_server_pairs(1)
@@ -265,16 +287,19 @@ class ChannelzServicerTest(unittest.TestCase):
             )
 
     def test_server_basic(self):
-        self._pairs = _generate_channel_server_pairs(1)
+        self._pairs = _generate_channel_server_pairs(1, self._channelz_stub)
+        server_id = self._pairs[0].server_ref_id
         resp = self._channelz_stub.GetServers(
-            channelz_pb2.GetServersRequest(start_server_id=0)
+            channelz_pb2.GetServersRequest(start_server_id=server_id)
         )
         self.assertEqual(len(resp.server), 1)
+        self.assertEqual(resp.server[0].ref.server_id, server_id)
 
     def test_get_one_server(self):
-        self._pairs = _generate_channel_server_pairs(1)
+        self._pairs = _generate_channel_server_pairs(1, self._channelz_stub)
+        server_id = self._pairs[0].server_ref_id
         gss_resp = self._channelz_stub.GetServers(
-            channelz_pb2.GetServersRequest(start_server_id=0)
+            channelz_pb2.GetServersRequest(start_server_id=server_id)
         )
         self.assertEqual(len(gss_resp.server), 1)
         gs_resp = self._channelz_stub.GetServer(
@@ -287,7 +312,7 @@ class ChannelzServicerTest(unittest.TestCase):
         )
 
     def test_server_call(self):
-        self._pairs = _generate_channel_server_pairs(1)
+        self._pairs = _generate_channel_server_pairs(1, self._channelz_stub)
         k_success = 23
         k_failed = 29
         for i in range(k_success):
@@ -296,22 +321,16 @@ class ChannelzServicerTest(unittest.TestCase):
             self._send_failed_unary_unary(0)
 
         while True:
-            resp = self._channelz_stub.GetServers(
-                channelz_pb2.GetServersRequest(start_server_id=0)
-            )
+            resp = self._get_server_by_ref_id(self._pairs[0].server_ref_id)
             if (
-                resp.server[0].calls_started
-                == resp.server[0].data.calls_succeeded
-                + resp.server[0].data.calls_failed
+                resp.data.calls_started
+                == resp.data.calls_succeeded + resp.data.calls_failed
 
             ):
                 break
-        self.assertEqual(len(resp.server), 1)
-        self.assertEqual(
-            resp.server[0].data.calls_started, k_success + k_failed
-        )
-        self.assertEqual(resp.server[0].data.calls_succeeded, k_success)
-        self.assertEqual(resp.server[0].data.calls_failed, k_failed)
+        self.assertEqual(resp.data.calls_started, k_success + k_failed)
+        self.assertEqual(resp.data.calls_succeeded, k_success)
+        self.assertEqual(resp.data.calls_failed, k_failed)
 
     def test_many_subchannels_and_sockets(self):
         k_channels = 4
@@ -439,28 +458,24 @@ class ChannelzServicerTest(unittest.TestCase):
         )
 
     def test_server_sockets(self):
-        self._pairs = _generate_channel_server_pairs(1)
+        self._pairs = _generate_channel_server_pairs(1, self._channelz_stub)
         self._send_successful_unary_unary(0)
         self._send_failed_unary_unary(0)
 
         while True:
-            gs_resp = self._channelz_stub.GetServers(
-                channelz_pb2.GetServersRequest(start_server_id=0)
-            )
+            gs_resp = self._get_server_by_ref_id(self._pairs[0].server_ref_id)
             if (
-                gs_resp.server[0].data.calls_started
-                == gs_resp.server[0].data.calls_succeeded
-                + gs_resp.server[0].data.calls_failed
+                gs_resp.data.calls_started
+                == gs_resp.data.calls_succeeded + gs_resp.data.calls_failed
             ):
                 break
-        self.assertEqual(len(gs_resp.server), 1)
-        self.assertEqual(gs_resp.server[0].data.calls_started, 2)
-        self.assertEqual(gs_resp.server[0].data.calls_succeeded, 1)
-        self.assertEqual(gs_resp.server[0].data.calls_failed, 1)
+        self.assertEqual(gs_resp.data.calls_started, 2)
+        self.assertEqual(gs_resp.data.calls_succeeded, 1)
+        self.assertEqual(gs_resp.data.calls_failed, 1)
 
         gss_resp = self._channelz_stub.GetServerSockets(
             channelz_pb2.GetServerSocketsRequest(
-                server_id=gs_resp.server[0].ref.server_id, start_socket_id=0
+                server_id=gs_resp.ref.server_id, start_socket_id=0
             )
         )
 
@@ -505,17 +520,13 @@ class ChannelzServicerTest(unittest.TestCase):
         )
 
     def test_server_listen_sockets(self):
-        self._pairs = _generate_channel_server_pairs(1)
-
-        gss_resp = self._channelz_stub.GetServers(
-            channelz_pb2.GetServersRequest(start_server_id=0)
-        )
-        self.assertEqual(len(gss_resp.server), 1)
-        self.assertEqual(len(gss_resp.server[0].listen_socket), 1)
+        self._pairs = _generate_channel_server_pairs(1, self._channelz_stub)
+        resp = self._get_server_by_ref_id(self._pairs[0].server_ref_id)
+        self.assertEqual(len(resp.listen_socket), 1)
 
         gs_resp: channelz_pb2.GetSocketResponse = self._channelz_stub.GetSocket(
             channelz_pb2.GetSocketRequest(
-                socket_id=gss_resp.server[0].listen_socket[0].socket_id
+                socket_id=resp.listen_socket[0].socket_id
             )
         )
 

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -150,6 +150,7 @@ class ChannelzServicerTest(AioTestBase):
         resp = await self._channelz_stub.GetServers(
             channelz_pb2.GetServersRequest(start_server_id=ref_id)
         )
+        self.assertEqual(len(resp.server), 1)
         self.assertEqual(ref_id, resp.server[0].ref.server_id)
         return resp.server[0]
 
@@ -292,6 +293,7 @@ class ChannelzServicerTest(AioTestBase):
             await self._send_failed_unary_unary(pairs[0])
 
         while True:
+            resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
             if (
                 resp.data.calls_started ==
                 resp.data.calls_succeeded + resp.data.calls_failed

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -291,6 +291,12 @@ class ChannelzServicerTest(AioTestBase):
         for i in range(k_failed):
             await self._send_failed_unary_unary(pairs[0])
 
+        while True:
+            if (
+                resp.data.calls_started ==
+                resp.data.calls_succeeded + resp.data.calls_failed
+            ):
+                break
         resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
         self.assertEqual(resp.data.calls_started, k_success + k_failed)
         self.assertEqual(resp.data.calls_succeeded, k_success)
@@ -418,7 +424,13 @@ class ChannelzServicerTest(AioTestBase):
         await self._send_successful_unary_unary(pairs[0])
         await self._send_failed_unary_unary(pairs[0])
 
-        resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
+        while True:
+            resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
+            if (
+                resp.data.calls_started ==
+                resp.data.calls_succeeded + resp.data.calls_failed
+            ):
+                break
         self.assertEqual(resp.data.calls_started, 2)
         self.assertEqual(resp.data.calls_succeeded, 1)
         self.assertEqual(resp.data.calls_failed, 1)

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -295,8 +295,8 @@ class ChannelzServicerTest(AioTestBase):
         while True:
             resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
             if (
-                resp.data.calls_started ==
-                resp.data.calls_succeeded + resp.data.calls_failed
+                resp.data.calls_started
+                == resp.data.calls_succeeded + resp.data.calls_failed
             ):
                 break
         resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
@@ -429,8 +429,8 @@ class ChannelzServicerTest(AioTestBase):
         while True:
             resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
             if (
-                resp.data.calls_started ==
-                resp.data.calls_succeeded + resp.data.calls_failed
+                resp.data.calls_started
+                == resp.data.calls_succeeded + resp.data.calls_failed
             ):
                 break
         self.assertEqual(resp.data.calls_started, 2)

--- a/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/channelz/channelz_servicer_test.py
@@ -292,14 +292,15 @@ class ChannelzServicerTest(AioTestBase):
         for i in range(k_failed):
             await self._send_failed_unary_unary(pairs[0])
 
-        while True:
+        for _ in range(100):
             resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
             if (
                 resp.data.calls_started
                 == resp.data.calls_succeeded + resp.data.calls_failed
             ):
                 break
-        resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
+            await asyncio.sleep(0.01)
+
         self.assertEqual(resp.data.calls_started, k_success + k_failed)
         self.assertEqual(resp.data.calls_succeeded, k_success)
         self.assertEqual(resp.data.calls_failed, k_failed)
@@ -376,7 +377,7 @@ class ChannelzServicerTest(AioTestBase):
         # Subchannel exists
         self.assertGreater(len(gc_resp.channel.subchannel_ref), 0)
 
-        while True:
+        for _ in range(100):
             gsc_resp = await self._channelz_stub.GetSubchannel(
                 channelz_pb2.GetSubchannelRequest(
                     subchannel_id=gc_resp.channel.subchannel_ref[
@@ -390,13 +391,15 @@ class ChannelzServicerTest(AioTestBase):
                 + gsc_resp.subchannel.data.calls_failed
             ):
                 break
+            await asyncio.sleep(0.01)
+
         self.assertEqual(gsc_resp.subchannel.data.calls_started, 1)
         self.assertEqual(gsc_resp.subchannel.data.calls_failed, 0)
         self.assertEqual(gsc_resp.subchannel.data.calls_succeeded, 1)
         # Socket exists
         self.assertEqual(len(gsc_resp.subchannel.socket_ref), 1)
 
-        while True:
+        for _ in range(100):
             gs_resp = await self._channelz_stub.GetSocket(
                 channelz_pb2.GetSocketRequest(
                     socket_id=gsc_resp.subchannel.socket_ref[0].socket_id
@@ -408,6 +411,8 @@ class ChannelzServicerTest(AioTestBase):
                 + gs_resp.socket.data.streams_failed
             ):
                 break
+            await asyncio.sleep(0.01)
+
         self.assertEqual(gs_resp.socket.data.streams_started, 1)
         self.assertEqual(gs_resp.socket.data.streams_failed, 0)
         self.assertEqual(gs_resp.socket.data.streams_succeeded, 1)
@@ -426,13 +431,15 @@ class ChannelzServicerTest(AioTestBase):
         await self._send_successful_unary_unary(pairs[0])
         await self._send_failed_unary_unary(pairs[0])
 
-        while True:
+        for _ in range(100):
             resp = await self._get_server_by_ref_id(pairs[0].server_ref_id)
             if (
                 resp.data.calls_started
                 == resp.data.calls_succeeded + resp.data.calls_failed
             ):
                 break
+            await asyncio.sleep(0.01)
+
         self.assertEqual(resp.data.calls_started, 2)
         self.assertEqual(resp.data.calls_succeeded, 1)
         self.assertEqual(resp.data.calls_failed, 1)


### PR DESCRIPTION
## Issue 1
Client RPC call is unblocked as soon as return status reaches it. `RecordCallSucceeded()` and `RecordCallFailed()` on the `ServerNode` are executed afterwards on a server thread. Asserting exact counter values immediately after an RPC is race-prone.

## Solution 1
Applied the same pattern used elsewhere in the test suite - while loop which waits until server call counters are settled before asserting.

## Issue 2
A stale server from the previous test case run is still registered in the channelz registry. This makes `GetServers()` calls to return more servers than expected. Issue itself fixed here: https://github.com/grpc/grpc/pull/43260.

## Solution 2
Added id-scoping for `GetServers()` calls in a sync Python stack as per AsyncIO stack. From the test's perspective: every test fixture records its own server's channelz ID at creation and queries `GetServers(start_server_id=<own_id>)`, which will restrict the server view to the one created in this exact test case.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

