### PR TITLE
[Python] Fix -Werror=unused-result error triggered by Cythonized code

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -28,6 +28,8 @@ cdef extern from *:
     #ifdef _WIN32
         send((SOCKET)fd, "1", 1, 0);
     #else
+        // Discard the return value via a variable to satisfy
+        // __attribute__((warn_unused_result)) under -Werror=unused-result.
         ssize_t rc = write(fd, "1", 1);
         (void)rc;
     #endif

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -28,7 +28,8 @@ cdef extern from *:
     #ifdef _WIN32
         send((SOCKET)fd, "1", 1, 0);
     #else
-        write(fd, "1", 1);
+        ssize_t rc = write(fd, "1", 1);
+        (void)rc;
     #endif
     }
     """


### PR DESCRIPTION
# Description

Fixes #43308

When we pass `-Werror=unused-result`, during building `cygrpc.so`, Cython code errors out with following stack trace - 

```
ERROR: ~/cython/BUILD.bazel:25:12: Compiling src/python/grpcio/grpc/_cython/cygrpc.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target //src/python/grpcio/grpc/_cython:cygrpc.so) /usr/lib/llvm-19/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 ... (remaining 140 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-opt/bin/src/python/grpcio/grpc/_cython/cygrpc.cpp:1297:9: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
 1297 |         write(fd, "1", 1);
      |         ^~~~~ ~~~~~~~~~~
1 error generated.
```

# Testing

## Manual

On linux machine below command fails on main branch but passes on this branch

```
bazel build -c opt \
  --copt="-Werror=unused-result" \
  --cxxopt="-Werror=unused-result" \
  //src/python/grpcio/grpc/_cython:cygrpc.so
```

