### PR TITLE
python: skip grpc module for protos without services

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -941,6 +941,10 @@ bool PythonGrpcGenerator::Generate(const FileDescriptor* file,
                                    const std::string& parameter,
                                    GeneratorContext* context,
                                    std::string* error) const {
+  if (file->service_count() == 0) {
+    return true;
+  }
+
   // Get output file name.
   std::string pb2_file_name;
   std::string pb2_grpc_file_name;

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -724,6 +724,18 @@ class ModuleMainTest(unittest.TestCase):
                 stream.seek(0)
                 self.assertEqual(0, len(stream.read()))
             self.assertEqual(0, proc.returncode)
+            self.assertTrue(
+                os.path.exists(
+                    os.path.join(work_dir, "grpc", "testing", "empty_pb2.py")
+                )
+            )
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(
+                        work_dir, "grpc", "testing", "empty_pb2_grpc.py"
+                    )
+                )
+            )
         finally:
             shutil.rmtree(work_dir)
 


### PR DESCRIPTION
Fixes #32763

## Summary
- skip Python gRPC module generation when a proto file defines no services
- keep generating the regular `_pb2.py` module
- extend the existing clean-output test to verify that `empty_pb2_grpc.py` is not created

## Testing
- `ModuleMainTest.test_clean_output`