### PR TITLE
[CI] Disable ruby build test for x64-mingw-ucrt.

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -520,7 +520,9 @@ def targets():
             PythonArtifact("windows", "x64", "Python314"),
             PythonArtifact("windows", "x64", "Python315", presubmit=True),
             RubyArtifact("linux", "x86-mingw32", presubmit=True),
-            RubyArtifact("linux", "x64-mingw-ucrt"),
+            # TODO(weizheyuan, asheshvidyut): Properly install gcc-mingw >= 10
+            # (which is required by abseil) and re-enable this test.
+            # RubyArtifact("linux", "x64-mingw-ucrt"),
             RubyArtifact("linux", "x86_64-linux-gnu", presubmit=True),
             RubyArtifact("linux", "x86_64-linux-musl", presubmit=True),
             RubyArtifact("linux", "x86-linux-gnu"),

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -523,6 +523,8 @@ def targets():
             # TODO(weizheyuan, asheshvidyut): Properly install gcc-mingw >= 10
             # (which is required by abseil) and re-enable this test.
             # RubyArtifact("linux", "x64-mingw-ucrt"),
+            #
+            # See https://github.com/grpc/grpc/issues/43374
             RubyArtifact("linux", "x86_64-linux-gnu", presubmit=True),
             RubyArtifact("linux", "x86_64-linux-musl", presubmit=True),
             RubyArtifact("linux", "x86-linux-gnu"),


### PR DESCRIPTION
Newer Abseil requires gcc >= 10 which we don't have for ruby distrib tests. Some prior work (#43185, #43288) addressed most of the problem but left `x64-mingw-ucrt` broken. That docker image require some extra work to get gcc work properly with 64-bit UCRT. Disable it for now to unblock abseil upgrade.

See also https://github.com/grpc/grpc/issues/43374