### PR TITLE
[Python] Update black version and formatting with Python 3.15

### DIFF
--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -21,6 +21,7 @@ timeout on client side:
 2. Client will set a timer (customized client timeout) waiting for initial_metadata.
 3. Client will timeout if it didn't receive initial_metadata.
 """
+
 import logging
 import threading
 from typing import Sequence, Tuple

--- a/grpc-style-config.toml
+++ b/grpc-style-config.toml
@@ -5,6 +5,8 @@ target-version = [
   "py311",
   "py312",
   "py313",
+  "py314",
+  "py315"
 ]
 extend-exclude = '''
 # A regex preceded with ^/ will apply only to files and directories

--- a/src/csharp/Grpc.Tools.Tests/scripts/fakeprotoc.py
+++ b/src/csharp/Grpc.Tools.Tests/scripts/fakeprotoc.py
@@ -115,7 +115,7 @@ def _parse_protoc_arguments(protoc_args, projectdir):
             # Assumes that cmdline arguments are always passed in the
             # "--somearg=argvalue", which happens to be the form that
             # msbuild integration uses, but it's not the only way.
-            (name, value) = arg.split("=", 1)
+            name, value = arg.split("=", 1)
 
             if (
                 name == "--dependency_out"

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Invocation-side implementation of gRPC Asyncio Python."""
+
 # pyright: reportPrivateUsage = false
 
 import asyncio

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Implementation of the metadata abstraction for gRPC Asyncio Python."""
+
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/src/python/grpcio/grpc/aio/_utils.py
+++ b/src/python/grpcio/grpc/aio/_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Internal utilities used by the gRPC Aio module."""
+
 import time
 from typing import Optional
 

--- a/src/python/grpcio/grpc/experimental/__init__.py
+++ b/src/python/grpcio/grpc/experimental/__init__.py
@@ -15,6 +15,7 @@
 
 These APIs are subject to be removed during any minor version release.
 """
+
 from __future__ import annotations
 
 import copy

--- a/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
+++ b/src/python/grpcio_tests/tests/stress/unary_stream_benchmark.py
@@ -26,8 +26,7 @@ _PORT = 5741
 _MESSAGE_SIZE = 4
 _RESPONSE_COUNT = 32 * 1024
 
-_SERVER_CODE = (
-    """
+_SERVER_CODE = """
 import datetime
 import threading
 import grpc
@@ -48,9 +47,7 @@ server.add_insecure_port('[::]:%d')
 unary_stream_benchmark_pb2_grpc.add_UnaryStreamBenchmarkServiceServicer_to_server(Handler(), server)
 server.start()
 server.wait_for_termination()
-"""
-    % _PORT
-)
+""" % _PORT
 
 try:
     from src.python.grpcio_tests.tests.stress import (

--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests that a channel will reconnect if a connection is dropped"""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the metadata abstraction that's used in the asynchronous driver."""
+
 import logging
 import unittest
 

--- a/test/cpp/qps/scenario_runner.py
+++ b/test/cpp/qps/scenario_runner.py
@@ -49,7 +49,6 @@ Other --runner_cmd examples:
 "
 """
 
-
 import os
 import subprocess
 import sys

--- a/tools/codegen/core/gen_grpc_tls_credentials_options.py
+++ b/tools/codegen/core/gen_grpc_tls_credentials_options.py
@@ -273,8 +273,7 @@ def put_copyright(f, year):
 // limitations under the License.
 //
 //
-"""
-        % (year),
+""" % (year),
         file=f,
     )
 

--- a/tools/codegen/core/gen_join.py
+++ b/tools/codegen/core/gen_join.py
@@ -18,8 +18,7 @@ import sys
 
 from mako.template import Template
 
-join_state = Template(
-    """
+join_state = Template("""
 template <class Traits, ${",".join(f"typename P{i}" for i in range(0,n))}>
 struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
   template <typename T>
@@ -100,8 +99,7 @@ struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
     return Pending{};
   }
 };
-"""
-)
+""")
 
 front_matter = """
 #ifndef GRPC_SRC_CORE_LIB_PROMISE_DETAIL_JOIN_STATE_H

