### PR TITLE
Remove `unconstrained_client` from `scenario_config.py`

### DIFF
--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1221,7 +1221,6 @@ class PythonAsyncIOLanguage(Language):
             server_language="c++",
             channels=1,
             client_processes=1,
-            unconstrained_client="async",
             categories=[SMOKETEST, SCALABLE],
         )
 


### PR DESCRIPTION
Remove `unconstrained_client` from `scenario_config.py`

1. Ping-pong is supposed to test 1 request at a time (send 1, wait for reply, measure latency).
2. unconstrained_client="async" sent multiple requests at the same time on a single thread.
3. Because multiple requests queued up, each request had to wait over a second in line, causing the 1.25s latency spike.