### PR TITLE
[CI] Fix Python 3.15 Sanity

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,7 +119,6 @@ PYTHON_VERSIONS = [
     "3.12",
     "3.13",
     "3.14",
-    "3.15",
 ]
 
 # TODO(weizheyuan): figure out how it interacts with protobuf 31

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -119,7 +119,6 @@ PYTHON_VERSIONS = [
     "3.12",
     "3.13",
     "3.14",
-    "3.15",
 ]
 
 # TODO(weizheyuan): figure out how it interacts with protobuf 31


### PR DESCRIPTION
Temporarily remove Python 3.15 from Bazel config to avoid the Pyyaml build error in `generate_project.sh`:
```text
ERROR: An error occurred during the fetch of repository 'rules_python++pip+grpc_python_dependencies_315_pyyaml_sdist_d7662337':
...
  File "/tmp/pip-build-env-.../site-packages/Cython/Compiler/Errors.py", line 32, in <module>
    from ..Utils import open_new_file
SystemError: module Cython.Utils uses unknown slot ID 84
ERROR: Failed to build 'pyyaml' when getting requirements to build wheel
```