### PR TITLE
[core] Validate externally-derived integers before casting to C enum types (UB)

### DIFF
--- a/src/core/ext/transport/chaotic_good/frame.cc
+++ b/src/core/ext/transport/chaotic_good/frame.cc
@@ -223,8 +223,14 @@ absl::StatusOr<ServerMetadataHandle> ServerMetadataGrpcFromProto(
   auto md = Arena::MakePooled<ServerMetadata>();
   md->Set(GrpcStatusFromWire(), true);
   if (metadata.has_status()) {
+    // The wire value is an untrusted uint32_t; values outside the
+    // grpc_status_code range map to GRPC_STATUS_UNKNOWN (mirroring
+    // GrpcStatusMetadata::ParseMemento) rather than being cast directly,
+    // which would be undefined behavior.
     md->Set(GrpcStatusMetadata(),
-            static_cast<grpc_status_code>(metadata.status()));
+            metadata.status() >= GRPC_STATUS__DO_NOT_USE
+                ? GRPC_STATUS_UNKNOWN
+                : static_cast<grpc_status_code>(metadata.status()));
   }
   if (metadata.has_message()) {
     md->Set(GrpcMessageMetadata(), Slice::FromCopiedString(metadata.message()));

--- a/src/core/ext/transport/chaotic_good_legacy/frame.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/frame.cc
@@ -218,8 +218,14 @@ absl::StatusOr<ServerMetadataHandle> ServerMetadataGrpcFromProto(
   auto md = Arena::MakePooled<ServerMetadata>();
   md->Set(GrpcStatusFromWire(), true);
   if (metadata.has_status()) {
+    // The wire value is an untrusted uint32_t; values outside the
+    // grpc_status_code range map to GRPC_STATUS_UNKNOWN (mirroring
+    // GrpcStatusMetadata::ParseMemento) rather than being cast directly,
+    // which would be undefined behavior.
     md->Set(GrpcStatusMetadata(),
-            static_cast<grpc_status_code>(metadata.status()));
+            metadata.status() >= GRPC_STATUS__DO_NOT_USE
+                ? GRPC_STATUS_UNKNOWN
+                : static_cast<grpc_status_code>(metadata.status()));
   }
   if (metadata.has_message()) {
     md->Set(GrpcMessageMetadata(), Slice::FromCopiedString(metadata.message()));

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -91,6 +91,14 @@ class CommaSeparatedLists {
 };
 
 const CommaSeparatedLists kCommaSeparatedLists;
+
+std::optional<grpc_compression_algorithm> CompressionAlgorithmFromInt(
+    int64_t algorithm) {
+  if (algorithm < 0 || algorithm >= GRPC_COMPRESS_ALGORITHMS_COUNT) {
+    return std::nullopt;
+  }
+  return static_cast<grpc_compression_algorithm>(algorithm);
+}
 }  // namespace
 
 std::optional<grpc_compression_algorithm> ParseCompressionAlgorithm(
@@ -104,14 +112,6 @@ std::optional<grpc_compression_algorithm> ParseCompressionAlgorithm(
   } else {
     return std::nullopt;
   }
-}
-
-std::optional<grpc_compression_algorithm> CompressionAlgorithmFromInt(
-    int64_t algorithm) {
-  if (algorithm < 0 || algorithm >= GRPC_COMPRESS_ALGORITHMS_COUNT) {
-    return std::nullopt;
-  }
-  return static_cast<grpc_compression_algorithm>(algorithm);
 }
 
 grpc_compression_algorithm

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -106,6 +106,14 @@ std::optional<grpc_compression_algorithm> ParseCompressionAlgorithm(
   }
 }
 