--- a/tools/codegen/core/gen_seq.py
+++ b/tools/codegen/core/gen_seq.py
@@ -18,8 +18,7 @@ import sys
 
 from mako.template import Template
 
-seq_state = Template(
-    """
+seq_state = Template("""
 <%def name="decl(promise_name, i, n)">
 using Promise${i} = ${promise_name};
 % if i < n-1:
@@ -180,8 +179,7 @@ tail${i}:
       }
     }
   }
-};"""
-)
+};""")
 
 front_matter = """
 #ifndef GRPC_SRC_CORE_LIB_PROMISE_DETAIL_SEQ_STATE_H

--- a/tools/distrib/black_code.sh
+++ b/tools/distrib/black_code.sh
@@ -36,7 +36,7 @@ python3 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 
-pip install black==25.1.0
+pip install black==26.5.1
 pip list
 
 if [[ "$ACTION" == "--check" ]]; then

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -413,7 +413,7 @@ for lang in languages:
             # docker image name must be in the format <docker_path>/<image>:<gcr_tag>
             assert image.startswith(args.docker_path) and image.find(":") != -1
             # Add a tag to exclude the image from the GCP Vulnerability Scanner.
-            (image_name, tag_name) = image.rsplit(":", 1)
+            image_name, tag_name = image.rsplit(":", 1)
             alternate_image = (
                 f"{image_name}:infrastructure-public-image-{tag_name}"
             )

--- a/tools/run_tests/performance/bq_upload_result.py
+++ b/tools/run_tests/performance/bq_upload_result.py
@@ -36,7 +36,7 @@ def _upload_netperf_latency_csv_to_bigquery(
     project_id, dataset_id, table_id, result_file
 ):
     with open(result_file, "r") as f:
-        (col1, col2, col3) = f.read().split(",")
+        col1, col2, col3 = f.read().split(",")
         latency50 = float(col1.strip()) * 1000
         latency90 = float(col2.strip()) * 1000
         latency99 = float(col3.strip()) * 1000

--- a/tools/run_tests/performance/prometheus.py
+++ b/tools/run_tests/performance/prometheus.py
@@ -26,6 +26,7 @@ in given pods. The cpu data obtained is total cpu second used within
 given period of time. The memory data was instant memory usage at
 the query time.
 """
+
 import argparse
 import json
 import logging

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1715,11 +1715,11 @@ try:
                             jobs.append(test_job)
     for server in args.override_server:
         server_name = server[0]
-        (server_host, server_port) = server[1].split(":")
+        server_host, server_port = server[1].split(":")
         server_addresses[server_name] = (server_host, server_port)
 
     for server_name, server_address in list(server_addresses.items()):
-        (server_host, server_port) = server_address
+        server_host, server_port = server_address
         server_language = _LANGUAGES.get(server_name, None)
         skip_server = []  # test cases unimplemented by server
         if server_language:

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2962,8 +2962,7 @@ def get_startup_script(path_to_server_binary, service_port):
             service_port,
         )
     else:
-        return (
-            """#!/bin/bash
+        return """#!/bin/bash
 sudo apt update
 sudo apt install -y git default-jdk
 mkdir java_server
@@ -2974,9 +2973,7 @@ pushd interop-testing
 ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 
 nohup build/install/grpc-interop-testing/bin/xds-test-server \
-    --port=%d 1>/dev/null &"""
-            % service_port
-        )
+    --port=%d 1>/dev/null &""" % service_port
 
 
 def create_instance_template(


### PR DESCRIPTION
Update black to the most recent version to allow Python 3.15 formatting support.
Update files formatting with the updated black version.

> [!NOTE]
>
>The only manual changes are in https://github.com/grpc/grpc/pull/43285/changes/77d640fa5e33d840bb3f7e27c8a5c11db671ec6c
>
>Remaining are auto generated changes from the black formatter.