### PR TITLE
Fix loadtest template typos and refactor python asyncio scenarios

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -151,6 +151,7 @@ declare -A useLanguage=(
   [java]=1
   [node]=1
   [python]=1
+  [python_asyncio]=1
   [ruby]=1
   [rust]=1
   [php8]=1
@@ -207,6 +208,13 @@ fi
 if [[ -v "useLanguage[python]" ]]; then
   configLangArgs8core+=(-l python) # 8-core only.
   runnerLangArgs+=(-l "python:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
+fi
+
+# python_asyncio
+if [[ -v "useLanguage[python_asyncio]" ]]; then
+  configLangArgs8core+=(-l python_asyncio)
+  configLangArgs32core+=(-l python_asyncio)
+  runnerLangArgs+=(-l "python_asyncio:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
 
 # ruby

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1049,13 +1049,6 @@ class PythonLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_protobuf_async_unary_ping_pong",
-            rpc_type="UNARY",
-            client_type="ASYNC_CLIENT",
-            server_type="ASYNC_SERVER",
-        )
-
-        yield _ping_pong_scenario(
             "python_protobuf_sync_unary_ping_pong",
             rpc_type="UNARY",
             client_type="SYNC_CLIENT",
@@ -1181,7 +1174,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_streaming_ping_pong",
+            "python_protobuf_async_streaming_ping_pong",
             rpc_type="STREAMING",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1192,17 +1185,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_unary_ping_pong",
-            rpc_type="UNARY",
-            client_type="ASYNC_CLIENT",
-            server_type="ASYNC_SERVER",
-            client_processes=1,
-            server_processes=1,
-            categories=[SMOKETEST, SCALABLE],
-        )
-
-        yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_unary_ping_pong",
+            "python_protobuf_async_unary_ping_pong",
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1213,7 +1196,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_unary_qps_unconstrained",
+            "python_protobuf_async_unary_qps_unconstrained",
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1222,7 +1205,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_streaming_qps_unconstrained",
+            "python_protobuf_async_streaming_qps_unconstrained",
             rpc_type="STREAMING",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1231,7 +1214,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_to_cpp_protobuf_async_unary_ping_pong_1thread",
+            "python_to_cpp_protobuf_async_unary_ping_pong_1thread",
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
@@ -1267,7 +1250,7 @@ class PythonAsyncIOLanguage(Language):
         )
 
         yield _ping_pong_scenario(
-            "python_asyncio_protobuf_async_unary_ping_pong_1MB",
+            "python_protobuf_async_unary_ping_pong_1MB",
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",

--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -272,7 +272,7 @@ spec:
       - bash
       image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
-      rgs:
+      args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
@@ -363,7 +363,7 @@ spec:
       - bash
       image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
-      rgs:
+      args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
@@ -331,7 +331,7 @@ spec:
       - bash
       image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
-      rgs:
+      args:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \


### PR DESCRIPTION
Fix loadtest template typos and refactor python asyncio scenarios

Testing: Scenario Execution
Executed the Python AsyncIO benchmark scenarios locally via the `run_performance_tests.py` script:

1. Confirm scenario discovery (Dry-run)
```
python3 tools/run_tests/run_performance_tests.py -l python_asyncio --dry_run
```
2. Execute Python AsyncIO scenarios (e.g., Unary Ping-Pong)
```
python3 tools/run_tests/run_performance_tests.py \
  -l python_asyncio \
  -r "^python_protobuf_async_unary_ping_pong$"
```
3. Execute Cross-Language scenario (Python AsyncIO Client / C++ Server)
```
python3 tools/run_tests/run_performance_tests.py \
  -l python_asyncio c++ \
  -r "^python_to_cpp_protobuf_async_unary_ping_pong_1thread$"
```
Result: All the AsyncIO benchmark scenario monitored on the dashboard was built and executed successfully.