### PR TITLE
[Python] Fix grpc_op array leak when an aio batch fails or its awaiter is cancelled

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -38,12 +38,14 @@ cdef struct CallbackContext:
     cpython.PyObject *loop
     cpython.PyObject *failure_handler
     cpython.PyObject *callback_wrapper
+    cpython.PyObject *on_complete
 
 
 cdef class CallbackWrapper:
     cdef CallbackContext context
     cdef object _reference_of_future
     cdef object _reference_of_failure_handler
+    cdef object _reference_of_on_complete
 
     @staticmethod
     cdef void functor_run(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -32,12 +32,14 @@ cdef class CallbackFailureHandler:
 
 cdef class CallbackWrapper:
 
-    def __cinit__(self, object future, object loop, CallbackFailureHandler failure_handler):
+    def __cinit__(self, object future, object loop, CallbackFailureHandler failure_handler, object on_complete=None):
         self.context.functor.functor_run = self.functor_run
         self.context.waiter = <cpython.PyObject*>future
         self.context.loop = <cpython.PyObject*>loop
         self.context.failure_handler = <cpython.PyObject*>failure_handler
         self.context.callback_wrapper = <cpython.PyObject*>self
+        self.context.on_complete = <cpython.PyObject*>on_complete if on_complete is not None else NULL
+        self._reference_of_on_complete = on_complete
         # NOTE(lidiz) Not using a list here, because this class is critical in
         # data path. We should make it as efficient as possible.
         self._reference_of_future = future
@@ -53,6 +55,14 @@ cdef class CallbackWrapper:
             int success) noexcept:
         cdef CallbackContext *context = <CallbackContext *>functor
         cdef object waiter = <object>context.waiter
+        if context.on_complete != NULL:
+            # Runs on the event loop before the waiter's callbacks, so the batch's
+            # C resources are released even if nobody awaits the waiter anymore.
+            try:
+                (<object>context.loop).call_soon_threadsafe(<object>context.on_complete)
+            except RuntimeError:
+                # The loop is already closed; release synchronously rather than leak.
+                (<object>context.on_complete)()
         if not waiter.cancelled():
             if success == 0:
                 (<CallbackFailureHandler>context.failure_handler).handle(waiter)
@@ -74,6 +84,12 @@ class ExecuteBatchError(InternalError):
     """Raised when execute batch returns a failure from Core."""
 
 
+cdef _make_batch_releaser(_BatchOperationTag tag):
+    def release():
+        tag.release()
+    return release
+
+
 async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
                                tuple operations,
                                object loop):
