### PR TITLE
Investigate max size test failure

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -955,9 +955,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
                             //   responses by setting a google.protobuf.FieldMask in the
                             //   request:
                             //   https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto
-                            XCTAssertEqualObjects(
-                                error.localizedDescription,
-                                @"CLIENT: Received message larger than max (4194305 vs. 4194304)");
+                            XCTAssertTrue([error.localizedDescription
+                                containsString:@"CLIENT: Received message larger than max (4194305 vs. 4194304)"]);
                             [expectation fulfill];
                           }];
     waiterBlock(@[ expectation ], GRPCInteropTestTimeoutDefault);

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -941,24 +941,26 @@ static dispatch_once_t initGlobalInterceptorFactory;
     request.responseSize = kPayloadSize;
 
     __weak RMTTestService *weakService = service;
-    [service unaryCallWithRequest:request
-                          handler:^(RMTSimpleResponse *response, NSError *error) {
-                            if (weakService == nil) {
-                              return;
-                            }
-                            // TODO(jcanizales): Catch the error and rethrow it with an
-                            // actionable message:
-                            // - Use +[GRPCCall setResponseSizeLimit:forHost:] to set a
-                            // higher limit.
-                            // - If you're developing the server, consider using response
-                            // streaming, or let clients filter
-                            //   responses by setting a google.protobuf.FieldMask in the
-                            //   request:
-                            //   https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto
-                            XCTAssertTrue([error.localizedDescription
-                                containsString:@"CLIENT: Received message larger than max (4194305 vs. 4194304)"]);
-                            [expectation fulfill];
-                          }];
+    [service
+        unaryCallWithRequest:request
+                     handler:^(RMTSimpleResponse *response, NSError *error) {
+                       if (weakService == nil) {
+                         return;
+                       }
+                       // TODO(jcanizales): Catch the error and rethrow it with an
+                       // actionable message:
+                       // - Use +[GRPCCall setResponseSizeLimit:forHost:] to set a
+                       // higher limit.
+                       // - If you're developing the server, consider using response
+                       // streaming, or let clients filter
+                       //   responses by setting a google.protobuf.FieldMask in the
+                       //   request:
+                       //   https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto
+                       XCTAssertTrue([error.localizedDescription
+                           containsString:
+                               @"CLIENT: Received message larger than max (4194305 vs. 4194304)"]);
+                       [expectation fulfill];
+                     }];
     waiterBlock(@[ expectation ], GRPCInteropTestTimeoutDefault);
   });
 }


### PR DESCRIPTION
Update the assertion in InteropTests.m to check for substring containment (containsString:) rather than strict equality matching. This aligns with other test suites in gRPC (e.g. C++ core tests.