+std::optional<grpc_compression_algorithm> CompressionAlgorithmFromInt(
+    int64_t algorithm) {
+  if (algorithm < 0 || algorithm >= GRPC_COMPRESS_ALGORITHMS_COUNT) {
+    return std::nullopt;
+  }
+  return static_cast<grpc_compression_algorithm>(algorithm);
+}
+
 grpc_compression_algorithm
 CompressionAlgorithmSet::CompressionAlgorithmForLevel(
     grpc_compression_level level) const {
@@ -228,7 +236,7 @@ DefaultCompressionAlgorithmFromChannelArgs(const ChannelArgs& args) {
   if (value == nullptr) return std::nullopt;
   auto ival = value->GetIfInt();
   if (ival.has_value()) {
-    return static_cast<grpc_compression_algorithm>(*ival);
+    return CompressionAlgorithmFromInt(*ival);
   }
   auto sval = value->GetIfString();
   if (sval != nullptr) {

--- a/src/core/lib/compression/compression_internal.h
+++ b/src/core/lib/compression/compression_internal.h
@@ -37,6 +37,11 @@ namespace grpc_core {
 // or nullopt on error.
 std::optional<grpc_compression_algorithm> ParseCompressionAlgorithm(
     absl::string_view algorithm);
+// Given an integer value (e.g. from a channel arg), return the corresponding
+// compression algorithm, or nullopt if the value does not name a known
+// algorithm. Never produces an out-of-range enum value.
+std::optional<grpc_compression_algorithm> CompressionAlgorithmFromInt(
+    int64_t algorithm);
 // Convert a compression algorithm to a string. Returns nullptr if a name is not
 // known.
 const char* CompressionAlgorithmAsString(grpc_compression_algorithm algorithm);

--- a/src/core/lib/compression/compression_internal.h
+++ b/src/core/lib/compression/compression_internal.h
@@ -37,11 +37,6 @@ namespace grpc_core {
 // or nullopt on error.
 std::optional<grpc_compression_algorithm> ParseCompressionAlgorithm(
     absl::string_view algorithm);
-// Given an integer value (e.g. from a channel arg), return the corresponding
-// compression algorithm, or nullopt if the value does not name a known
-// algorithm. Never produces an out-of-range enum value.
-std::optional<grpc_compression_algorithm> CompressionAlgorithmFromInt(
-    int64_t algorithm);
 // Convert a compression algorithm to a string. Returns nullptr if a name is not
 // known.
 const char* CompressionAlgorithmAsString(grpc_compression_algorithm algorithm);

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -290,8 +290,14 @@ void alts_handshaker_client_handle_response(alts_handshaker_client* c,
         result, &client->recv_bytes,
         grpc_gcp_HandshakerResp_bytes_consumed(resp));
   }
-  grpc_status_code code = static_cast<grpc_status_code>(
-      grpc_gcp_HandshakerStatus_code(resp_status));
+  const uint32_t status_code = grpc_gcp_HandshakerStatus_code(resp_status);
+  // The handshaker service response is not trusted to be in range: casting an
+  // out-of-range value to grpc_status_code would be undefined behavior, so map
+  // such values to GRPC_STATUS_UNKNOWN (mirroring
+  // GrpcStatusMetadata::ParseMemento) instead.
+  grpc_status_code code = status_code >= GRPC_STATUS__DO_NOT_USE
+                              ? GRPC_STATUS_UNKNOWN
+                              : static_cast<grpc_status_code>(status_code);
   std::string error;
   if (code != GRPC_STATUS_OK) {
     upb_StringView details = grpc_gcp_HandshakerStatus_details(resp_status);

--- a/src/core/xds/grpc/xds_common_types_parser.cc
+++ b/src/core/xds/grpc/xds_common_types_parser.cc
@@ -78,22 +78,28 @@ Duration ParseDuration(const google_protobuf_Duration* proto_duration,
 //
 
 uint32_t ParseFractionalPercent(
-    const envoy_type_v3_FractionalPercent* fractional_percent) {
+    const envoy_type_v3_FractionalPercent* fractional_percent,
+    ValidationErrors* errors) {
   if (fractional_percent == nullptr) return 1000000;
   uint32_t numerator =
       envoy_type_v3_FractionalPercent_numerator(fractional_percent);
-  const auto denominator =
-      static_cast<envoy_type_v3_FractionalPercent_DenominatorType>(
-          envoy_type_v3_FractionalPercent_denominator(fractional_percent));
-  switch (denominator) {
+  // Switch on the raw int32_t value from the wire: casting an out-of-range
+  // value to the enum type first would be undefined behavior.
+  switch (envoy_type_v3_FractionalPercent_denominator(fractional_percent)) {
     case envoy_type_v3_FractionalPercent_MILLION:
       break;
     case envoy_type_v3_FractionalPercent_TEN_THOUSAND:
       numerator *= 100;
       break;
     case envoy_type_v3_FractionalPercent_HUNDRED:
-    default:
       numerator *= 10000;
+      break;
+    default:
+      errors->AddError(absl::StrCat(
+          "invalid denominator: ",
+          envoy_type_v3_FractionalPercent_denominator(fractional_percent)));
+      numerator *= 10000;
+      break;
   }
   return std::min(numerator, 1000000u);
 }

--- a/src/core/xds/grpc/xds_common_types_parser.cc
+++ b/src/core/xds/grpc/xds_common_types_parser.cc
@@ -85,6 +85,7 @@ uint32_t ParseFractionalPercent(
       envoy_type_v3_FractionalPercent_numerator(fractional_percent);
   // Switch on the raw int32_t value from the wire: casting an out-of-range
   // value to the enum type first would be undefined behavior.
+  ValidationErrors::ScopedField field(errors, ".denominator");
   switch (envoy_type_v3_FractionalPercent_denominator(fractional_percent)) {
     case envoy_type_v3_FractionalPercent_MILLION:
       break;

--- a/src/core/xds/grpc/xds_common_types_parser.h
+++ b/src/core/xds/grpc/xds_common_types_parser.h
@@ -63,7 +63,8 @@ inline std::optional<uint32_t> ParseUInt32Value(
 
 // Returns the number per million.
 uint32_t ParseFractionalPercent(
-    const envoy_type_v3_FractionalPercent* fractional_percent);
+    const envoy_type_v3_FractionalPercent* fractional_percent,
+    ValidationErrors* errors);
 
 std::optional<grpc_resolved_address> ParseXdsAddress(
     const envoy_config_core_v3_Address* address, ValidationErrors* errors);

--- a/src/core/xds/grpc/xds_http_composite_filter.cc
+++ b/src/core/xds/grpc/xds_http_composite_filter.cc
@@ -151,7 +151,7 @@ class ExecuteFilterActionFactory final : public XdsMatcherActionFactory {
                                             ".sample_percent.default_value");
         errors->AddError("field not set");
       } else {
-        sample_per_million = ParseFractionalPercent(default_value);
+        sample_per_million = ParseFractionalPercent(default_value, errors);
       }
     }
     return std::make_unique<CompositeFilter::ExecuteFilterAction>(

--- a/src/core/xds/grpc/xds_http_composite_filter.cc
+++ b/src/core/xds/grpc/xds_http_composite_filter.cc
@@ -146,9 +146,9 @@ class ExecuteFilterActionFactory final : public XdsMatcherActionFactory {
       const auto* default_value =
           envoy_config_core_v3_RuntimeFractionalPercent_default_value(
               sample_percent_proto);
+      ValidationErrors::ScopedField field(errors,
+                                          ".sample_percent.default_value");
       if (default_value == nullptr) {
-        ValidationErrors::ScopedField field(errors,
-                                            ".sample_percent.default_value");
         errors->AddError("field not set");
       } else {
         sample_per_million = ParseFractionalPercent(default_value, errors);

--- a/src/core/xds/grpc/xds_http_fault_filter.cc
+++ b/src/core/xds/grpc/xds_http_fault_filter.cc
@@ -44,18 +44,22 @@ namespace grpc_core {
 
 namespace {
 
-uint32_t GetDenominator(const envoy_type_v3_FractionalPercent* fraction) {
+uint32_t GetDenominator(const envoy_type_v3_FractionalPercent* fraction,
+                        ValidationErrors* errors) {
   if (fraction != nullptr) {
-    const auto denominator =
-        static_cast<envoy_type_v3_FractionalPercent_DenominatorType>(
-            envoy_type_v3_FractionalPercent_denominator(fraction));
-    switch (denominator) {
+    // Switch on the raw int32_t value from the wire: casting an out-of-range
+    // value to the enum type first would be undefined behavior.
+    switch (envoy_type_v3_FractionalPercent_denominator(fraction)) {
       case envoy_type_v3_FractionalPercent_MILLION:
         return 1000000;
       case envoy_type_v3_FractionalPercent_TEN_THOUSAND:
         return 10000;
       case envoy_type_v3_FractionalPercent_HUNDRED:
+        return 100;
       default:
+        errors->AddError(absl::StrCat(
+            "invalid denominator: ",
+            envoy_type_v3_FractionalPercent_denominator(fraction)));
         return 100;
     }
   }
@@ -141,9 +145,10 @@ XdsHttpFaultFilterFactory::ParseTopLevelConfig(
         envoy_extensions_filters_http_fault_v3_FaultAbort_percentage(
             fault_abort);
     if (percent != nullptr) {
+      ValidationErrors::ScopedField field(errors, ".percentage");
       config->abort_percentage_numerator =
           envoy_type_v3_FractionalPercent_numerator(percent);
-      config->abort_percentage_denominator = GetDenominator(percent);
+      config->abort_percentage_denominator = GetDenominator(percent, errors);
     }
   }
   // Section 2: Parse the delay injection config
@@ -171,9 +176,10 @@ XdsHttpFaultFilterFactory::ParseTopLevelConfig(
         envoy_extensions_filters_common_fault_v3_FaultDelay_percentage(
             fault_delay);
     if (percent != nullptr) {
+      ValidationErrors::ScopedField field(errors, ".percentage");
       config->delay_percentage_numerator =
           envoy_type_v3_FractionalPercent_numerator(percent);
-      config->delay_percentage_denominator = GetDenominator(percent);
+      config->delay_percentage_denominator = GetDenominator(percent, errors);
     }
   }
   // Section 3: Parse the maximum active faults

--- a/src/core/xds/grpc/xds_http_fault_filter.cc
+++ b/src/core/xds/grpc/xds_http_fault_filter.cc
@@ -145,9 +145,9 @@ XdsHttpFaultFilterFactory::ParseTopLevelConfig(
         envoy_extensions_filters_http_fault_v3_FaultAbort_percentage(
             fault_abort);
     if (percent != nullptr) {
-      ValidationErrors::ScopedField field(errors, ".percentage");
       config->abort_percentage_numerator =
           envoy_type_v3_FractionalPercent_numerator(percent);
+      ValidationErrors::ScopedField field(errors, ".percentage.denominator");
       config->abort_percentage_denominator = GetDenominator(percent, errors);
     }
   }
@@ -176,9 +176,9 @@ XdsHttpFaultFilterFactory::ParseTopLevelConfig(
         envoy_extensions_filters_common_fault_v3_FaultDelay_percentage(
             fault_delay);
     if (percent != nullptr) {
-      ValidationErrors::ScopedField field(errors, ".percentage");
       config->delay_percentage_numerator =
           envoy_type_v3_FractionalPercent_numerator(percent);
+      ValidationErrors::ScopedField field(errors, ".percentage.denominator");
       config->delay_percentage_denominator = GetDenominator(percent, errors);
     }
   }

--- a/test/core/compression/compression_test.cc
+++ b/test/core/compression/compression_test.cc
@@ -22,7 +22,10 @@
 #include <stdlib.h>
 
 #include <memory>
+#include <optional>
 
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/compression/compression_internal.h"
 #include "src/core/util/useful.h"
 #include "test/core/test_util/test_config.h"
 #include "gtest/gtest.h"
@@ -237,6 +240,30 @@ TEST(CompressionTest, CompressionEnableDisableAlgorithm) {
     grpc_compression_options_enable_algorithm(&options, algorithm);
     ASSERT_NE(
         grpc_compression_options_is_algorithm_enabled(&options, algorithm), 0);
+  }
+}
+
+TEST(CompressionTest, DefaultCompressionAlgorithmFromChannelArgsValidation) {
+  using grpc_core::ChannelArgs;
+  using grpc_core::DefaultCompressionAlgorithmFromChannelArgs;
+  // Unset channel arg yields nullopt.
+  EXPECT_EQ(DefaultCompressionAlgorithmFromChannelArgs(ChannelArgs()),
+            std::nullopt);
+  // In-range values round-trip.
+  for (int v = GRPC_COMPRESS_NONE; v < GRPC_COMPRESS_ALGORITHMS_COUNT; ++v) {
+    EXPECT_EQ(DefaultCompressionAlgorithmFromChannelArgs(ChannelArgs().Set(
+                  GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM, v)),
+              std::optional<grpc_compression_algorithm>(
+                  static_cast<grpc_compression_algorithm>(v)))
+        << "value: " << v;
+  }
+  // Out-of-range values are rejected rather than producing undefined behavior.
+  for (int v :
+       {-1000, -1, static_cast<int>(GRPC_COMPRESS_ALGORITHMS_COUNT), 4, 1000}) {
+    EXPECT_EQ(DefaultCompressionAlgorithmFromChannelArgs(ChannelArgs().Set(
+                  GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM, v)),
+              std::nullopt)
+        << "value: " << v;
   }
 }
 

--- a/test/core/transport/chaotic_good/BUILD
+++ b/test/core/transport/chaotic_good/BUILD
@@ -136,6 +136,7 @@ grpc_fuzz_test(
         "//src/core:chaotic_good_frame",
         "//src/core:grpc_check",
         "//src/core:memory_quota",
+        "//src/core:metadata_batch",
         "//src/core:resource_quota",
     ],
 )

--- a/test/core/transport/chaotic_good/frame_test.cc
+++ b/test/core/transport/chaotic_good/frame_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 
+#include "src/core/call/metadata_batch.h"
 #include "src/core/lib/resource_quota/memory_quota.h"
 #include "src/core/lib/resource_quota/resource_quota.h"
 #include "src/core/util/grpc_check.h"
@@ -47,6 +48,16 @@ void AssertRoundTrips(const Frame& input) {
 FUZZ_TEST(FrameTest, AssertRoundTrips).WithDomains(AnyFrame());
 
 TEST(FrameTest, SettingsFrameRoundTrips) { AssertRoundTrips(SettingsFrame{}); }
+
+TEST(FrameTest, ServerMetadataGrpcFromProtoOutOfRangeStatus) {
+  chaotic_good_frame::ServerMetadata proto;
+  proto.set_status(4294967295u);
+  auto md = ServerMetadataGrpcFromProto(proto);
+  ASSERT_TRUE(md.ok()) << md.status();
+  auto status = (*md)->get(GrpcStatusMetadata());
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(*status, GRPC_STATUS_UNKNOWN);
+}
 
 }  // namespace
 }  // namespace chaotic_good

--- a/test/core/transport/chaotic_good_legacy/BUILD
+++ b/test/core/transport/chaotic_good_legacy/BUILD
@@ -90,6 +90,7 @@ grpc_cc_test(
         "//src/core:chaotic_good_legacy_frame",
         "//src/core:grpc_check",
         "//src/core:memory_quota",
+        "//src/core:metadata_batch",
         "//src/core:resource_quota",
     ],
 )

--- a/test/core/transport/chaotic_good_legacy/frame_test.cc
+++ b/test/core/transport/chaotic_good_legacy/frame_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 
+#include "src/core/call/metadata_batch.h"
 #include "src/core/lib/resource_quota/memory_quota.h"
 #include "src/core/lib/resource_quota/resource_quota.h"
 #include "src/core/util/grpc_check.h"
@@ -46,6 +47,16 @@ void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
 
 TEST(FrameTest, SettingsFrameRoundTrips) {
   AssertRoundTrips(SettingsFrame{}, FrameType::kSettings);
+}
+
+TEST(FrameTest, ServerMetadataGrpcFromProtoOutOfRangeStatus) {
+  chaotic_good_frame::ServerMetadata proto;
+  proto.set_status(4294967295u);
+  auto md = ServerMetadataGrpcFromProto(proto);
+  ASSERT_TRUE(md.ok()) << md.status();
+  auto status = (*md)->get(GrpcStatusMetadata());
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(*status, GRPC_STATUS_UNKNOWN);
 }
 
 }  // namespace

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -87,6 +87,7 @@ typedef struct notification {
 typedef enum {
   INVALID,
   FAILED,
+  OUT_OF_RANGE_STATUS,
   CLIENT_START,
   SERVER_START,
   CLIENT_NEXT,
@@ -241,6 +242,9 @@ static grpc_byte_buffer* generate_handshaker_response(
       break;
     case FAILED:
       grpc_gcp_HandshakerStatus_set_code(status, 3 /* INVALID ARGUMENT */);
+      break;
+    case OUT_OF_RANGE_STATUS:
+      grpc_gcp_HandshakerStatus_set_code(status, 4294967295u);
       break;
   }
   size_t buf_len;
@@ -1185,6 +1189,52 @@ static void on_shutdown_resp_cb(tsi_result status, void* user_data,
   ASSERT_EQ(bytes_to_send, nullptr);
   ASSERT_EQ(bytes_to_send_size, 0);
   ASSERT_EQ(result, nullptr);
+}
+
+static void on_out_of_range_status_resp_cb(tsi_result status, void* user_data,
+                                           const unsigned char* bytes_to_send,
+                                           size_t bytes_to_send_size,
+                                           tsi_handshaker_result* result) {
+  ASSERT_EQ(status, TSI_UNKNOWN_ERROR);
+  ASSERT_EQ(user_data, nullptr);
+  ASSERT_EQ(bytes_to_send, nullptr);
+  ASSERT_EQ(bytes_to_send_size, 0);
+  ASSERT_EQ(result, nullptr);
+}
+
+TEST(AltsTsiHandshakerTest, CheckHandleResponseOutOfRangeStatusCode) {
+  should_handshaker_client_api_succeed = false;
+  // Initialization.
+  notification_init(&caller_to_tsi_notification);
+  notification_init(&tsi_to_caller_notification);
+  ///
+  /// Create a handshaker at the client side, for which the mock handshaker
+  /// service returns a status code outside the range of grpc_status_code.
+  ///
+  tsi_handshaker* handshaker = CreateTestHandshaker(true /* is_client */);
+  tsi_handshaker_next(handshaker, nullptr, 0, nullptr, nullptr, nullptr,
+                      OnClientStartSuccessCb, nullptr);
+  alts_tsi_handshaker* alts_handshaker =
+      reinterpret_cast<alts_tsi_handshaker*>(handshaker);
+  alts_handshaker_client* client =
+      alts_tsi_handshaker_get_client_for_testing(alts_handshaker);
+  // Tests.
+  grpc_byte_buffer* recv_buffer =
+      generate_handshaker_response(OUT_OF_RANGE_STATUS);
+  alts_handshaker_client_set_fields_for_testing(
+      client, alts_handshaker, on_out_of_range_status_resp_cb, nullptr,
+      recv_buffer, /*inject_read_failure=*/false);
+  alts_handshaker_client_handle_response(client, true /* is_ok*/);
+  alts_handshaker_client_ref_for_testing(client);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, absl::OkStatus());
+  }
+  // Cleanup.
+  run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
+  notification_destroy(&caller_to_tsi_notification);
+  notification_destroy(&tsi_to_caller_notification);
 }
 
 TEST(AltsTsiHandshakerTest, CheckHandleResponseAfterShutdown) {

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -250,6 +250,12 @@ TEST_F(FractionalPercentTest, InvalidDenominator) {
   envoy_type_v3_FractionalPercent_set_denominator(proto, 99);
   ValidationErrors errors;
   EXPECT_EQ(300000, ParseFractionalPercent(proto, &errors));
+  absl::Status status =
+      errors.status(absl::StatusCode::kInvalidArgument, "validation failed");
+  EXPECT_EQ(status.message(),
+            "validation failed: ["
+            "field:denominator error:invalid denominator: 99]")
+      << status;
 }
 
 //

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -199,7 +199,8 @@ TEST_F(DurationTest, ValuesTooHigh) {
 using FractionalPercentTest = XdsCommonTypesTest;
 
 TEST_F(FractionalPercentTest, AlwaysIfUnset) {
-  EXPECT_EQ(1000000, ParseFractionalPercent(nullptr));
+  ValidationErrors errors;
+  EXPECT_EQ(1000000, ParseFractionalPercent(nullptr, &errors));
 }
 
 TEST_F(FractionalPercentTest, PerHundred) {
@@ -208,7 +209,8 @@ TEST_F(FractionalPercentTest, PerHundred) {
   envoy_type_v3_FractionalPercent_set_numerator(proto, 30);
   envoy_type_v3_FractionalPercent_set_denominator(
       proto, envoy_type_v3_FractionalPercent_HUNDRED);
-  EXPECT_EQ(300000, ParseFractionalPercent(proto));
+  ValidationErrors errors;
+  EXPECT_EQ(300000, ParseFractionalPercent(proto, &errors));
 }
 
 TEST_F(FractionalPercentTest, PerTenThousand) {
@@ -217,7 +219,8 @@ TEST_F(FractionalPercentTest, PerTenThousand) {
   envoy_type_v3_FractionalPercent_set_numerator(proto, 30);
   envoy_type_v3_FractionalPercent_set_denominator(
       proto, envoy_type_v3_FractionalPercent_TEN_THOUSAND);
-  EXPECT_EQ(3000, ParseFractionalPercent(proto));
+  ValidationErrors errors;
+  EXPECT_EQ(3000, ParseFractionalPercent(proto, &errors));
 }
 
 TEST_F(FractionalPercentTest, PerMillion) {
@@ -226,7 +229,8 @@ TEST_F(FractionalPercentTest, PerMillion) {
   envoy_type_v3_FractionalPercent_set_numerator(proto, 30);
   envoy_type_v3_FractionalPercent_set_denominator(
       proto, envoy_type_v3_FractionalPercent_MILLION);
-  EXPECT_EQ(30, ParseFractionalPercent(proto));
+  ValidationErrors errors;
+  EXPECT_EQ(30, ParseFractionalPercent(proto, &errors));
 }
 
 TEST_F(FractionalPercentTest, ClampsValue) {
@@ -235,7 +239,17 @@ TEST_F(FractionalPercentTest, ClampsValue) {
   envoy_type_v3_FractionalPercent_set_numerator(proto, 105);
   envoy_type_v3_FractionalPercent_set_denominator(
       proto, envoy_type_v3_FractionalPercent_HUNDRED);
-  EXPECT_EQ(1000000, ParseFractionalPercent(proto));
+  ValidationErrors errors;
+  EXPECT_EQ(1000000, ParseFractionalPercent(proto, &errors));
+}
+
+TEST_F(FractionalPercentTest, InvalidDenominator) {
+  envoy_type_v3_FractionalPercent* proto =
+      envoy_type_v3_FractionalPercent_new(upb_arena_.ptr());
+  envoy_type_v3_FractionalPercent_set_numerator(proto, 30);
+  envoy_type_v3_FractionalPercent_set_denominator(proto, 99);
+  ValidationErrors errors;
+  EXPECT_EQ(300000, ParseFractionalPercent(proto, &errors));
 }
 
 //

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -512,6 +512,48 @@ TEST_P(XdsFaultInjectionFilterConfigTest, ParseInvalidGrpcStatusCode) {
       << status;
 }
 
+TEST_P(XdsFaultInjectionFilterConfigTest,
+       ParseInvalidAbortPercentageDenominator) {
+  HTTPFault fault;
+  auto* percentage = fault.mutable_abort()->mutable_percentage();
+  percentage->set_numerator(75);
+  percentage->GetReflection()->SetEnumValue(
+      percentage, percentage->GetDescriptor()->FindFieldByName("denominator"),
+      99);
+  XdsExtension extension = MakeXdsExtension(fault);
+  auto config = ParseConfig(std::move(extension));
+  absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
+                                       "errors validating filter config");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "errors validating filter config: ["
+            "field:http_filter.value[envoy.extensions.filters.http.fault.v3"
+            ".HTTPFault].abort.percentage error:invalid denominator: 99]")
+      << status;
+}
+
+TEST_P(XdsFaultInjectionFilterConfigTest,
+       ParseInvalidDelayPercentageDenominator) {
+  HTTPFault fault;
+  auto* delay = fault.mutable_delay();
+  delay->mutable_fixed_delay()->set_seconds(1);
+  auto* percentage = delay->mutable_percentage();
+  percentage->set_numerator(25);
+  percentage->GetReflection()->SetEnumValue(
+      percentage, percentage->GetDescriptor()->FindFieldByName("denominator"),
+      99);
+  XdsExtension extension = MakeXdsExtension(fault);
+  auto config = ParseConfig(std::move(extension));
+  absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
+                                       "errors validating filter config");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "errors validating filter config: ["
+            "field:http_filter.value[envoy.extensions.filters.http.fault.v3"
+            ".HTTPFault].delay.percentage error:invalid denominator: 99]")
+      << status;
+}
+
 TEST_P(XdsFaultInjectionFilterConfigTest, ParseInvalidDuration) {
   HTTPFault fault;
   fault.mutable_delay()->mutable_fixed_delay()->set_seconds(315576000001);

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -528,7 +528,8 @@ TEST_P(XdsFaultInjectionFilterConfigTest,
   EXPECT_EQ(status.message(),
             "errors validating filter config: ["
             "field:http_filter.value[envoy.extensions.filters.http.fault.v3"
-            ".HTTPFault].abort.percentage error:invalid denominator: 99]")
+            ".HTTPFault].abort.percentage.denominator error:invalid "
+            "denominator: 99]")
       << status;
 }
 
@@ -550,7 +551,8 @@ TEST_P(XdsFaultInjectionFilterConfigTest,
   EXPECT_EQ(status.message(),
             "errors validating filter config: ["
             "field:http_filter.value[envoy.extensions.filters.http.fault.v3"
-            ".HTTPFault].delay.percentage error:invalid denominator: 99]")
+            ".HTTPFault].delay.percentage.denominator error:invalid "
+            "denominator: 99]")
       << status;
 }
 


### PR DESCRIPTION
Casting an integer outside an unscoped C enumeration's range to the enum type is undefined behavior ([expr.static.cast]/7), and UBSan's `-fsanitize=enum` traps it. OSS-Fuzz has hit this shape three times in this tree (022baab189 and 9f5e9dbf60 for compression channel args; ee6464083f for grpc-status on the wire — the latter also widened `GRPC_STATUS__DO_NOT_USE` to `0x7fffffffu`, which does not cover the upper half of `uint32_t`: values in [2^31, 2^32-1] remain UB to cast).

This PR eliminates the remaining unguarded casts of externally-derived integers to unscoped enums — 6 sites in 4 subsystems — by either validating before the cast or removing the cast entirely:

1. **`compression_internal.cc`** (`DefaultCompressionAlgorithmFromChannelArgs`): raw `static_cast<grpc_compression_algorithm>` on the `grpc.default_compression_algorithm` channel arg. The sibling `CompressionOptionsFromChannelArgs` was clamped in 9f5e9dbf60; this call site was missed. Fixed via a new `CompressionAlgorithmFromInt()` validated helper (mirrors the string-side `ParseCompressionAlgorithm` contract; out-of-range → `nullopt` → caller falls back to `GRPC_COMPRESS_NONE`, matching today's effective behavior).

2. **`xds_http_fault_filter.cc`** (`GetDenominator`) and **`xds_common_types_parser.cc`** (`ParseFractionalPercent`): raw casts of the upb int32_t `FractionalPercent.denominator` wire field to `envoy_type_v3_FractionalPercent_DenominatorType` (valid range [0,2]). Fixed by switching on the integer directly (no cast at all) and reporting `ValidationErrors` on out-of-range values, so the resource is NACKed — the same validation contract as 4af0c8334d. `ParseFractionalPercent` gains a `ValidationErrors*` parameter; its one other caller (`xds_http_composite_filter.cc`) is updated.

3. **`chaotic_good/frame.cc`** and **`chaotic_good_legacy/frame.cc`** (`ServerMetadataGrpcFromProto`): raw `static_cast<grpc_status_code>` on the untrusted wire `uint32 status` field. Fixed by mapping out-of-range values to `GRPC_STATUS_UNKNOWN`, mirroring the HTTP/2 metadata layer's `GrpcStatusMetadata::ParseMemento` policy (ee6464083f).

4. **`alts_handshaker_client.cc`**: raw `static_cast<grpc_status_code>` on the ALTS handshaker service's `HandshakerStatus.code` (uint32 from the service response). Same out-of-range → `GRPC_STATUS_UNKNOWN` mapping; the handshake then fails cleanly via the existing `code != GRPC_STATUS_OK` path.

## Evidence (pre-patch, UBSan `-fsanitize=undefined`, aarch64)

Each site was triggered through a test exercising the real parse path. Pre-patch logs show `runtime error: load of value <v>, which is not a valid value for type`:

| Site | Trigger | UBSan report location |
|---|---|---|
| `compression_internal.cc:231` | channel arg int = -1000 | optional load returning from `DefaultCompressionAlgorithmFromChannelArgs` |
| `xds_http_fault_filter.cc:52` | `denominator: 99` in HTTPFault config | switch load in `GetDenominator` |
| `xds_common_types_parser.cc:88` | `denominator: 99` in FractionalPercent | switch load in `ParseFractionalPercent` |
| `chaotic_good/frame.cc:227` | `ServerMetadata{status: 4294967295}` | `metadata_batch.h:1012` load of invalid `grpc_status_code` |
| `chaotic_good_legacy/frame.cc:222` | same | same |
| `alts_handshaker_client.cc:296,:308` | `HandshakerStatus{code: 4294967295}` | comparison + `alts_tsi_utils.cc:30` switch load |

Post-patch: all six paths run with zero UBSan reports; invalid values are rejected (xds: NACK) or remapped (status → UNKNOWN, compression → NONE) as described above.

## Completeness argument

An int→enum conversion cannot happen implicitly in C++, so the inventory is enumerable. Swept all of `src/core` for casts to `grpc_compression_algorithm`, `grpc_compression_level`, `grpc_status_code`, and `envoy_*`/`xds_*` upb enums, plus a triaged tree-wide `static_cast` sweep:

- metadata `ParseMemento` traits: all enum-valued traits either string-match (closed validation) or range-check (grpc-status, post-ee6464083f) — clean;
- `absl::StatusCode` casts: scoped enum with fixed underlying type — defined behavior, excluded;
- `FrameType` casts: `enum class : uint8_t` — defined behavior, excluded;
- previously fixed sites (022baab189, 9f5e9dbf60, ee6464083f, 4af0c8334d): verified still guarded.

## Tests

- `compression_test`: new `DefaultCompressionAlgorithmFromChannelArgsValidation` (round-trip + reject cases).
- `xds_http_filters_test`: new `ParseInvalid{Abort,Delay}PercentageDenominator` (both top-level and override config).
- `xds_common_types_test`: new `InvalidDenominator`; existing calls updated for the signature change.
- `chaotic_good/frame_test.cc`, `chaotic_good_legacy/frame_test.cc`: new `ServerMetadataGrpcFromProtoOutOfRangeStatus`.
- `alts_tsi_handshaker_test`: new `CheckHandleResponseOutOfRangeStatusCode`.

All of the above pass under ASan+UBSan; `api_fuzzer` (including the `FuzzerBugRegressionInvalidEnumValues` regression) and the surrounding `xds`/`chaotic_good`/`alts` test suites pass as well.