@@ -85,7 +101,8 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
     cdef CallbackWrapper wrapper = CallbackWrapper(
         future,
         loop,
-        CallbackFailureHandler('execute_batch', operations, ExecuteBatchError))
+        CallbackFailureHandler('execute_batch', operations, ExecuteBatchError),
+        _make_batch_releaser(batch_operation_tag))
     cdef grpc_call_error error = grpc_call_start_batch(
         grpc_call_wrapper.call,
         batch_operation_tag.c_ops,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
@@ -45,6 +45,7 @@ cdef class _BatchOperationTag(_Tag):
   cdef size_t c_nops
 
   cdef void prepare(self) except *
+  cdef void release(self) except *
   cdef BatchOperationEvent event(self, grpc_event c_event)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
@@ -64,12 +64,26 @@ cdef class _BatchOperationTag:
         operation.c()
         self.c_ops[index] = operation.c_op
 
-  cdef BatchOperationEvent event(self, grpc_event c_event):
+  cdef void release(self) except *:
+    # Idempotent: parses the received operations and frees the ops array once.
+    # Core consumes the ops array inside grpc_call_start_batch and keeps no
+    # pointer to it, so this only has to wait for the batch to complete, not
+    # for anyone to consume its event.
     cdef Operation operation
-    if 0 < self.c_nops:
+    if self.c_ops != NULL:
       for operation in self._operations:
         operation.un_c()
       gpr_free(self.c_ops)
+      self.c_ops = NULL
+
+  def __dealloc__(self):
+    if self.c_ops != NULL:
+      gpr_free(self.c_ops)
+      self.c_ops = NULL
+
+  cdef BatchOperationEvent event(self, grpc_event c_event):
+    if 0 < self.c_nops:
+      self.release()
       return BatchOperationEvent(
           c_event.type, c_event.success, self._user_tag, self._operations)
     else:

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -31,6 +31,7 @@ _BLOCK_BRIEFLY = "/test/BlockBriefly"
 _UNARY_STREAM_ASYNC_GEN = "/test/UnaryStreamAsyncGen"
 _UNARY_STREAM_READER_WRITER = "/test/UnaryStreamReaderWriter"
 _UNARY_STREAM_EVILLY_MIXED = "/test/UnaryStreamEvillyMixed"
+_UNARY_STREAM_SWALLOWS_CANCELLATION = "/test/UnaryStreamSwallowsCancellation"
 _STREAM_UNARY_ASYNC_GEN = "/test/StreamUnaryAsyncGen"
 _STREAM_UNARY_READER_WRITER = "/test/StreamUnaryReaderWriter"
 _STREAM_UNARY_EVILLY_MIXED = "/test/StreamUnaryEvillyMixed"
@@ -76,6 +77,9 @@ class _GenericHandler(grpc.GenericRpcHandler):
             ),
             _UNARY_STREAM_EVILLY_MIXED: grpc.unary_stream_rpc_method_handler(
                 self._unary_stream_evilly_mixed
+            ),
+            _UNARY_STREAM_SWALLOWS_CANCELLATION: grpc.unary_stream_rpc_method_handler(
+                self._unary_stream_swallows_cancellation
             ),
             _STREAM_UNARY_ASYNC_GEN: grpc.stream_unary_rpc_method_handler(
                 self._stream_unary_async_gen
@@ -126,6 +130,18 @@ class _GenericHandler(grpc.GenericRpcHandler):
     async def _unary_stream_async_gen(self, unused_request, unused_context):
         for _ in range(_NUM_STREAM_RESPONSES):
             yield _RESPONSE
+
+    async def _unary_stream_swallows_cancellation(
+        self, unused_request, unused_context
+    ):
+        # Returns normally after the client cancelled, so the server goes on to
+        # send a final status on a call the peer already abandoned.
+        try:
+            while True:
+                yield _RESPONSE
+                await asyncio.sleep(test_constants.SHORT_TIMEOUT / 10)
+        except asyncio.CancelledError:
+            return
 
     async def _unary_stream_reader_writer(self, unused_request, context):
         for _ in range(_NUM_STREAM_RESPONSES):
@@ -291,6 +307,21 @@ class TestServer(AioTestBase):
 
         self.assertEqual(_NUM_STREAM_RESPONSES, response_cnt)
         self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_cancel_unary_stream_swallowed_by_handler(self):
+        # The final status batch fails because the client is gone; the failed
+        # batch must still be cleaned up and must not affect later RPCs.
+        unary_stream_call = self._channel.unary_stream(
+            _UNARY_STREAM_SWALLOWS_CANCELLATION
+        )
+        for _ in range(_NUM_STREAM_RESPONSES):
+            call = unary_stream_call(_REQUEST)
+            self.assertEqual(_RESPONSE, await call.read())
+            self.assertTrue(call.cancel())
+            self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+        unary_unary_call = self._channel.unary_unary(_SIMPLE_UNARY_UNARY)
+        self.assertEqual(_RESPONSE, await unary_unary_call(_REQUEST))
 
     async def test_unary_stream_reader_writer(self):
         unary_stream_call = self._channel.unary_stream(


### PR DESCRIPTION
Fixes #43360

`execute_batch()` frees a batch's `gpr_malloc`'d `grpc_op` array only when the awaiting coroutine consumes the batch's event (`_BatchOperationTag.event()` after `await future`). If the batch completes with `success == 0`, `await future` raises `ExecuteBatchError` first; if the awaiting task is cancelled while the batch is in flight, the tag is simply dropped. Either way the array (80 bytes per op) leaks, and `_BatchOperationTag` has no `__dealloc__` to catch it.

Both happen routinely in a long-lived service: a server-streaming handler that returns normally after the client cancelled makes the server send a final status on an already-cancelled call (`_handle_exceptions` then silently ignores the `ExecuteBatchError` because `client_closed` is set), and `asyncio.timeout()` or `call.cancel()` around a read cancels the task while a `RECV_MESSAGE` batch is outstanding. One of our processes accumulated 222k leaked arrays in 12 days, about 0.6 per server stream; the scattered 96-byte chunks pinned the heap so glibc could neither trim nor reuse it (954 MiB mapped, 328 MiB resident, 152 MiB live). Details and the reproduction are in the issue.

This PR releases the batch's C-side resources when Core completes the batch, whether or not anyone still awaits it:

- `_BatchOperationTag.release()` is idempotent (`un_c()` each operation, `gpr_free` the array once); `event()` delegates to it, so the sync API is unchanged.
- `CallbackWrapper` takes an optional `on_complete` callable, which `functor_run` schedules on the batch's loop before the waiter's callbacks. `execute_batch` passes the tag's releaser. The wrapper is what Core holds, so the tag now lives exactly as long as the batch, and the release runs on the loop thread in the success path, the failure path, and when the awaiting coroutine is gone.
- `__dealloc__` frees the array as a last resort, without touching the `Operation` objects.

Core consumes the ops array inside `grpc_call_start_batch` and keeps no pointer to it (`FilterStackCall::StartBatch` copies each op into the transport op; `ClientCall::CommitBatch` / `ServerCall::CommitBatch` index it through `BatchOpIndex` and capture only the pointed-to data), so freeing it as soon as the batch completes is safe.

Validation with the reproduction from the issue (4,000 client-cancelled unary-stream calls; leaked arrays counted by walking the process's own glibc heap), 1.83.1 from PyPI against a source build of 1.83.1 with this patch:

| handler on client cancel | before: leaked `SEND_STATUS_FROM_SERVER` / `RECV_MESSAGE` arrays | after |
|---|---|---|
| propagates `CancelledError` | 0 / 3,566 | 0 / 0 |
| catches it and returns | 3,422 / 3,444 | 0 / 0 |

The new `test_cancel_unary_stream_swallowed_by_handler` in `server_test.py` exercises the failed-status-batch path (it cannot observe the leak itself; that needs the heap walk in the issue). Against the patched build, `tests_aio.unit` `server_test`, `call_test`, `abort_test`, `timeout_test`, `done_callback_test`, `close_channel_test`, `server_interceptor_test`, the client interceptor tests, `compression_test`, `channel_test`, `wait_for_ready_test` and `multithread_test` pass.
