### PR TITLE
[CI] Disable building boringssl cmake tests due to name collision.

### DIFF
--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -22,6 +22,9 @@ if(gRPC_SSL_PROVIDER STREQUAL "module")
   endif()
 
   if(EXISTS "${BORINGSSL_ROOT_DIR}/CMakeLists.txt")
+    # Disable BoringSSL tests to avoid target collisions with gRPC's benchmark/gtest dependencies.
+    set(BUILD_TESTING OFF CACHE BOOL "Disable BoringSSL tests" FORCE)
+
     if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Ninja")
       if(CMAKE_VERSION VERSION_LESS 3.13)
         # Visual Studio build with assembly optimizations is broken for older


### PR DESCRIPTION
Boringssl builds test targets `benchmark` and `benchmark_main` which collides with existing gRPC test targets (when `gRPC_BUILD_TESTS` is ON

Ad-hoc run:

- [ ] [grpc/core/master/linux/grpc_portability_openssl](https://source.cloud.google.com/results/invocations/2fcd62fe-349e-44e4-a94c-63df54429d01)
