### PR TITLE
[ObjC] Support named_framework_to_proto_path_mappings_path in gRPC pl…

### DIFF
--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -41,10 +41,9 @@ using ::grpc_objective_c_generator::SystemImport;
 
 namespace {
 
-bool ParseFrameworkMappings(
-    const ::std::string& path,
-    ::std::map<::std::string, ::std::string>* mappings,
-    ::std::string* error) {
+bool ParseFrameworkMappings(const ::std::string& path,
+                            ::std::map<::std::string, ::std::string>* mappings,
+                            ::std::string* error) {
   ::std::ifstream file(path);
   if (!file.is_open()) {
     *error = "Unable to open framework mapping file: " + path;
@@ -212,11 +211,13 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       } else if (param[0] == "named_framework_to_proto_path_mappings_path") {
         if (param.size() != 2) {
           *error = std::string(
-              "Format: named_framework_to_proto_path_mappings_path=path/to/mappings");
+              "Format: "
+              "named_framework_to_proto_path_mappings_path=path/to/mappings");
           return false;
         } else if (param[1].empty()) {
-          *error = std::string(
-              "Path to mappings file cannot be empty for parameter: ") +
+          *error =
+              std::string(
+                  "Path to mappings file cannot be empty for parameter: ") +
               param[0];
           return false;
         }

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -20,6 +20,7 @@
 
 #include <google/protobuf/compiler/objectivec/names.h>
 
+#include <fstream>
 #include <memory>
 
 #include "src/compiler/config.h"
@@ -40,13 +41,78 @@ using ::grpc_objective_c_generator::SystemImport;
 
 namespace {
 
+bool ParseFrameworkMappings(
+    const ::std::string& path,
+    ::std::map<::std::string, ::std::string>* mappings,
+    ::std::string* error) {
+  ::std::ifstream file(path);
+  if (!file.is_open()) {
+    *error = "Unable to open framework mapping file: " + path;
+    return false;
+  }
+  ::std::string line;
+  while (::std::getline(file, line)) {
+    size_t comment_pos = line.find('#');
+    if (comment_pos != ::std::string::npos) {
+      line.erase(comment_pos);
+    }
+    size_t first = line.find_first_not_of(" \t\r\n");
+    if (first == ::std::string::npos) continue;
+    size_t last = line.find_last_not_of(" \t\r\n");
+    line = line.substr(first, last - first + 1);
+    if (line.empty()) continue;
+
+    size_t colon_pos = line.find(':');
+    if (colon_pos == ::std::string::npos) {
+      *error = "Framework/proto mapping line missing colon: '" + line + "'";
+      return false;
+    }
+    ::std::string framework_name = line.substr(0, colon_pos);
+    size_t fw_first = framework_name.find_first_not_of(" \t\r\n");
+    size_t fw_last = framework_name.find_last_not_of(" \t\r\n");
+    if (fw_first == ::std::string::npos) {
+      *error = "Empty framework name in mapping line: '" + line + "'";
+      return false;
+    }
+    framework_name = framework_name.substr(fw_first, fw_last - fw_first + 1);
+
+    ::std::string proto_list = line.substr(colon_pos + 1);
+    ::std::vector<::std::string> protos =
+        grpc_generator::tokenize(proto_list, ",");
+    for (const auto& proto : protos) {
+      size_t p_first = proto.find_first_not_of(" \t\r\n");
+      if (p_first == ::std::string::npos) continue;
+      size_t p_last = proto.find_last_not_of(" \t\r\n");
+      ::std::string proto_file = proto.substr(p_first, p_last - p_first + 1);
+      if (!proto_file.empty()) {
+        (*mappings)[proto_file] = framework_name;
+      }
+    }
+  }
+  return true;
+}
+
+inline ::std::string FrameworkForFile(
+    const grpc::protobuf::FileDescriptor* file,
+    const ::std::map<::std::string, ::std::string>& framework_mappings,
+    const ::std::string& default_framework) {
+  auto it = framework_mappings.find(std::string(file->name()));
+  if (it != framework_mappings.end()) {
+    return it->second;
+  }
+  return default_framework;
+}
+
 inline ::std::string ImportProtoHeaders(
     const grpc::protobuf::FileDescriptor* dep, const char* indent,
-    const ::std::string& framework,
+    const ::std::map<::std::string, ::std::string>& framework_mappings,
+    const ::std::string& default_framework,
     const ::std::string& pb_runtime_import_prefix) {
   ::std::string header = grpc_objective_c_generator::MessageHeaderName(dep);
 
   if (!IsProtobufLibraryBundledProtoFile(dep)) {
+    ::std::string framework =
+        FrameworkForFile(dep, framework_mappings, default_framework);
     if (framework.empty()) {
       return indent + LocalImport(header);
     } else {
@@ -123,6 +189,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     ::std::string framework;
     ::std::string pb_runtime_import_prefix;
     ::std::string grpc_local_import_prefix;
+    ::std::string framework_mappings_path;
+    ::std::map<::std::string, ::std::string> framework_mappings;
     std::vector<::std::string> params_list =
         grpc_generator::tokenize(parameter, ",");
     for (auto param_str = params_list.begin(); param_str != params_list.end();
@@ -141,6 +209,18 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           return false;
         }
         framework = param[1];
+      } else if (param[0] == "named_framework_to_proto_path_mappings_path") {
+        if (param.size() != 2) {
+          *error = std::string(
+              "Format: named_framework_to_proto_path_mappings_path=path/to/mappings");
+          return false;
+        } else if (param[1].empty()) {
+          *error = std::string(
+              "Path to mappings file cannot be empty for parameter: ") +
+              param[0];
+          return false;
+        }
+        framework_mappings_path = param[1];
       } else if (param[0] == "runtime_import_prefix") {
         if (param.size() != 2) {
           *error = grpc::string("Format: runtime_import_prefix=dir/");
@@ -155,6 +235,13 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           return false;
         }
         grpc_local_import_prefix = param[1];
+      }
+    }
+
+    if (!framework_mappings_path.empty()) {
+      if (!ParseFrameworkMappings(framework_mappings_path, &framework_mappings,
+                                  error)) {
+        return false;
       }
     }
 
@@ -192,11 +279,13 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     {
       // Generate .pbrpc.h
 
+      ::std::string file_framework =
+          FrameworkForFile(file, framework_mappings, framework);
       ::std::string imports;
-      if (framework.empty()) {
+      if (file_framework.empty()) {
         imports = LocalImport(file_name + ".pbobjc.h");
       } else {
-        imports = FrameworkImport(file_name + ".pbobjc.h", framework);
+        imports = FrameworkImport(file_name + ".pbobjc.h", file_framework);
       }
 
       ::std::string system_imports;
@@ -241,8 +330,9 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
       ::std::string class_imports;
       for (int i = 0; i < file->dependency_count(); i++) {
-        class_imports += ImportProtoHeaders(
-            file->dependency(i), "  ", framework, pb_runtime_import_prefix);
+        class_imports +=
+            ImportProtoHeaders(file->dependency(i), "  ", framework_mappings,
+                               framework, pb_runtime_import_prefix);
       }
 
       ::std::string ng_protocols;
@@ -280,13 +370,15 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     {
       // Generate .pbrpc.m
 
+      ::std::string file_framework =
+          FrameworkForFile(file, framework_mappings, framework);
       ::std::string imports;
-      if (framework.empty()) {
+      if (file_framework.empty()) {
         imports = LocalImport(file_name + ".pbrpc.h") +
                   LocalImport(file_name + ".pbobjc.h");
       } else {
-        imports = FrameworkImport(file_name + ".pbrpc.h", framework) +
-                  FrameworkImport(file_name + ".pbobjc.h", framework);
+        imports = FrameworkImport(file_name + ".pbrpc.h", file_framework) +
+                  FrameworkImport(file_name + ".pbobjc.h", file_framework);
       }
 
       if (grpc_local_import) {
@@ -310,8 +402,9 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
       ::std::string class_imports;
       for (int i = 0; i < file->dependency_count(); i++) {
-        class_imports += ImportProtoHeaders(file->dependency(i), "", framework,
-                                            pb_runtime_import_prefix);
+        class_imports +=
+            ImportProtoHeaders(file->dependency(i), "", framework_mappings,
+                               framework, pb_runtime_import_prefix);
       }
 
       ::std::string definitions;

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -21,7 +21,10 @@
 #include <google/protobuf/compiler/objectivec/names.h>
 
 #include <fstream>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "src/compiler/config.h"
 #include "src/compiler/objective_c_generator.h"

--- a/src/objective-c/tests/PluginTest/plugin_option_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_option_test.sh
@@ -109,30 +109,30 @@ $PROTOC \
     src/objective-c/tests/RemoteTestClient/*.proto
 
 # Verify mapped framework imports in header
-[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
-    grep '#import <TestFramework/Test\.pbobjc\.h>'`" ] || {
+grep -q '#import <TestFramework/Test\.pbobjc\.h>' \
+    "${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h" || {
     echo >&2 "Test.pbrpc.h missing TestFramework import for Test.pbobjc.h"
     exit 1
 }
-[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
-    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+grep -q '#import <MessagesFramework/Messages\.pbobjc\.h>' \
+    "${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h" || {
     echo >&2 "Test.pbrpc.h missing MessagesFramework import for Messages.pbobjc.h"
     exit 1
 }
 
 # Verify mapped framework imports in source
-[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
-    grep '#import <TestFramework/Test\.pbrpc\.h>'`" ] || {
+grep -q '#import <TestFramework/Test\.pbrpc\.h>' \
+    "${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m" || {
     echo >&2 "Test.pbrpc.m missing TestFramework import for Test.pbrpc.h"
     exit 1
 }
-[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
-    grep '#import <TestFramework/Test\.pbobjc\.h>'`" ] || {
+grep -q '#import <TestFramework/Test\.pbobjc\.h>' \
+    "${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m" || {
     echo >&2 "Test.pbrpc.m missing TestFramework import for Test.pbobjc.h"
     exit 1
 }
-[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
-    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+grep -q '#import <MessagesFramework/Messages\.pbobjc\.h>' \
+    "${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m" || {
     echo >&2 "Test.pbrpc.m missing MessagesFramework import for Messages.pbobjc.h"
     exit 1
 }
@@ -155,13 +155,13 @@ $PROTOC \
     -I ${WELL_KNOWN_PROTOS_PATH} \
     src/objective-c/tests/RemoteTestClient/*.proto
 
-[ "`cat ${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
-    grep '#import <DefaultFramework/Test\.pbobjc\.h>'`" ] || {
+grep -q '#import <DefaultFramework/Test\.pbobjc\.h>' \
+    "${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h" || {
     echo >&2 "Test.pbrpc.h missing DefaultFramework fallback import for Test.pbobjc.h"
     exit 1
 }
-[ "`cat ${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
-    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+grep -q '#import <MessagesFramework/Messages\.pbobjc\.h>' \
+    "${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h" || {
     echo >&2 "Test.pbrpc.h missing MessagesFramework import for Messages.pbobjc.h"
     exit 1
 }

--- a/src/objective-c/tests/PluginTest/plugin_option_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_option_test.sh
@@ -88,6 +88,84 @@ $PROTOC \
     echo >&2 "grpc system files should be imported with full paths."    
 }
 
+# Verify the "named_framework_to_proto_path_mappings_path" option
+MAPPING_FILE=./framework_mappings.txt
+cat <<EOF > ${MAPPING_FILE}
+# Comment line
+TestFramework: src/objective-c/tests/RemoteTestClient/test.proto
+MessagesFramework: src/objective-c/tests/RemoteTestClient/messages.proto
+EOF
+
+PROTO_FRAMEWORK_OUT=./proto_framework_out
+rm -rf ${PROTO_FRAMEWORK_OUT}
+mkdir -p ${PROTO_FRAMEWORK_OUT}
+
+$PROTOC \
+    --plugin=protoc-gen-grpc="$PLUGIN" \
+    --objc_out=${PROTO_FRAMEWORK_OUT} \
+    --grpc_out=named_framework_to_proto_path_mappings_path=${MAPPING_FILE}:${PROTO_FRAMEWORK_OUT} \
+    -I . \
+    -I ${WELL_KNOWN_PROTOS_PATH} \
+    src/objective-c/tests/RemoteTestClient/*.proto
+
+# Verify mapped framework imports in header
+[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
+    grep '#import <TestFramework/Test\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.h missing TestFramework import for Test.pbobjc.h"
+    exit 1
+}
+[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
+    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.h missing MessagesFramework import for Messages.pbobjc.h"
+    exit 1
+}
+
+# Verify mapped framework imports in source
+[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
+    grep '#import <TestFramework/Test\.pbrpc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.m missing TestFramework import for Test.pbrpc.h"
+    exit 1
+}
+[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
+    grep '#import <TestFramework/Test\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.m missing TestFramework import for Test.pbobjc.h"
+    exit 1
+}
+[ "`cat ${PROTO_FRAMEWORK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.m |
+    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.m missing MessagesFramework import for Messages.pbobjc.h"
+    exit 1
+}
+
+# Verify fallback with generate_for_named_framework
+MAPPING_FALLBACK_FILE=./framework_mappings_fallback.txt
+cat <<EOF > ${MAPPING_FALLBACK_FILE}
+MessagesFramework: src/objective-c/tests/RemoteTestClient/messages.proto
+EOF
+
+PROTO_FALLBACK_OUT=./proto_fallback_out
+rm -rf ${PROTO_FALLBACK_OUT}
+mkdir -p ${PROTO_FALLBACK_OUT}
+
+$PROTOC \
+    --plugin=protoc-gen-grpc="$PLUGIN" \
+    --objc_out=${PROTO_FALLBACK_OUT} \
+    --grpc_out=named_framework_to_proto_path_mappings_path=${MAPPING_FALLBACK_FILE},generate_for_named_framework=DefaultFramework:${PROTO_FALLBACK_OUT} \
+    -I . \
+    -I ${WELL_KNOWN_PROTOS_PATH} \
+    src/objective-c/tests/RemoteTestClient/*.proto
+
+[ "`cat ${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
+    grep '#import <DefaultFramework/Test\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.h missing DefaultFramework fallback import for Test.pbobjc.h"
+    exit 1
+}
+[ "`cat ${PROTO_FALLBACK_OUT}/src/objective-c/tests/RemoteTestClient/Test.pbrpc.h |
+    grep '#import <MessagesFramework/Messages\.pbobjc\.h>'`" ] || {
+    echo >&2 "Test.pbrpc.h missing MessagesFramework import for Messages.pbobjc.h"
+    exit 1
+}
+
 # Run one extra command to clear $? before exiting the script to prevent
 # failing even when tests pass.
 echo "Plugin option tests passed."


### PR DESCRIPTION
…ugin (#28669)

- Added support for named_framework_to_proto_path_mappings_path parameter to grpc_objective_c_plugin.
- Implemented ParseFrameworkMappings to parse framework-to-proto mapping files.
- Updated import generation to use mapped frameworks for generated .pbobjc and .pbrpc files.
- Added tests in plugin_option_test.sh verifying mapped framework imports and fallback behavior.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

