### PR TITLE
[Python][Aio] Optimize shutdown_grpc_aio by checking finalization only at zero refcount

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -112,26 +112,7 @@ cpdef shutdown_grpc_aio():
         assert _global_aio_state.refcount > 0
         _global_aio_state.refcount -= 1
 
-        # Do not manually shutdown when python interpreter already being
-        # finalized (cleaning up resources, destroying objects, preparing
-        # for program exit, etc). Context:
-        # 1. Some of the resources we'll try to access may already be
-        #    freed, and the order is not deterministic.
-        #    Examples: #38679, #33342, #36655.
-        # 2. PollerCompletionQueue.shutdown() will try to wait on its poller
-        #    thread to finish gracefully. Since Python 3.14, joining non-daemon
-        #    threads during finalization results in PythonFinalizationError.
-        #    Details in https://github.com/python/cpython/pull/130402.
-        #
-        # Why `sys is None` check:
-        # Python interpreter in some cases unloads top-level symbols (sys,
-        # _LOGGER), earlier than AioChannel.__dealloc__ triggers shutdown.
-        # If sys is unloaded, we assume the interpreter is finalizing, otherwise
-        # we check sys.is_finalizing().
-        if sys is None or sys.is_finalizing():
-            return
-
-        # Only call the shutdown when refcount down to 0.
+                # Only call the shutdown when refcount down to 0.
         # Note that we expose `init_grpc_aio` which, will result in an incorrect
         # positive refcount when called manually.
         # Before the above finalization check was added, init_grpc_aio's
@@ -139,4 +120,22 @@ cpdef shutdown_grpc_aio():
         # a positive refcount when called manually. See #22365, #38679, #33342.
         # TODO(sergiitk): consider deprecating init_grpc_aio from public APIs.
         if not _global_aio_state.refcount:
+            # Do not manually shutdown when python interpreter already being
+            # finalized (cleaning up resources, destroying objects, preparing
+            # for program exit, etc). Context:
+            # 1. Some of the resources we'll try to access may already be
+            #    freed, and the order is not deterministic.
+            #    Examples: #38679, #33342, #36655.
+            # 2. PollerCompletionQueue.shutdown() will try to wait on its poller
+            #    thread to finish gracefully. Since Python 3.14, joining non-daemon
+            #    threads during finalization results in PythonFinalizationError.
+            #    Details in https://github.com/python/cpython/pull/130402.
+            #
+            # Why `sys is None` check:
+            # Python interpreter in some cases unloads top-level symbols (sys,
+            # _LOGGER), earlier than AioChannel.__dealloc__ triggers shutdown.
+            # If sys is unloaded, we assume the interpreter is finalizing, otherwise
+            # we check sys.is_finalizing().
+            if sys is None or sys.is_finalizing():
+                return
             _actual_aio_shutdown()


### PR DESCRIPTION
### Summary
In #40649, a `sys.is_finalizing()` check was added to `shutdown_grpc_aio()` to avoid errors during interpreter shutdown. However, because `shutdown_grpc_aio()` runs on every RPC deallocation (`_AioCall.__dealloc__` and `RPCState.__dealloc__`), calling `sys.is_finalizing()` on every single RPC cleanup introduced unnecessary overhead and mutex hold time on the hot path.

This change moves the `sys.is_finalizing()` check inside the `if not _global_aio_state.refcount:` branch so that it only runs when the subsystem refcount actually reaches 0, completely avoiding the overhead during active RPC processing while preserving interpreter finalization safety.
Performance improvement is on average about 0.3%.
