### PR TITLE
Fix a compile error when using GRPC_CHECK_NE with std::unique_ptr

### DIFF
--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -561,7 +561,7 @@ class ClientImpl : public Client {
                       std::shared_ptr<Channel>)>& create_stub) {
       if (config.use_session()) {
         session_holder_ = EstablishSession(channel_);
-        GRPC_CHECK_NE(session_holder_, nullptr);
+        GRPC_CHECK_NE(session_holder_.get(), nullptr);
         stub_ = create_stub(session_holder_->virtual_channel());
       } else {
         stub_ = create_stub(channel_);


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

