### PR TITLE
[CI] fix grpc_build_boringssl_at_head

### DIFF
--- a/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
@@ -33,5 +33,5 @@ env_vars {
 # Tiny hack: misusing an already allowlisted env var to pass branch name to checkout
 env_vars {
   key: "BAZEL_FLAGS"
-  value: "master-with-bazel"
+  value: "main"
 }


### PR DESCRIPTION
Fix the `grpc/core/master/linux/grpc_build_boringssl_at_head` job by updating the obsolete git branch ref.
- [x] [grpc/core/master/linux/grpc_build_boringssl_at_head](https://source.cloud.google.com/results/invocations/0b3e794f-0b74-431a-b495-c37c82b182c8)