### PR TITLE
[security] Bind DPoP tokens to the TLS session

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -782,6 +782,7 @@ grpc_cc_library(
         "//src/core:gdch_service_account_credentials",
         "//src/core:grpc_authorization_base",
         "//src/core:grpc_channel_idle_filter",
+        "//src/core:grpc_dpop_credentials",
         "//src/core:grpc_external_account_credentials",
         "//src/core:grpc_fake_credentials",
         "//src/core:grpc_google_default_credentials",

--- a/grpc.def
+++ b/grpc.def
@@ -24,6 +24,7 @@ EXPORTS
     grpc_gdch_service_account_credentials_create
     grpc_google_refresh_token_credentials_create
     grpc_access_token_credentials_create
+    grpc_dpop_credentials_create
     grpc_google_iam_credentials_create
     grpc_sts_credentials_create
     grpc_auth_metadata_context_copy

--- a/include/grpc/credentials.h
+++ b/include/grpc/credentials.h
@@ -82,6 +82,18 @@ GRPCAPI grpc_call_credentials* grpc_google_refresh_token_credentials_create(
 GRPCAPI grpc_call_credentials* grpc_access_token_credentials_create(
     const char* access_token, void* reserved);
 
+/** Creates DPoP (RFC 9449) call credentials that bind an access token to an
+   EC P-256 proof-of-possession key and to the current TLS connection's channel
+   binding (tls-unique / tls-exporter). Metadata is only attached on TLS
+   connections that expose channel binding, so a stolen token cannot be
+   replayed on a different TLS session. This API is experimental and may
+   change in the future.
+   - access_token is the raw OAuth2 access token (no scheme prefix).
+   - ec_private_pem is a PEM-encoded EC private key (P-256 / ES256).
+   May return NULL if the input is invalid. */
+GRPCAPI grpc_call_credentials* grpc_dpop_credentials_create(
+    const char* access_token, const char* ec_private_pem, void* reserved);
+
 /** Creates an IAM credentials object for connecting to Google. */
 GRPCAPI grpc_call_credentials* grpc_google_iam_credentials_create(
     const char* authorization_token, const char* authority_selector,

--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -44,6 +44,10 @@ extern "C" {
 // https://www.openssl.org/docs/man1.1.0/man3/SSL_get_peer_cert_chain.html.
 #define GRPC_X509_PEM_CERT_CHAIN_PROPERTY_NAME "x509_pem_cert_chain"
 #define GRPC_SSL_SESSION_REUSED_PROPERTY "ssl_session_reused"
+/** Per-connection TLS channel binding material ("type:base64url"), derived
+    from tls-unique (RFC 5929) or tls-exporter (RFC 9266). Unique to this TLS
+    connection; used to bind call credentials (e.g. DPoP) to the session. */
+#define GRPC_TLS_CHANNEL_BINDING_PROPERTY_NAME "tls_channel_binding"
 #define GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME \
   "ssl_negotiated_key_exchange_group"
 #define GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME "security_level"

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -5190,6 +5190,40 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpc_dpop_credentials",
+    srcs = [
+        "credentials/call/dpop/dpop_credentials.cc",
+    ],
+    hdrs = [
+        "credentials/call/dpop/dpop_credentials.h",
+    ],
+    external_deps = [
+        "absl/log",
+        "absl/status",
+        "absl/status:statusor",
+        "absl/strings",
+        "absl/time",
+        "libcrypto",
+    ],
+    deps = [
+        "arena_promise",
+        "metadata_batch",
+        "slice",
+        "unique_type_name",
+        "useful",
+        "//:gpr",
+        "//:grpc_base",
+        "//:grpc_core_credentials_header",
+        "//:grpc_credentials_util",
+        "//:grpc_public_hdrs",
+        "//:grpc_security_base",
+        "//:promise",
+        "//:ref_counted_ptr",
+        "//:transport_auth_context",
+    ],
+)
+
+grpc_cc_library(
     name = "grpc_oauth2_credentials",
     srcs = [
         "credentials/call/oauth2/oauth2_credentials.cc",

--- a/src/core/credentials/call/dpop/dpop_credentials.cc
+++ b/src/core/credentials/call/dpop/dpop_credentials.cc
@@ -1,0 +1,368 @@
+﻿// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// DPoP call credentials implementation (RFC 9449, EXPERIMENTAL).
+//
+// Per-RPC flow:
+//   1. Require a TLS connection (https security connector; ssl auth context).
+//   2. Require per-connection TLS channel binding from the auth context
+//      (tls-unique / tls-exporter). This binds the proof to this TLS session.
+//   3. Build htu from the TLS url scheme + authority + path.
+//   4. Sign a DPoP proof JWT (ES256) covering htm, htu, ath, jti, iat,
+//      and tls_channel_binding.
+//   5. Attach "authorization: DPoP <token>" and "dpop: <proof>" to metadata.
+//
+// Cryptography: uses BoringSSL / OpenSSL EVP APIs already present in the tree.
+
+#include "src/core/credentials/call/dpop/dpop_credentials.h"
+
+#include <grpc/credentials.h>
+#include <grpc/grpc_security_constants.h>
+#include <grpc/support/port_platform.h>
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <stdlib.h>
+
+#include <array>
+#include <cstring>
+#include <string>
+#include <utility>
+
+#include "src/core/call/metadata_batch.h"
+#include "src/core/credentials/call/call_credentials.h"
+#include "src/core/credentials/transport/security_connector.h"
+#include "src/core/credentials/transport/tls/tls_utils.h"
+#include "src/core/lib/promise/promise.h"
+#include "src/core/lib/slice/slice.h"
+#include "src/core/util/ref_counted_ptr.h"
+#include "src/core/util/unique_type_name.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+
+namespace grpc_core {
+
+namespace {
+
+// Base64url-encode (no padding) a byte span.
+std::string Base64UrlNoPad(absl::string_view in) {
+  std::string out;
+  absl::WebSafeBase64Escape(in, &out);
+  while (!out.empty() && out.back() == '=') out.pop_back();
+  return out;
+}
+
+// SHA-256 of |input|, returned as a base64url string (no padding).
+std::string Sha256Base64Url(absl::string_view input) {
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  SHA256(reinterpret_cast<const unsigned char*>(input.data()), input.size(),
+         digest);
+  return Base64UrlNoPad(absl::string_view(
+      reinterpret_cast<const char*>(digest), SHA256_DIGEST_LENGTH));
+}
+
+std::string JsonString(absl::string_view s) {
+  return absl::StrCat("\"", s, "\"");
+}
+
+std::string BnToBase64Url(const BIGNUM* bn, int len) {
+  std::string buf(len, '\0');
+  BN_bn2binpad(bn, reinterpret_cast<unsigned char*>(&buf[0]), len);
+  return Base64UrlNoPad(buf);
+}
+
+// Build a minimal RFC 7517 JWK object for an EC P-256 public key.
+std::string BuildEcJwk(EVP_PKEY* pkey) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  BIGNUM* x_bn = BN_new();
+  BIGNUM* y_bn = BN_new();
+  if (!EVP_PKEY_get_bn_param(pkey, "qX", &x_bn) ||
+      !EVP_PKEY_get_bn_param(pkey, "qY", &y_bn)) {
+    BN_free(x_bn);
+    BN_free(y_bn);
+    return "";
+  }
+  std::string x = BnToBase64Url(x_bn, 32);
+  std::string y = BnToBase64Url(y_bn, 32);
+  BN_free(x_bn);
+  BN_free(y_bn);
+#else
+  const EC_KEY* ec = EVP_PKEY_get0_EC_KEY(pkey);
+  if (ec == nullptr) return "";
+  const EC_GROUP* group = EC_KEY_get0_group(ec);
+  const EC_POINT* point = EC_KEY_get0_public_key(ec);
+  BIGNUM* x_bn = BN_new();
+  BIGNUM* y_bn = BN_new();
+  if (!EC_POINT_get_affine_coordinates_GFp(group, point, x_bn, y_bn, nullptr)) {
+    BN_free(x_bn);
+    BN_free(y_bn);
+    return "";
+  }
+  std::string x = BnToBase64Url(x_bn, 32);
+  std::string y = BnToBase64Url(y_bn, 32);
+  BN_free(x_bn);
+  BN_free(y_bn);
+#endif
+  return absl::StrCat("{", JsonString("kty"), ":", JsonString("EC"), ",",
+                      JsonString("crv"), ":", JsonString("P-256"), ",",
+                      JsonString("x"), ":", JsonString(x), ",",
+                      JsonString("y"), ":", JsonString(y), "}");
+}
+
+// Sign |to_sign| with |pkey| using ECDSA/SHA-256.
+// Returns IEEE P1363 (r||s) encoded signature as base64url, or empty on error.
+std::string EcdsaSign(EVP_PKEY* pkey, absl::string_view to_sign) {
+  EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+  if (ctx == nullptr) return "";
+
+  if (EVP_DigestSignInit(ctx, nullptr, EVP_sha256(), nullptr, pkey) != 1) {
+    EVP_MD_CTX_free(ctx);
+    return "";
+  }
+  if (EVP_DigestSignUpdate(ctx, to_sign.data(), to_sign.size()) != 1) {
+    EVP_MD_CTX_free(ctx);
+    return "";
+  }
+
+  size_t der_len = 0;
+  if (EVP_DigestSignFinal(ctx, nullptr, &der_len) != 1) {
+    EVP_MD_CTX_free(ctx);
+    return "";
+  }
+  std::string der(der_len, '\0');
+  if (EVP_DigestSignFinal(ctx, reinterpret_cast<unsigned char*>(&der[0]),
+                          &der_len) != 1) {
+    EVP_MD_CTX_free(ctx);
+    return "";
+  }
+  EVP_MD_CTX_free(ctx);
+  der.resize(der_len);
+
+  const unsigned char* p = reinterpret_cast<const unsigned char*>(der.data());
+  ECDSA_SIG* sig = d2i_ECDSA_SIG(nullptr, &p, static_cast<long>(der.size()));
+  if (sig == nullptr) return "";
+
+  const BIGNUM* r;
+  const BIGNUM* s;
+  ECDSA_SIG_get0(sig, &r, &s);
+  std::string rs(64, '\0');
+  BN_bn2binpad(r, reinterpret_cast<unsigned char*>(&rs[0]), 32);
+  BN_bn2binpad(s, reinterpret_cast<unsigned char*>(&rs[32]), 32);
+  ECDSA_SIG_free(sig);
+  return Base64UrlNoPad(rs);
+}
+
+std::string GenJti() {
+  std::array<unsigned char, 16> buf{};
+  if (RAND_bytes(buf.data(), buf.size()) != 1) {
+    // Extremely unlikely; still produce a unique-ish value.
+    int64_t now = absl::ToUnixNanos(absl::Now());
+    memcpy(buf.data(), &now, sizeof(now));
+  }
+  return Base64UrlNoPad(
+      absl::string_view(reinterpret_cast<const char*>(buf.data()), buf.size()));
+}
+
+// True when the call is bound to a TLS connection.
+bool IsTlsBoundConnection(
+    const grpc_call_credentials::GetRequestMetadataArgs* args) {
+  if (args == nullptr || args->security_connector == nullptr) {
+    return false;
+  }
+  if (args->security_connector->url_scheme() != GRPC_SSL_URL_SCHEME) {
+    return false;
+  }
+  if (args->auth_context != nullptr) {
+    absl::string_view security_type = GetAuthPropertyValue(
+        args->auth_context.get(), GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME);
+    if (!security_type.empty() &&
+        security_type != GRPC_SSL_TRANSPORT_SECURITY_TYPE) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Per-connection TLS channel binding ("type:base64url") from auth context.
+std::string GetTlsChannelBinding(
+    const grpc_call_credentials::GetRequestMetadataArgs* args) {
+  if (args == nullptr || args->auth_context == nullptr) return "";
+  absl::string_view value = GetAuthPropertyValue(
+      args->auth_context.get(), GRPC_TLS_CHANNEL_BINDING_PROPERTY_NAME);
+  return std::string(value);
+}
+
+// Build DPoP htu = <tls-scheme>://<authority><path>, stripping :443 for https.
+std::string MakeDpopHtu(
+    const ClientMetadataHandle& initial_metadata,
+    const grpc_call_credentials::GetRequestMetadataArgs* args) {
+  auto* path_md = initial_metadata->get_pointer(HttpPathMetadata());
+  auto* authority_md = initial_metadata->get_pointer(HttpAuthorityMetadata());
+  if (path_md == nullptr || authority_md == nullptr) {
+    return "";
+  }
+  absl::string_view path = path_md->as_string_view();
+  absl::string_view host_and_port = authority_md->as_string_view();
+  absl::string_view url_scheme = args->security_connector->url_scheme();
+  if (url_scheme == GRPC_SSL_URL_SCHEME) {
+    auto port_delimiter = host_and_port.find_last_of(':');
+    if (port_delimiter != absl::string_view::npos &&
+        host_and_port.substr(port_delimiter + 1) == "443") {
+      host_and_port = host_and_port.substr(0, port_delimiter);
+    }
+  }
+  return absl::StrCat(url_scheme, "://", host_and_port, path);
+}
+
+}  // namespace
+
+grpc_dpop_credentials::grpc_dpop_credentials(absl::string_view access_token,
+                                             absl::string_view ec_private_pem)
+    : authorization_value_(Slice::FromCopiedString(
+          absl::StrCat(GRPC_DPOP_AUTHORIZATION_SCHEME, access_token))),
+      ec_private_pem_(ec_private_pem) {}
+
+grpc_dpop_credentials::~grpc_dpop_credentials() = default;
+
+UniqueTypeName grpc_dpop_credentials::Type() {
+  static UniqueTypeName::Factory kFactory("DPoP");
+  return kFactory.Create();
+}
+
+std::string grpc_dpop_credentials::BuildDpopProof(
+    absl::string_view htu, absl::string_view tls_channel_binding) const {
+  BIO* bio = BIO_new_mem_buf(ec_private_pem_.data(),
+                             static_cast<int>(ec_private_pem_.size()));
+  if (bio == nullptr) {
+    LOG(ERROR) << "DPoP: BIO_new_mem_buf failed";
+    return "";
+  }
+  EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+  BIO_free(bio);
+  if (pkey == nullptr) {
+    LOG(ERROR) << "DPoP: failed to parse EC private key PEM";
+    return "";
+  }
+
+  std::string jwk = BuildEcJwk(pkey);
+  if (jwk.empty()) {
+    EVP_PKEY_free(pkey);
+    LOG(ERROR) << "DPoP: failed to build JWK from public key";
+    return "";
+  }
+
+  std::string header_json =
+      absl::StrCat("{", JsonString("typ"), ":", JsonString("dpop+jwt"), ",",
+                   JsonString("alg"), ":", JsonString("ES256"), ",",
+                   JsonString("jwk"), ":", jwk, "}");
+  std::string header_b64 = Base64UrlNoPad(header_json);
+
+  absl::string_view token_with_scheme = authorization_value_.as_string_view();
+  absl::string_view raw_token = token_with_scheme.substr(
+      sizeof(GRPC_DPOP_AUTHORIZATION_SCHEME) - 1);  // strip "DPoP "
+  std::string ath = Sha256Base64Url(raw_token);
+  std::string jti = GenJti();
+  int64_t iat = absl::ToUnixSeconds(absl::Now());
+
+  // tls_channel_binding is unique to this TLS session. Including it in the
+  // signed claims prevents replaying the proof on a different TLS connection.
+  std::string claims_json = absl::StrCat(
+      "{", JsonString("htm"), ":", JsonString("POST"), ",", JsonString("htu"),
+      ":", JsonString(htu), ",", JsonString("ath"), ":", JsonString(ath), ",",
+      JsonString("jti"), ":", JsonString(jti), ",", JsonString("iat"), ":",
+      std::to_string(iat), ",", JsonString("tls_channel_binding"), ":",
+      JsonString(tls_channel_binding), "}");
+  std::string claims_b64 = Base64UrlNoPad(claims_json);
+
+  std::string to_sign = absl::StrCat(header_b64, ".", claims_b64);
+  std::string sig = EcdsaSign(pkey, to_sign);
+  EVP_PKEY_free(pkey);
+
+  if (sig.empty()) {
+    LOG(ERROR) << "DPoP: ECDSA signing failed";
+    return "";
+  }
+
+  return absl::StrCat(to_sign, ".", sig);
+}
+
+ArenaPromise<absl::StatusOr<ClientMetadataHandle>>
+grpc_dpop_credentials::GetRequestMetadata(
+    ClientMetadataHandle initial_metadata, const GetRequestMetadataArgs* args) {
+  // Token binding: DPoP proofs are only emitted on TLS-secured connections.
+  if (!IsTlsBoundConnection(args)) {
+    return Immediate(absl::UnauthenticatedError(
+        "DPoP credentials require a TLS-secured connection"));
+  }
+
+  // Session binding: require per-connection channel binding so the proof
+  // cannot be replayed on another TLS session.
+  std::string tls_channel_binding = GetTlsChannelBinding(args);
+  if (tls_channel_binding.empty()) {
+    return Immediate(absl::UnauthenticatedError(
+        "DPoP credentials require TLS channel binding for this connection"));
+  }
+
+  std::string htu = MakeDpopHtu(initial_metadata, args);
+  if (htu.empty()) {
+    return Immediate(absl::UnauthenticatedError(
+        "DPoP: missing authority or path for htu"));
+  }
+
+  std::string proof = BuildDpopProof(htu, tls_channel_binding);
+  if (proof.empty()) {
+    return Immediate(
+        absl::UnauthenticatedError("DPoP: failed to build proof JWT"));
+  }
+
+  initial_metadata->Append(
+      GRPC_AUTHORIZATION_METADATA_KEY, authorization_value_.Ref(),
+      [](absl::string_view, const Slice&) { abort(); });
+
+  initial_metadata->Append(
+      GRPC_DPOP_PROOF_METADATA_KEY, Slice::FromCopiedString(proof),
+      [](absl::string_view, const Slice&) { abort(); });
+
+  return Immediate(std::move(initial_metadata));
+}
+
+}  // namespace grpc_core
+
+grpc_call_credentials* grpc_dpop_credentials_create(const char* access_token,
+                                                    const char* ec_private_pem,
+                                                    void* reserved) {
+  (void)reserved;
+  if (access_token == nullptr || access_token[0] == '\0') {
+    LOG(ERROR) << "grpc_dpop_credentials_create: access_token must not be empty";
+    return nullptr;
+  }
+  if (ec_private_pem == nullptr || ec_private_pem[0] == '\0') {
+    LOG(ERROR)
+        << "grpc_dpop_credentials_create: ec_private_pem must not be empty";
+    return nullptr;
+  }
+  return grpc_core::MakeRefCounted<grpc_core::grpc_dpop_credentials>(
+             access_token, ec_private_pem)
+      .release();
+}

--- a/src/core/credentials/call/dpop/dpop_credentials.h
+++ b/src/core/credentials/call/dpop/dpop_credentials.h
@@ -1,0 +1,78 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// DPoP (RFC 9449) call credentials. EXPERIMENTAL.
+// Binds the access token to a proof-of-possession key AND to the current TLS
+// connection's channel binding (tls-unique / tls-exporter), so a stolen token
+// (and even a stolen PoP key) cannot be replayed on a different TLS session.
+
+#ifndef GRPC_SRC_CORE_CREDENTIALS_CALL_DPOP_DPOP_CREDENTIALS_H
+#define GRPC_SRC_CORE_CREDENTIALS_CALL_DPOP_DPOP_CREDENTIALS_H
+
+#include <grpc/support/port_platform.h>
+
+#include <string>
+
+#include "src/core/credentials/call/call_credentials.h"
+#include "src/core/lib/promise/arena_promise.h"
+#include "src/core/lib/slice/slice.h"
+#include "src/core/lib/transport/transport.h"
+#include "src/core/util/ref_counted_ptr.h"
+#include "src/core/util/unique_type_name.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+#define GRPC_DPOP_PROOF_METADATA_KEY "dpop"
+#define GRPC_DPOP_AUTHORIZATION_SCHEME "DPoP "
+
+namespace grpc_core {
+
+// DPoP sender-constrained call credentials (RFC 9449, EXPERIMENTAL).
+// access_token   : raw OAuth2 token (no scheme prefix)
+// ec_private_pem : PEM-encoded EC private key (P-256 / ES256)
+class grpc_dpop_credentials final : public grpc_call_credentials {
+ public:
+  grpc_dpop_credentials(absl::string_view access_token,
+                        absl::string_view ec_private_pem);
+  ~grpc_dpop_credentials() override;
+
+  void Orphaned() override {}
+
+  ArenaPromise<absl::StatusOr<ClientMetadataHandle>> GetRequestMetadata(
+      ClientMetadataHandle initial_metadata,
+      const GetRequestMetadataArgs* args) override;
+
+  std::string debug_string() override {
+    return "DpopCredentials{token:present}";
+  }
+
+  static UniqueTypeName Type();
+  UniqueTypeName type() const override { return Type(); }
+
+ private:
+  int cmp_impl(const grpc_call_credentials* other) const override {
+    return QsortCompare(static_cast<const grpc_call_credentials*>(this), other);
+  }
+
+  // Build a DPoP proof JWT covering htu and the TLS channel binding.
+  std::string BuildDpopProof(absl::string_view htu,
+                             absl::string_view tls_channel_binding) const;
+
+  Slice authorization_value_;
+  std::string ec_private_pem_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_CREDENTIALS_CALL_DPOP_DPOP_CREDENTIALS_H

--- a/src/core/credentials/transport/tls/ssl_utils.cc
+++ b/src/core/credentials/transport/tls/ssl_utils.cc
@@ -304,6 +304,10 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       grpc_auth_context_add_property(ctx.get(),
                                      GRPC_SSL_SESSION_REUSED_PROPERTY,
                                      prop->value.data, prop->value.length);
+    } else if (strcmp(prop->name, TSI_TLS_CHANNEL_BINDING_PEER_PROPERTY) == 0) {
+      grpc_auth_context_add_property(ctx.get(),
+                                     GRPC_TLS_CHANNEL_BINDING_PROPERTY_NAME,
+                                     prop->value.data, prop->value.length);
     } else if (strcmp(prop->name, TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP) == 0) {
       grpc_auth_context_add_property(
           ctx.get(), GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME,
@@ -397,6 +401,10 @@ tsi_peer grpc_shallow_peer_from_ssl_auth_context(
                  0) {
         add_shallow_auth_property_to_peer(&peer, prop,
                                           TSI_X509_PEM_CERT_CHAIN_PROPERTY);
+      } else if (strcmp(prop->name, GRPC_TLS_CHANNEL_BINDING_PROPERTY_NAME) ==
+                 0) {
+        add_shallow_auth_property_to_peer(
+            &peer, prop, TSI_TLS_CHANNEL_BINDING_PEER_PROPERTY);
       } else if (strcmp(prop->name, GRPC_PEER_DNS_PROPERTY_NAME) == 0) {
         add_shallow_auth_property_to_peer(&peer, prop,
                                           TSI_X509_DNS_PEER_PROPERTY);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -88,6 +88,7 @@
 #include "absl/functional/bind_front.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -2251,6 +2252,56 @@ tsi_result tsi_ssl_get_cert_chain_contents(STACK_OF(X509) * peer_chain,
   return result;
 }
 
+// Build a per-connection TLS channel binding string:
+//   "<type>:<base64url(binding-bytes)>"
+// Prefer RFC 9266 tls-exporter on TLS 1.3; prefer RFC 5929 tls-unique on
+// TLS 1.2 when available (unique per connection even across resumption with
+// EMS). Falls back to tls-exporter. Returns empty string on failure.
+static std::string ComputeTlsChannelBinding(SSL* ssl) {
+  if (ssl == nullptr) return "";
+
+  uint8_t binding[64];
+  size_t binding_len = 0;
+  const char* binding_type = nullptr;
+
+#if defined(TLS1_3_VERSION)
+  const bool is_tls13 = SSL_version(ssl) == TLS1_3_VERSION;
+#else
+  const bool is_tls13 = false;
+#endif
+
+  if (!is_tls13) {
+#if defined(OPENSSL_IS_BORINGSSL)
+    // tls-unique is unique per TLS connection (RFC 5929).
+    if (SSL_get_tls_unique(ssl, binding, &binding_len, sizeof(binding)) == 1 &&
+        binding_len > 0) {
+      binding_type = "tls-unique";
+    }
+#endif
+  }
+
+  if (binding_type == nullptr) {
+    // RFC 9266: label "EXPORTER-Channel-Binding", empty context, 32 bytes.
+    static constexpr char kExporterLabel[] = "EXPORTER-Channel-Binding";
+    static constexpr size_t kExporterLen = 32;
+    if (SSL_export_keying_material(
+            ssl, binding, kExporterLen, kExporterLabel,
+            sizeof(kExporterLabel) - 1, nullptr, 0,
+            /*use_context=*/1) != 1) {
+      return "";
+    }
+    binding_len = kExporterLen;
+    binding_type = "tls-exporter";
+  }
+
+  std::string b64;
+  absl::WebSafeBase64Escape(
+      absl::string_view(reinterpret_cast<const char*>(binding), binding_len),
+      &b64);
+  while (!b64.empty() && b64.back() == '=') b64.pop_back();
+  return absl::StrCat(binding_type, ":", b64);
+}
+
 // --- tsi_handshaker_result methods implementation. ---
 static tsi_result ssl_handshaker_result_extract_peer(
     const tsi_handshaker_result* self, tsi_peer* peer) {
@@ -2280,8 +2331,10 @@ static tsi_result ssl_handshaker_result_extract_peer(
 
   X509* verified_root_cert = static_cast<X509*>(
       SSL_get_ex_data(impl->ssl, g_ssl_ex_verified_root_cert_index));
-  // 1 is for session reused property.
+  std::string channel_binding = ComputeTlsChannelBinding(impl->ssl);
+  // security_level + session_reused + optional channel_binding.
   size_t new_property_count = peer->property_count + 3;
+  if (!channel_binding.empty()) new_property_count++;
   if (alpn_selected != nullptr) new_property_count++;
   if (peer_chain != nullptr) new_property_count++;
   if (verified_root_cert != nullptr) new_property_count++;
@@ -2326,6 +2379,14 @@ static tsi_result ssl_handshaker_result_extract_peer(
       &peer->properties[peer->property_count]);
   if (result != TSI_OK) return result;
   peer->property_count++;
+
+  if (!channel_binding.empty()) {
+    result = tsi_construct_string_peer_property(
+        TSI_TLS_CHANNEL_BINDING_PEER_PROPERTY, channel_binding.data(),
+        channel_binding.size(), &peer->properties[peer->property_count]);
+    if (result != TSI_OK) return result;
+    peer->property_count++;
+  }
 
   if (verified_root_cert != nullptr) {
     result = peer_property_from_x509_subject(

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -49,6 +49,10 @@
 #define TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY \
   "x509_subject_alternative_name"
 #define TSI_SSL_SESSION_REUSED_PEER_PROPERTY "ssl_session_reused"
+// Per-connection TLS channel binding (RFC 5929 tls-unique or RFC 9266
+// tls-exporter). Value is "type:base64url(binding)" and is unique to this
+// TLS connection so tokens can be bound to the session.
+#define TSI_TLS_CHANNEL_BINDING_PEER_PROPERTY "tls_channel_binding"
 #define TSI_X509_PEM_CERT_PROPERTY "x509_pem_cert"
 #define TSI_X509_PEM_CERT_CHAIN_PROPERTY "x509_pem_cert_chain"
 #define TSI_SSL_ALPN_SELECTED_PROTOCOL "ssl_alpn_selected_protocol"

--- a/test/core/credentials/call/BUILD
+++ b/test/core/credentials/call/BUILD
@@ -149,6 +149,33 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "dpop_credentials_test",
+    srcs = ["dpop_credentials_test.cc"],
+    external_deps = [
+        "absl/status",
+        "absl/status:statusor",
+        "absl/strings",
+        "gtest",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc_core_credentials_header",
+        "//:grpc_security_base",
+        "//:promise",
+        "//:ref_counted_ptr",
+        "//:transport_auth_context",
+        "//src/core:exec_ctx_wakeup_scheduler",
+        "//src/core:grpc_dpop_credentials",
+        "//src/core:map",
+        "//src/core:metadata_batch",
+        "//src/core:notification",
+        "//test/core/test_util:grpc_test_util",
+        "//test/core/test_util:grpc_test_util_base",
+    ],
+)
+
+grpc_cc_test(
     name = "gdch_service_account_credentials_test",
     srcs = ["gdch_service_account_credentials_test.cc"],
     external_deps = [

--- a/test/core/credentials/call/dpop_credentials_test.cc
+++ b/test/core/credentials/call/dpop_credentials_test.cc
@@ -1,0 +1,333 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/credentials/call/dpop/dpop_credentials.h"
+
+#include <grpc/credentials.h>
+#include <grpc/grpc.h>
+#include <grpc/grpc_security_constants.h>
+#include <stdlib.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "src/core/call/metadata_batch.h"
+#include "src/core/credentials/transport/security_connector.h"
+#include "src/core/credentials/transport/transport_credentials.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/promise/exec_ctx_wakeup_scheduler.h"
+#include "src/core/lib/promise/map.h"
+#include "src/core/lib/promise/promise.h"
+#include "src/core/lib/resource_quota/arena.h"
+#include "src/core/transport/auth_context.h"
+#include "src/core/util/notification.h"
+#include "src/core/util/ref_counted_ptr.h"
+#include "test/core/test_util/test_config.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+
+namespace grpc_core {
+namespace {
+
+using ::testing::HasSubstr;
+
+// P-256 key generated for tests only.
+constexpr char kTestEcPrivatePem[] =
+    "-----BEGIN EC PRIVATE KEY-----\n"
+    "MHcCAQEEIPMEEXa2VO4i23yTei/hh39yx6JuNy8a3bmJlQgQTXVwoAoGCCqGSM49\n"
+    "AwEHoUQDQgAE54m/R+zIUc5kUwBzPyoe07jqN3DCOlwML7Lg3wYKR58N5uC6hrIe\n"
+    "fFvM3DicHFiuT1yg1XCaj4CHv+jxMNUlMA==\n"
+    "-----END EC PRIVATE KEY-----\n";
+
+constexpr char kTestAccessToken[] = "test-access-token";
+constexpr char kTestAuthority[] = "foo.test.google.fr:443";
+constexpr char kTestPath[] = "/foo/bar";
+constexpr char kTestChannelBindingA[] =
+    "tls-exporter:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+constexpr char kTestChannelBindingB[] =
+    "tls-exporter:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+class BogusSecurityConnector : public grpc_channel_security_connector {
+ public:
+  explicit BogusSecurityConnector(absl::string_view url_scheme)
+      : grpc_channel_security_connector(url_scheme, nullptr, nullptr) {}
+
+  void check_peer(tsi_peer, grpc_endpoint*, const ChannelArgs&,
+                  RefCountedPtr<grpc_auth_context>*, grpc_closure*) override {
+    abort();
+  }
+
+  void cancel_check_peer(grpc_closure*, grpc_error_handle) override { abort(); }
+
+  int cmp(const grpc_security_connector*) const override {
+    abort();
+    return 0;
+  }
+
+  ArenaPromise<absl::Status> CheckCallHost(absl::string_view,
+                                           grpc_auth_context*) override {
+    return Immediate(absl::PermissionDeniedError("unreachable"));
+  }
+
+  void add_handshakers(const ChannelArgs&, grpc_pollset_set*,
+                       HandshakeManager*) override {
+    abort();
+  }
+};
+
+bool Base64UrlUnescape(absl::string_view in, std::string* out) {
+  std::string padded(in);
+  while (padded.size() % 4 != 0) padded.push_back('=');
+  return absl::WebSafeBase64Unescape(padded, out);
+}
+
+RefCountedPtr<grpc_auth_context> MakeSslAuthContext(
+    absl::string_view channel_binding = kTestChannelBindingA) {
+  auto auth_context = MakeRefCounted<grpc_auth_context>(nullptr);
+  auth_context->add_cstring_property(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
+                                     GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  if (!channel_binding.empty()) {
+    auth_context->add_property(GRPC_TLS_CHANNEL_BINDING_PROPERTY_NAME,
+                               channel_binding.data(), channel_binding.size());
+  }
+  return auth_context;
+}
+
+struct DpopMetadata {
+  std::string authorization;
+  std::string dpop;
+};
+
+absl::StatusOr<DpopMetadata> GetDpopMetadata(
+    grpc_call_credentials* creds, absl::string_view url_scheme,
+    absl::string_view authority, absl::string_view path,
+    RefCountedPtr<grpc_auth_context> auth_context = nullptr) {
+  ExecCtx exec_ctx;
+  auto arena = SimpleArenaAllocator()->MakeArena();
+  grpc_metadata_batch md;
+  md.Set(HttpAuthorityMetadata(), Slice::FromCopiedString(authority));
+  md.Set(HttpPathMetadata(), Slice::FromCopiedString(path));
+
+  grpc_call_credentials::GetRequestMetadataArgs args;
+  args.security_connector = MakeRefCounted<BogusSecurityConnector>(url_scheme);
+  args.auth_context = std::move(auth_context);
+
+  grpc_polling_entity pollent =
+      grpc_polling_entity_create_from_pollset_set(grpc_pollset_set_create());
+  Notification done;
+  absl::Status status;
+  auto activity = MakeActivity(
+      [creds, &md, &args] {
+        return Map(
+            creds->GetRequestMetadata(
+                ClientMetadataHandle(&md, Arena::PooledDeleter(nullptr)),
+                &args),
+            [](absl::StatusOr<ClientMetadataHandle> metadata) {
+              return metadata.status();
+            });
+      },
+      ExecCtxWakeupScheduler(),
+      [&](absl::Status s) {
+        status = std::move(s);
+        done.Notify();
+      },
+      arena.get(), &pollent);
+  done.WaitForNotification();
+  activity.reset();
+  grpc_pollset_set_destroy(grpc_polling_entity_pollset_set(&pollent));
+  if (!status.ok()) return status;
+
+  DpopMetadata out;
+  md.Remove(HttpAuthorityMetadata());
+  md.Remove(HttpPathMetadata());
+  md.Log([&out](absl::string_view key, absl::string_view value) {
+    if (key == GRPC_AUTHORIZATION_METADATA_KEY) {
+      out.authorization = std::string(value);
+    } else if (key == GRPC_DPOP_PROOF_METADATA_KEY) {
+      out.dpop = std::string(value);
+    }
+  });
+  return out;
+}
+
+TEST(DpopCredentialsTest, CreateRejectsEmptyInputs) {
+  EXPECT_EQ(nullptr,
+            grpc_dpop_credentials_create("", kTestEcPrivatePem, nullptr));
+  EXPECT_EQ(nullptr,
+            grpc_dpop_credentials_create(kTestAccessToken, "", nullptr));
+  EXPECT_EQ(nullptr, grpc_dpop_credentials_create(nullptr, kTestEcPrivatePem,
+                                                  nullptr));
+  EXPECT_EQ(nullptr, grpc_dpop_credentials_create(kTestAccessToken, nullptr,
+                                                  nullptr));
+}
+
+TEST(DpopCredentialsTest, CreateSucceeds) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+  EXPECT_EQ(creds->type(), grpc_dpop_credentials::Type());
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->debug_string(), "DpopCredentials{token:present}");
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, RequiresTlsConnection) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  auto result = GetDpopMetadata(creds, "http", kTestAuthority, kTestPath);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnauthenticated);
+  EXPECT_THAT(result.status().message(), HasSubstr("TLS-secured connection"));
+
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, RejectsNonSslAuthContext) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  auto auth_context = MakeRefCounted<grpc_auth_context>(nullptr);
+  auth_context->add_cstring_property(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
+                                     "insecure");
+
+  auto result = GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority,
+                                kTestPath, std::move(auth_context));
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnauthenticated);
+  EXPECT_THAT(result.status().message(), HasSubstr("TLS-secured connection"));
+
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, RequiresTlsChannelBinding) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  // SSL auth context without channel binding must fail closed.
+  auto result = GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority,
+                                kTestPath, MakeSslAuthContext(""));
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnauthenticated);
+  EXPECT_THAT(result.status().message(), HasSubstr("channel binding"));
+
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, AttachesDpopProofBoundToTlsSession) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  auto result =
+      GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority, kTestPath,
+                      MakeSslAuthContext(kTestChannelBindingA));
+  ASSERT_TRUE(result.ok()) << result.status();
+
+  EXPECT_EQ(result->authorization, absl::StrCat("DPoP ", kTestAccessToken));
+  ASSERT_FALSE(result->dpop.empty());
+
+  std::vector<absl::string_view> parts = absl::StrSplit(result->dpop, '.');
+  ASSERT_EQ(parts.size(), 3u);
+
+  std::string header_json;
+  ASSERT_TRUE(Base64UrlUnescape(parts[0], &header_json));
+  EXPECT_THAT(header_json, HasSubstr("\"typ\":\"dpop+jwt\""));
+  EXPECT_THAT(header_json, HasSubstr("\"alg\":\"ES256\""));
+  EXPECT_THAT(header_json, HasSubstr("\"kty\":\"EC\""));
+
+  std::string claims_json;
+  ASSERT_TRUE(Base64UrlUnescape(parts[1], &claims_json));
+  EXPECT_THAT(claims_json, HasSubstr("\"htm\":\"POST\""));
+  EXPECT_THAT(claims_json,
+              HasSubstr("\"htu\":\"https://foo.test.google.fr/foo/bar\""));
+  EXPECT_THAT(claims_json, HasSubstr("\"ath\":"));
+  EXPECT_THAT(claims_json, HasSubstr("\"jti\":"));
+  EXPECT_THAT(claims_json, HasSubstr("\"iat\":"));
+  EXPECT_THAT(claims_json,
+              HasSubstr(absl::StrCat("\"tls_channel_binding\":\"",
+                                     kTestChannelBindingA, "\"")));
+
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, DifferentTlsSessionsProduceDifferentProofs) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken, kTestEcPrivatePem, nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  auto result_a =
+      GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority, kTestPath,
+                      MakeSslAuthContext(kTestChannelBindingA));
+  auto result_b =
+      GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority, kTestPath,
+                      MakeSslAuthContext(kTestChannelBindingB));
+  ASSERT_TRUE(result_a.ok()) << result_a.status();
+  ASSERT_TRUE(result_b.ok()) << result_b.status();
+  EXPECT_NE(result_a->dpop, result_b->dpop);
+
+  std::string claims_a;
+  std::string claims_b;
+  std::vector<absl::string_view> parts_a = absl::StrSplit(result_a->dpop, '.');
+  std::vector<absl::string_view> parts_b = absl::StrSplit(result_b->dpop, '.');
+  ASSERT_EQ(parts_a.size(), 3u);
+  ASSERT_EQ(parts_b.size(), 3u);
+  ASSERT_TRUE(Base64UrlUnescape(parts_a[1], &claims_a));
+  ASSERT_TRUE(Base64UrlUnescape(parts_b[1], &claims_b));
+  EXPECT_THAT(claims_a, HasSubstr(kTestChannelBindingA));
+  EXPECT_THAT(claims_b, HasSubstr(kTestChannelBindingB));
+  EXPECT_THAT(claims_a, ::testing::Not(HasSubstr(kTestChannelBindingB)));
+  EXPECT_THAT(claims_b, ::testing::Not(HasSubstr(kTestChannelBindingA)));
+
+  creds->Unref();
+}
+
+TEST(DpopCredentialsTest, InvalidPemFailsProof) {
+  grpc_call_credentials* creds = grpc_dpop_credentials_create(
+      kTestAccessToken,
+      "-----BEGIN EC PRIVATE KEY-----\nnot-a-key\n-----END EC PRIVATE KEY-----\n",
+      nullptr);
+  ASSERT_NE(creds, nullptr);
+
+  auto result =
+      GetDpopMetadata(creds, GRPC_SSL_URL_SCHEME, kTestAuthority, kTestPath,
+                      MakeSslAuthContext(kTestChannelBindingA));
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kUnauthenticated);
+  EXPECT_THAT(result.status().message(), HasSubstr("failed to build proof"));
+
+  creds->Unref();
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
+}


### PR DESCRIPTION
Bearer tokens are easy to replay once they leak. This adds experimental DPoP call credentials that only send metadata over TLS, sign a per-RPC proof with a P-256 key, and include the connection's channel binding (tls-unique / tls-exporter) in the JWT.

That last bit is the important one: even if someone steals the access token and the PoP key, the proof won't match a different TLS session.

TSI now surfaces the channel binding on the auth context after the handshake. Existing credential types are unchanged.