### PR TITLE
[event_engine] c-ares: Return early if channel is null rather than asserting

### DIFF
--- a/src/core/lib/event_engine/ares_resolver.cc
+++ b/src/core/lib/event_engine/ares_resolver.cc
@@ -397,9 +397,23 @@ void AresResolver::LookupHostname(
     return;
   }
   grpc_core::MutexLock lock(&mutex_);
+  if (channel_ == nullptr) {
+    // The c-ares channel is torn down and rebuilt across fork(). Reset()
+    // and Restart() take the mutex separately, so a thread entering here
+    // between them (e.g. a respawned executor/timer thread) can observe a
+    // null channel_. Fail the query softly so the caller retries instead of
+    // aborting the process. Checked before callback_map_.emplace()/arg
+    // allocation so we leave no dangling map entry (checked empty in the dtor)
+    // and leak no HostnameQueryArg.
+    event_engine_->Run(
+        [callback = std::move(callback),
+         status = absl::UnavailableError(
+             "c-ares channel unavailable; resolver reinitializing after "
+             "fork")]() mutable { callback(status); });
+    return;
+  }
   callback_map_.emplace(++id_, std::move(callback));
   auto* resolver_arg = new HostnameQueryArg(this, id_, name, port);
-  GRPC_CHECK_NE(channel_, nullptr);
   if (AresIsIpv6LoopbackAvailable()) {
     // Note that using AF_UNSPEC for both IPv6 and IPv4 queries does not work in
     // all cases, e.g. for localhost:<> it only gets back the IPv6 result (i.e.
@@ -445,9 +459,18 @@ void AresResolver::LookupSRV(
     return;
   }
   grpc_core::MutexLock lock(&mutex_);
+  if (channel_ == nullptr) {
+    // See LookupHostname: channel_ can be null while the resolver is
+    // reinitializing after fork(). Fail softly rather than aborting.
+    event_engine_->Run(
+        [callback = std::move(callback),
+         status = absl::UnavailableError(
+             "c-ares channel unavailable; resolver reinitializing after "
+             "fork")]() mutable { callback(status); });
+    return;
+  }
   callback_map_.emplace(++id_, std::move(callback));
   auto* resolver_arg = new QueryArg(this, id_, host);
-  GRPC_CHECK_NE(channel_, nullptr);
   ares_query(channel_, std::string(host).c_str(), ns_c_in, ns_t_srv,
              &AresResolver::OnSRVQueryDoneLocked, resolver_arg);
   CheckSocketsLocked();
@@ -481,9 +504,18 @@ void AresResolver::LookupTXT(
     return;
   }
   grpc_core::MutexLock lock(&mutex_);
+  if (channel_ == nullptr) {
+    // See LookupHostname: channel_ can be null while the resolver is
+    // reinitializing after fork(). Fail softly rather than aborting.
+    event_engine_->Run(
+        [callback = std::move(callback),
+         status = absl::UnavailableError(
+             "c-ares channel unavailable; resolver reinitializing after "
+             "fork")]() mutable { callback(status); });
+    return;
+  }
   callback_map_.emplace(++id_, std::move(callback));
   auto* resolver_arg = new QueryArg(this, id_, host);
-  GRPC_CHECK_NE(channel_, nullptr);
   ares_search(channel_, std::string(host).c_str(), ns_c_in, ns_t_txt,
               &AresResolver::OnTXTDoneLocked, resolver_arg);
   CheckSocketsLocked();

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -524,6 +524,7 @@ grpc_cc_test(
         "//:gpr_platform",
         "//:grpc",
         "//src/core:event_engine_tcp_socket_utils",
+        "//src/core:ares_resolver",
         "//src/core:notification",
         "//src/core:posix_event_engine",
         "//test/core/test_util:grpc_test_util",

--- a/test/core/event_engine/posix/dns_fork_test.cc
+++ b/test/core/event_engine/posix/dns_fork_test.cc
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "src/core/lib/event_engine/ares_resolver.h"
+#include "src/core/lib/event_engine/posix_engine/grpc_polled_fd_posix.h"
 #include "src/core/lib/event_engine/posix_engine/posix_engine.h"
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
 #include "src/core/util/notification.h"
@@ -180,6 +182,76 @@ TEST(DnsForkTest, DnsLookupAcrossForkInChild) {
   for (auto& callback : callbacks) {
     EXPECT_EQ(callback.times_got_called(), 1);
   }
+}
+
+// A lookup that arrives while the c-ares channel is null -- the window between
+// ReinitHandle::Reset() (which calls ares_destroy and nulls channel_) and
+// Restart() (which rebuilds it) during fork -- must complete the callback with
+// an error rather than aborting. A respawned executor/timer thread can enter a
+// lookup in that window because PostForkInChild restarts the executor and timer
+// manager before the resolver is rebuilt. Regression test for the
+// GRPC_CHECK_NE(channel_, nullptr) that used to fire here.
+TEST(DnsForkTest, LookupFailsSoftlyWhenChannelIsNull) {
+  auto ee = GetDefaultEventEngine();
+  // Build an AresResolver directly. The polled-fd factory's poller is unused:
+  // the null-channel guard returns before any fd is created, and Restart()
+  // below only re-initializes the c-ares channel (no fd activity happens
+  // without a successful lookup).
+  auto ares_resolver = AresResolver::CreateAresResolver(
+      /*dns_server=*/"", std::make_unique<GrpcPolledFdFactoryPosix>(nullptr),
+      ee);
+  ASSERT_TRUE(ares_resolver.ok()) << ares_resolver.status();
+  auto handle = (*ares_resolver)->GetReinitHandle().lock();
+  ASSERT_NE(handle, nullptr);
+  // Tear the channel down without rebuilding it: the exact state a thread can
+  // observe mid-fork.
+  handle->Reset(absl::CancelledError("test: null channel window"));
+
+  {
+    grpc_core::Notification done;
+    absl::Status status;
+    (*ares_resolver)
+        ->LookupHostname(
+            [&](const absl::StatusOr<std::vector<EventEngine::ResolvedAddress>>&
+                    r) {
+              status = r.status();
+              done.Notify();
+            },
+            "foo.test.google.fr:443", "443");
+    done.WaitForNotification();
+    EXPECT_TRUE(absl::IsUnavailable(status)) << status;
+  }
+  {
+    grpc_core::Notification done;
+    absl::Status status;
+    (*ares_resolver)
+        ->LookupSRV(
+            [&](const absl::StatusOr<
+                std::vector<EventEngine::DNSResolver::SRVRecord>>& r) {
+              status = r.status();
+              done.Notify();
+            },
+            "foo.test.google.fr:443");
+    done.WaitForNotification();
+    EXPECT_TRUE(absl::IsUnavailable(status)) << status;
+  }
+  {
+    grpc_core::Notification done;
+    absl::Status status;
+    (*ares_resolver)
+        ->LookupTXT(
+            [&](const absl::StatusOr<std::vector<std::string>>& r) {
+              status = r.status();
+              done.Notify();
+            },
+            "foo.test.google.fr:443");
+    done.WaitForNotification();
+    EXPECT_TRUE(absl::IsUnavailable(status)) << status;
+  }
+
+  // Rebuild the channel so the resolver can be destroyed cleanly (the dtor
+  // checks channel_ != nullptr and calls ares_destroy).
+  handle->Restart();
 }
 
 #else  // GRPC_ENABLE_FORK_SUPPORT


### PR DESCRIPTION
This resolves another crash found in stress testing our forking application.

relates to https://github.com/grpc/grpc/pull/41975
