### PR TITLE
[Backport][v1.83.x] Fix legacy_channel.cc compile error with `std::optional<absl::Functio…

### DIFF
--- a/src/core/lib/surface/legacy_channel.cc
+++ b/src/core/lib/surface/legacy_channel.cc
@@ -180,7 +180,9 @@ grpc_call* LegacyChannel::CreateCall(
   args.authority = std::move(authority);
   args.send_deadline = deadline;
   args.registered_method = registered_method;
-  args.arena_init_function = arena_init_function;
+  if (arena_init_function.has_value()) {
+    args.arena_init_function.emplace(*arena_init_function);
+  }
   grpc_call* call;
   GRPC_LOG_IF_ERROR("call_create", grpc_call_create(&args, &call));
   return call;


### PR DESCRIPTION
…nRef>` by using `emplace()`

Backport of https://github.com/grpc/grpc/pull/42918 Fixes https://github.com/grpc/grpc/issues/43261

