### PR TITLE
infra: increase C++ regional TD Kokoro timeout to 45 mins

### DIFF
--- a/tools/internal_ci/linux/psm-regional_td.cfg
+++ b/tools/internal_ci/linux/psm-regional_td.cfg
@@ -16,7 +16,6 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
-# Hard timeout limit for C++ regional test suite run (bumped from 30 to 45 mins)
 timeout_mins: 45
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/psm-regional_td.cfg
+++ b/tools/internal_ci/linux/psm-regional_td.cfg
@@ -16,7 +16,8 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
-timeout_mins: 30
+# Hard timeout limit for C++ regional test suite run (bumped from 30 to 45 mins)
+timeout_mins: 45
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
infra: increase C++ regional TD Kokoro timeout to 45 mins

The C++ regional Traffic Director PSM interop test suite is exceeding
the previous 30-minute timeout limit on Kokoro, causing test jobs to be
prematurely terminated.

Bump timeout_mins from 30 to 45 minutes to ensure the test suite has
sufficient time to complete all test cases and artifact collection.
