### PR TITLE
[chttp2] Enforce RFC 9113 flow-control window limit on received WINDOW_UPDATE frames

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -179,10 +179,12 @@ absl::Status TransportFlowControl::IncomingUpdateContext::RecvData(
 int64_t TransportFlowControl::target_window() const {
   // See comment above announced_stream_total_over_incoming_window_ for the
   // logic behind this decision.
-  return static_cast<uint32_t>(
-      std::min(static_cast<int64_t>((1u << 31) - 1),
-               announced_stream_total_over_incoming_window_ +
-                   std::max<int64_t>(1, target_initial_window_size_)));
+  // Clamp below at zero: the total is a sum of positive per-stream deltas, and
+  // a negative value here would otherwise wrap the uint32 window to ~4GB,
+  // making us advertise a huge receive window to the peer.
+  return std::clamp(announced_stream_total_over_incoming_window_ +
+                        std::max<int64_t>(1, target_initial_window_size_),
+                    int64_t{0}, kMaxWindowUpdateSize);
 }
 
 FlowControlAction TransportFlowControl::UpdateAction(FlowControlAction action) {

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -297,7 +297,17 @@ class TransportFlowControl final {
 
     // Call this function when a transport-level WINDOW_UPDATE frame is received
     // from peer to increase remote window.
-    void RecvUpdate(uint32_t size) { tfc_->remote_window_ += size; }
+    // Returns an error if the update would push the send window past the
+    // RFC 9113 section 6.9.1 limit of 2^31-1.
+    absl::Status RecvUpdate(uint32_t size) {
+      if (tfc_->remote_window_ + size > kMaxWindow) {
+        return absl::InternalError(
+            absl::StrCat("transport flow control window ", tfc_->remote_window_,
+                         " + ", size, " exceeds the RFC 9113 limit of 2^31-1"));
+      }
+      tfc_->remote_window_ += size;
+      return absl::OkStatus();
+    }
 
     // Finish the update and check whether we became stalled or unstalled.
     StallEdge Finish() {
@@ -639,7 +649,20 @@ class StreamFlowControl final {
 
     // Call this when a WINDOW_UPDATE frame is received from peer for this
     // stream, to increase send window.
-    void RecvUpdate(uint32_t size) { sfc_->remote_window_delta_ += size; }
+    // Returns an error if the update would push the effective send window
+    // (peer initial window size + delta) past the RFC 9113 section 6.9.1
+    // limit of 2^31-1.
+    absl::Status RecvUpdate(uint32_t size, uint32_t peer_initial_window_size) {
+      if (sfc_->remote_window_delta_ + peer_initial_window_size + size >
+          kMaxWindow) {
+        return absl::InternalError(absl::StrCat(
+            "stream flow control window ", sfc_->remote_window_delta_, " + ",
+            peer_initial_window_size, " + ", size,
+            " exceeds the RFC 9113 limit of 2^31-1"));
+      }
+      sfc_->remote_window_delta_ += size;
+      return absl::OkStatus();
+    }
 
     // Call this after sending a DATA frame for this stream, to decrease send
     // window based on `outgoing_frame_size`.

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -23,11 +23,13 @@
 
 #include "src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h"
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
+#include "src/core/ext/transport/chttp2/transport/http2_status.h"
 #include "src/core/ext/transport/chttp2/transport/http2_ztrace_collector.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/ext/transport/chttp2/transport/stream_lists.h"
 #include "src/core/telemetry/stats.h"
 #include "src/core/util/grpc_check.h"
+#include "src/core/util/status_helper.h"
 #include "src/core/util/time.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
@@ -113,9 +115,22 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
               (now - s->last_window_update_time).millis());
         }
         s->last_window_update_time = now;
-        grpc_core::chttp2::StreamFlowControl::OutgoingUpdateContext(
-            &s->flow_control)
-            .RecvUpdate(received_update);
+        absl::Status fc_status =
+            grpc_core::chttp2::StreamFlowControl::OutgoingUpdateContext(
+                &s->flow_control)
+                .RecvUpdate(received_update,
+                            t->settings.peer().initial_window_size());
+        if (!fc_status.ok()) {
+          // RFC 9113 section 6.9.1: a WINDOW_UPDATE that causes the
+          // flow-control window to exceed 2^31-1 is a connection error of
+          // type FLOW_CONTROL_ERROR.
+          return grpc_error_set_int(
+              GRPC_ERROR_CREATE(
+                  absl::StrCat("flow control error: ", fc_status.message())),
+              grpc_core::StatusIntProperty::kHttp2Error,
+              static_cast<intptr_t>(
+                  grpc_core::http2::Http2ErrorCode::kFlowControlError));
+        }
         t->http2_stats->IncrementHttp2StreamRemoteWindowUpdate(received_update);
         if (grpc_chttp2_list_remove_stalled_by_stream(t, s)) {
           grpc_chttp2_mark_stream_writable(t, s);
@@ -134,7 +149,18 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
       t->last_window_update_time = now;
       t->http2_stats->IncrementHttp2TransportRemoteWindowUpdate(
           received_update);
-      upd.RecvUpdate(received_update);
+      absl::Status fc_status = upd.RecvUpdate(received_update);
+      if (!fc_status.ok()) {
+        // RFC 9113 section 6.9.1: a WINDOW_UPDATE that causes the
+        // flow-control window to exceed 2^31-1 is a connection error of
+        // type FLOW_CONTROL_ERROR.
+        return grpc_error_set_int(
+            GRPC_ERROR_CREATE(
+                absl::StrCat("flow control error: ", fc_status.message())),
+            grpc_core::StatusIntProperty::kHttp2Error,
+            static_cast<intptr_t>(
+                grpc_core::http2::Http2ErrorCode::kFlowControlError));
+      }
       if (upd.Finish() == grpc_core::chttp2::StallEdge::kUnstalled) {
         grpc_chttp2_initiate_write(
             t, GRPC_CHTTP2_INITIATE_WRITE_TRANSPORT_FLOW_CONTROL_UNSTALLED);

--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.cc
@@ -524,8 +524,14 @@ Http2Status Http2ClientTransport::ProcessIncomingFrame(
     stream = LookupStream(frame.stream_id);
   }
 
-  const bool should_trigger_write = ProcessIncomingWindowUpdateFrameFlowControl(
-      frame, flow_control_, stream.get());
+  ValueOrHttp2Status<bool> window_update_result =
+      ProcessIncomingWindowUpdateFrameFlowControl(
+          frame, flow_control_, stream.get(), settings_->peer());
+  if (!window_update_result.IsOk()) {
+    return ValueOrHttp2Status<bool>::TakeStatus(
+        std::move(window_update_result));
+  }
+  const bool should_trigger_write = window_update_result.value();
 
   if (should_trigger_write) {
     return ToHttpOkOrConnError(TriggerWriteCycle());

--- a/src/core/ext/transport/chttp2/transport/http2_server_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_server_transport.cc
@@ -621,8 +621,14 @@ Http2Status Http2ServerTransport::ProcessIncomingFrame(
     stream = LookupStream(frame.stream_id);
   }
 
-  const bool should_trigger_write = ProcessIncomingWindowUpdateFrameFlowControl(
-      frame, flow_control_, stream.get());
+  ValueOrHttp2Status<bool> window_update_result =
+      ProcessIncomingWindowUpdateFrameFlowControl(
+          frame, flow_control_, stream.get(), settings_->peer());
+  if (!window_update_result.IsOk()) {
+    return ValueOrHttp2Status<bool>::TakeStatus(
+        std::move(window_update_result));
+  }
+  const bool should_trigger_write = window_update_result.value();
 
   if (should_trigger_write) {
     return ToHttpOkOrConnError(TriggerWriteCycle());

--- a/src/core/ext/transport/chttp2/transport/http2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/http2_transport.cc
@@ -391,9 +391,10 @@ ProcessIncomingDataFrameFlowControl(const Http2FrameHeader& frame_header,
   return chttp2::FlowControlAction();
 }
 
-bool ProcessIncomingWindowUpdateFrameFlowControl(
+ValueOrHttp2Status<bool> ProcessIncomingWindowUpdateFrameFlowControl(
     const Http2WindowUpdateFrame& frame,
-    chttp2::TransportFlowControl& flow_control, Stream* stream) {
+    chttp2::TransportFlowControl& flow_control, Stream* stream,
+    const Http2Settings& peer_settings) {
   if (frame.stream_id != 0) {
     if (stream != nullptr) {
       GRPC_HTTP2_COMMON_DLOG
@@ -401,7 +402,17 @@ bool ProcessIncomingWindowUpdateFrameFlowControl(
           << frame.stream_id << " increment " << frame.increment;
       chttp2::StreamFlowControl::OutgoingUpdateContext fc_update(
           &stream->GetStreamFlowControl());
-      fc_update.RecvUpdate(frame.increment);
+      const absl::Status fc_status = fc_update.RecvUpdate(
+          frame.increment, peer_settings.initial_window_size());
+      if (!fc_status.ok()) {
+        // RFC 9113 section 6.9.1: a WINDOW_UPDATE that causes the
+        // flow-control window to exceed 2^31-1 is an error of type
+        // FLOW_CONTROL_ERROR.
+        LOG(ERROR) << "Flow control error: " << fc_status.message();
+        return Http2Status::Http2ConnectionError(
+            Http2ErrorCode::kFlowControlError,
+            std::string(fc_status.message()));
+      }
     } else {
       // If stream id is non zero, and stream is nullptr, maybe the stream was
       // closed. Ignore this WINDOW_UPDATE frame.
@@ -415,7 +426,12 @@ bool ProcessIncomingWindowUpdateFrameFlowControl(
         << frame.increment;
     chttp2::TransportFlowControl::OutgoingUpdateContext fc_update(
         &flow_control);
-    fc_update.RecvUpdate(frame.increment);
+    const absl::Status fc_status = fc_update.RecvUpdate(frame.increment);
+    if (!fc_status.ok()) {
+      LOG(ERROR) << "Flow control error: " << fc_status.message();
+      return Http2Status::Http2ConnectionError(
+          Http2ErrorCode::kFlowControlError, std::string(fc_status.message()));
+    }
     if (fc_update.Finish() == chttp2::StallEdge::kUnstalled) {
       // If transport moves from kStalled to kUnstalled, streams blocked by
       // transport flow control will become writable. Return true to trigger a

--- a/src/core/ext/transport/chttp2/transport/http2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_transport.h
@@ -200,9 +200,10 @@ ProcessIncomingDataFrameFlowControl(const Http2FrameHeader& frame,
                                     Stream* stream);
 
 // Returns true if a write should be triggered
-bool ProcessIncomingWindowUpdateFrameFlowControl(
+ValueOrHttp2Status<bool> ProcessIncomingWindowUpdateFrameFlowControl(
     const Http2WindowUpdateFrame& frame,
-    chttp2::TransportFlowControl& flow_control, Stream* stream);
+    chttp2::TransportFlowControl& flow_control, Stream* stream,
+    const Http2Settings& peer_settings);
 
 void MaybeAddTransportWindowUpdateFrame(
     chttp2::TransportFlowControl& flow_control, FrameSender& frame_sender);

--- a/test/core/bad_client/generate_tests.bzl
+++ b/test/core/bad_client/generate_tests.bzl
@@ -33,6 +33,7 @@ BAD_CLIENT_TESTS = {
     "server_registered_method": test_options(),
     "simple_request": test_options(),
     "window_overflow": test_options(),
+    "window_update_overflow": test_options(),
     "unknown_frame": test_options(),
 }
 

--- a/test/core/bad_client/tests/window_update_overflow.cc
+++ b/test/core/bad_client/tests/window_update_overflow.cc
@@ -1,0 +1,65 @@
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <grpc/grpc.h>
+
+#include "src/core/server/server.h"
+#include "src/core/util/grpc_check.h"
+#include "test/core/bad_client/bad_client.h"
+#include "test/core/test_util/test_config.h"
+#include "gtest/gtest.h"
+#include "absl/log/log.h"
+
+// Client preface, empty SETTINGS frame, then a WINDOW_UPDATE with the maximum
+// increment for the connection: the connection send window would become
+// 65535 + 0x7fffffff, exceeding the RFC 9113 maximum of 2^31-1.
+static const char kPayload[] =
+    "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+    "\x00\x00\x00\x04\x00\x00\x00\x00\x00"  // empty SETTINGS
+    "\x00\x00\x04\x08\x00\x00\x00\x00\x00"  // WINDOW_UPDATE header, stream 0
+    "\x7f\xff\xff\xff";                     // increment 0x7fffffff
+
+// The server must close the connection itself on the flow-control violation
+// (the parse fails with FLOW_CONTROL_ERROR). The client stays connected, so if
+// the violation is silently accepted the connection stays open and this
+// verifier fails.
+static void verifier(grpc_server* server, grpc_completion_queue* cq,
+                     void* /*registered_method*/) {
+  const gpr_timespec deadline = gpr_time_add(
+      gpr_now(GPR_CLOCK_MONOTONIC), gpr_time_from_seconds(2, GPR_TIMESPAN));
+  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+    GRPC_CHECK(gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), deadline) < 0)
+        << "server did not close the connection on a WINDOW_UPDATE that "
+           "overflows the flow-control window";
+    GRPC_CHECK(grpc_completion_queue_next(
+                   cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
+                   .type == GRPC_QUEUE_TIMEOUT);
+  }
+}
+
+TEST(WindowUpdateOverflowTest, TransportWindowOverflow) {
+  grpc_bad_client_arg arg = {nullptr, nullptr, kPayload, sizeof(kPayload) - 1};
+  grpc_run_bad_client_test(verifier, &arg, 1, 0);
+}
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
+  int result = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return result;
+}

--- a/test/core/transport/chttp2/flow_control_manager_test.cc
+++ b/test/core/transport/chttp2/flow_control_manager_test.cc
@@ -144,7 +144,8 @@ TEST(FlowControlManagerTest, GetStreamFlowControlTokens) {
   {
     chttp2::StreamFlowControl::OutgoingUpdateContext sfc_upd(
         &stream_flow_control);
-    sfc_upd.RecvUpdate(500);
+    ASSERT_TRUE(
+        sfc_upd.RecvUpdate(500, peer_settings.initial_window_size()).ok());
   }
   EXPECT_EQ(chttp2::kDefaultWindow - 500,
             GetStreamFlowControlTokens(stream_flow_control, peer_settings));
@@ -203,7 +204,8 @@ TEST(FlowControlManagerTest, GetMaxPermittedDequeue) {
         &stream_flow_control);
     sfc_upd.SentData(60000);
     // This restores the stream tokens, but NOT the transport tokens.
-    sfc_upd.RecvUpdate(60000);
+    ASSERT_TRUE(
+        sfc_upd.RecvUpdate(60000, peer_settings.initial_window_size()).ok());
   }
   // transport window = 64535-60000=4535, stream_delta=-1000-60000+60000 = -1000
   // flow_control_tokens = min(4535, -1000+65535) = min(4535, 64535) = 4535
@@ -216,7 +218,7 @@ TEST(FlowControlManagerTest, GetMaxPermittedDequeue) {
   {
     chttp2::TransportFlowControl::OutgoingUpdateContext tfc_upd(
         &transport_flow_control);
-    tfc_upd.RecvUpdate(60000);
+    ASSERT_TRUE(tfc_upd.RecvUpdate(60000).ok());
   }
   // transport window = 4535+60000=64535, stream_delta=-1000
   // Decrease peer_settings initial window size

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -323,6 +323,42 @@ TEST_F(FlowControlTest, OnStreamClosedDecreasesAnnouncedDeltaFromTransport) {
   EXPECT_EQ(sfc2.test_only_announced_window_delta(), 0);
 }
 
+// RFC 9113 section 6.9.1: a WINDOW_UPDATE that would push a flow-control
+// window past 2^31-1 must produce an error, not silently grow the window.
+TEST_F(FlowControlTest, TransportRecvUpdateBeyondMaxWindowIsError) {
+  ExecCtx exec_ctx;
+  TransportFlowControl tfc(/*peer_name=*/"test",
+                           /*enable_bdp_probe=*/true, &memory_owner_);
+  TransportFlowControl::OutgoingUpdateContext upd(&tfc);
+  // Exactly up to the limit is accepted.
+  constexpr uint32_t kToMax = (1u << 31) - 1 - kDefaultWindow;
+  ASSERT_TRUE(upd.RecvUpdate(kToMax).ok());
+  EXPECT_EQ(tfc.remote_window(), kMaxWindow);
+  // One byte more overflows: error, and the window is unchanged.
+  EXPECT_FALSE(upd.RecvUpdate(1).ok());
+  EXPECT_EQ(tfc.remote_window(), kMaxWindow);
+}
+
+TEST_F(FlowControlTest, StreamRecvUpdateBeyondMaxWindowIsError) {
+  ExecCtx exec_ctx;
+  TransportFlowControl tfc(/*peer_name=*/"test",
+                           /*enable_bdp_probe=*/true, &memory_owner_);
+  StreamFlowControl sfc(&tfc);
+  StreamFlowControl::OutgoingUpdateContext upd(&sfc);
+  // The effective stream send window is peer_initial_window_size + delta.
+  constexpr uint32_t kToMax = (1u << 31) - 1 - kDefaultWindow;
+  ASSERT_TRUE(upd.RecvUpdate(kToMax, kDefaultWindow).ok());
+  EXPECT_EQ(sfc.remote_window_delta(), kToMax);
+  // One byte more overflows: error, and the delta is unchanged.
+  EXPECT_FALSE(upd.RecvUpdate(1, kDefaultWindow).ok());
+  EXPECT_EQ(sfc.remote_window_delta(), kToMax);
+  // With a maximum-size peer initial window, even a one-byte increment on a
+  // zero delta overflows.
+  StreamFlowControl sfc_max(&tfc);
+  StreamFlowControl::OutgoingUpdateContext upd_max(&sfc_max);
+  EXPECT_FALSE(upd_max.RecvUpdate(1, static_cast<uint32_t>(kMaxWindow)).ok());
+}
+
 }  // namespace chttp2
 }  // namespace grpc_core
 

--- a/test/core/transport/chttp2/http2_client_transport_test.cc
+++ b/test/core/transport/chttp2/http2_client_transport_test.cc
@@ -31,6 +31,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "src/core/call/call_filters.h"
 #include "src/core/call/call_spine.h"
@@ -38,6 +39,7 @@
 #include "src/core/call/metadata.h"
 #include "src/core/call/metadata_batch.h"
 #include "src/core/channelz/channelz.h"
+#include "src/core/ext/transport/chttp2/transport/flow_control.h"
 #include "src/core/ext/transport/chttp2/transport/frame.h"
 #include "src/core/ext/transport/chttp2/transport/http2_status.h"
 #include "src/core/ext/transport/chttp2/transport/transport_common.h"
@@ -1004,6 +1006,61 @@ TEST_F(Http2ClientTransportTest, TestFlowControlWindow) {
   std::shared_ptr<EventSequenceEndpoint::Step> step2 = endpoint()->NewStep();
   AddTransportCloseExpectations(step2.get());
   step2->Wait();
+}
+
+namespace {
+
+// Scans the written bytes for a complete GOAWAY frame carrying
+// FLOW_CONTROL_ERROR.
+void ExpectGoawayFlowControlError(SliceBuffer& buffer) {
+  std::vector<uint8_t> bytes(buffer.Length());
+  buffer.CopyFirstNBytesIntoBuffer(buffer.Length(),
+                                   reinterpret_cast<char*>(bytes.data()));
+  size_t off = 0;
+  bool found = false;
+  while (off + 9 <= bytes.size()) {
+    const uint32_t len =
+        (bytes[off] << 16) | (bytes[off + 1] << 8) | bytes[off + 2];
+    const uint8_t type = bytes[off + 3];
+    if (off + 9 + len > bytes.size()) break;
+    if (type == 0x7 && len >= 8) {
+      const uint32_t error_code = (bytes[off + 13] << 24) |
+                                  (bytes[off + 14] << 16) |
+                                  (bytes[off + 15] << 8) | bytes[off + 16];
+      if (error_code ==
+          static_cast<uint32_t>(Http2ErrorCode::kFlowControlError)) {
+        found = true;
+      }
+    }
+    off += 9 + len;
+  }
+  EXPECT_TRUE(found) << "expected a GOAWAY frame with FLOW_CONTROL_ERROR";
+}
+
+}  // namespace
+
+TEST_F(Http2ClientTransportTest,
+       WindowUpdateOverflowingWindowIsConnectionError) {
+  ExecCtx ctx;
+  // 1. Initialize the transport and exchange settings.
+  InitTransport(GetChannelArgs());
+  SpawnTransportLoopsAndExchangeSettings();
+
+  // 2. Server sends a max-increment WINDOW_UPDATE for the connection; the
+  //    transport immediately answers with a FLOW_CONTROL_ERROR GOAWAY.
+  std::shared_ptr<EventSequenceEndpoint::Step> step = endpoint()->NewStep();
+  step->ThenPerformRead({helper_.SerializedWindowUpdateFrame(
+      /*stream_id=*/0, /*increment=*/0x7fffffff)});
+  step->ThenExpectWrite(
+      [](SliceBuffer& buffer) { ExpectGoawayFlowControlError(buffer); });
+  step->Wait();
+  event_engine()->Tick();
+
+  // 3. RFC 9113 section 6.9.1: the send window must never exceed 2^31-1
+  //    (65535 + 0x7fffffff exceeds it): the update is rejected and the window
+  //    stays in range.
+  EXPECT_LE(client_transport()->TestOnlyTransportFlowControlWindow(),
+            RFC9113::kMaxSize31Bit);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/core/transport/chttp2/http2_transport_test.cc
+++ b/test/core/transport/chttp2/http2_transport_test.cc
@@ -616,6 +616,7 @@ TEST(Http2CommonTransportTest,
   chttp2::TransportFlowControl flow_control(
       /*peer_name=*/"TestFlowControl", /*enable_bdp_probe=*/false,
       /*memory_owner=*/nullptr);
+  Http2Settings peer_settings;
   EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow);
 
   Http2WindowUpdateFrame frame;
@@ -623,14 +624,16 @@ TEST(Http2CommonTransportTest,
 
   // If stream_id != 0 and stream is null, no change in flow control window.
   frame.stream_id = 1;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, flow_control,
-                                              /*stream=*/nullptr);
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, flow_control, /*stream=*/nullptr, peer_settings)
+                  .IsOk());
   EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow);
 
   // If stream_id == 0, transport flow control window should increase.
   frame.stream_id = 0;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, flow_control,
-                                              /*stream=*/nullptr);
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, flow_control, /*stream=*/nullptr, peer_settings)
+                  .IsOk());
   EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow + 1000);
 
   // If increment is 0, no change in flow control window.
@@ -638,19 +641,22 @@ TEST(Http2CommonTransportTest,
   // layer, we should be graceful with it at this layer.
   frame.increment = 0;
   frame.stream_id = 0;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, flow_control,
-                                              /*stream=*/nullptr);
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, flow_control, /*stream=*/nullptr, peer_settings)
+                  .IsOk());
   EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow + 1000);
   frame.stream_id = 1;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, flow_control,
-                                              /*stream=*/nullptr);
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, flow_control, /*stream=*/nullptr, peer_settings)
+                  .IsOk());
   EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow + 1000);
 
   // Large increment
   frame.increment = 10000;
   frame.stream_id = 0;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, flow_control,
-                                              /*stream=*/nullptr);
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, flow_control, /*stream=*/nullptr, peer_settings)
+                  .IsOk());
   EXPECT_EQ(flow_control.remote_window(),
             chttp2::kDefaultWindow + 1000 + 10000);
 }
@@ -658,6 +664,7 @@ TEST(Http2CommonTransportTest,
 TEST_P(TestsNeedingStreamObjects,
        ProcessIncomingWindowUpdateFrameFlowControlWithStream) {
   RefCountedPtr<Stream> stream = CreateMinimalTestStream(1);
+  Http2Settings peer_settings;
   EXPECT_EQ(transport_flow_control_.remote_window(), chttp2::kDefaultWindow);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 0);
 
@@ -667,15 +674,17 @@ TEST_P(TestsNeedingStreamObjects,
   // If stream_id != 0 and stream is not null, stream flow control window
   // should increase.
   frame.stream_id = 1;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, transport_flow_control_,
-                                              stream.get());
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, transport_flow_control_, stream.get(), peer_settings)
+                  .IsOk());
   EXPECT_EQ(transport_flow_control_.remote_window(), chttp2::kDefaultWindow);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 1000);
 
   // If stream_id == 0, transport flow control window should increase.
   frame.stream_id = 0;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, transport_flow_control_,
-                                              stream.get());
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, transport_flow_control_, stream.get(), peer_settings)
+                  .IsOk());
   EXPECT_EQ(transport_flow_control_.remote_window(),
             chttp2::kDefaultWindow + 1000);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 1000);
@@ -685,14 +694,16 @@ TEST_P(TestsNeedingStreamObjects,
   // layer, we should be graceful with it at this layer.
   frame.increment = 0;
   frame.stream_id = 0;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, transport_flow_control_,
-                                              stream.get());
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, transport_flow_control_, stream.get(), peer_settings)
+                  .IsOk());
   EXPECT_EQ(transport_flow_control_.remote_window(),
             chttp2::kDefaultWindow + 1000);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 1000);
   frame.stream_id = 1;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, transport_flow_control_,
-                                              stream.get());
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, transport_flow_control_, stream.get(), peer_settings)
+                  .IsOk());
   EXPECT_EQ(transport_flow_control_.remote_window(),
             chttp2::kDefaultWindow + 1000);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 1000);
@@ -700,11 +711,32 @@ TEST_P(TestsNeedingStreamObjects,
   // Large increment
   frame.increment = 10000;
   frame.stream_id = 1;
-  ProcessIncomingWindowUpdateFrameFlowControl(frame, transport_flow_control_,
-                                              stream.get());
+  ASSERT_TRUE(ProcessIncomingWindowUpdateFrameFlowControl(
+                  frame, transport_flow_control_, stream.get(), peer_settings)
+                  .IsOk());
   EXPECT_EQ(transport_flow_control_.remote_window(),
             chttp2::kDefaultWindow + 1000);
   EXPECT_EQ(stream->GetStreamFlowControl().remote_window_delta(), 1000 + 10000);
+}
+
+TEST(Http2CommonTransportTest,
+     ProcessIncomingWindowUpdateFrameFlowControlOverflow) {
+  chttp2::TransportFlowControl flow_control(
+      /*peer_name=*/"TestFlowControl", /*enable_bdp_probe=*/false,
+      /*memory_owner=*/nullptr);
+  Http2Settings peer_settings;
+
+  // RFC 9113 section 6.9.1: an update that would push the connection send
+  // window past 2^31-1 is a FLOW_CONTROL_ERROR connection error.
+  Http2WindowUpdateFrame frame;
+  frame.stream_id = 0;
+  frame.increment = 0x7fffffff;
+  auto result = ProcessIncomingWindowUpdateFrameFlowControl(
+      frame, flow_control, /*stream=*/nullptr, peer_settings);
+  ASSERT_FALSE(result.IsOk());
+  EXPECT_EQ(result.GetConnectionErrorCode(), Http2ErrorCode::kFlowControlError);
+  // The window is unchanged by a rejected update.
+  EXPECT_EQ(flow_control.remote_window(), chttp2::kDefaultWindow);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
RFC 9113 §6.9.1: "A sender MUST NOT allow a flow-control window to exceed 2^31-1 octets. If a sender receives a WINDOW_UPDATE that causes a flow-control window to exceed this maximum, it MUST terminate either the stream or the connection, as appropriate" with a FLOW_CONTROL_ERROR.

gRPC's HTTP/2 stack (both legacy CHTTP2 and the promise-based PH2 transport) never enforced this: the 31-bit increment from a peer WINDOW_UPDATE frame is added to the connection/stream send window with no ceiling check. A single `WINDOW_UPDATE(0, 0x7fffffff)` on a fresh connection puts the connection send window at 65535 + 2^31-1 — over the limit — with no error. The team's own TODO acknowledges the gap (`flow_control_manager.h:96`).

Consequences at HEAD:
- gRPC silently authorizes sending beyond the RFC maximum; peers tracking their receive window in int32 see it go negative and must answer FLOW_CONTROL_ERROR against us (interop breakage / forced disconnects from conformant peers).
- Legacy: with ≥2^32 cumulative stream credit, `DataSendContext::stream_remote_window()`'s `uint32_t` view wraps mod 2^32 while the int64 account keeps draining — send-side gating and accounting diverge.
- PH2: an over-limit stream window trips `GRPC_DCHECK` in `GetStreamFlowControlTokens` (`flow_control_manager.h:70-72`) the next time the stream dequeues data — a hard abort in checked/debug builds (and gRPC's own fuzz/ASan CI); in NDEBUG builds the accounting stays silently corrupt.

This PR enforces the ceiling once, in the shared `chttp2` flow-control classes, so both transports inherit it:

1. `TransportFlowControl::OutgoingUpdateContext::RecvUpdate` and
   `StreamFlowControl::OutgoingUpdateContext::RecvUpdate` now return an error if
   the update would push the (effective) window past 2^31-1. The stream check
   evaluates the effective window (peer initial window + delta), matching the
   existing `GetStreamFlowControlTokens` invariant.
2. Legacy CHTTP2: the parse error propagates with `StatusIntProperty::kHttp2Error
   = FLOW_CONTROL_ERROR`; the connection closes (existing parse-error machinery).
3. PH2: `ProcessIncomingWindowUpdateFrameFlowControl` returns
   `ValueOrHttp2Status<bool>` and produces `Http2ConnectionError(kFlowControlError)`,
   mirroring the existing RecvData overflow handling; both client and server
   transports are plumbed.
4. Defense in depth: `TransportFlowControl::target_window()` is clamped to
   [0, 2^31-1]; previously a negative `announced_stream_total_over_incoming_window_`
   would wrap the uint32 cast to ~4GB and make us advertise a huge receive window.

Not in scope (deliberate): a SETTINGS_INITIAL_WINDOW_SIZE increase likewise moves
effective stream windows without a WINDOW_UPDATE (RFC 9113 §6.9.2 interaction);
left for a follow-up. The stream-level overflow is treated as a connection error,
which the RFC permits and which matches PH2's existing strictness for increment==0.

## Evidence

Pre-patch (ASan+UBSan build, aarch64):
- `window_update_overflow_bad_client_test` (legacy CHTTP2 server, raw wire bytes):
  server accepted `WINDOW_UPDATE(0, 0x7fffffff)` silently and kept the connection
  open (test: "server did not close the connection").
- `http2_client_transport_test` (PH2 client, mock endpoint): after the same frame,
  `TestOnlyTransportFlowControlWindow()` = 2147549182 > 2^31-1, no error, no GOAWAY.
- The flow-control classes had zero test coverage of RecvUpdate at all
  (grep-confirmed in `flow_control_test.cc`).

Post-patch: all new and existing tests pass; zero UBSan reports.

## Tests

- `flow_control_test.cc`: `TransportRecvUpdateBeyondMaxWindowIsError`,
  `StreamRecvUpdateBeyondMaxWindowIsError` (at-limit accepted, one-byte-over
  rejected, window unchanged after rejection, max peer-initial-window edge).
- `http2_transport_test.cc`: `ProcessIncomingWindowUpdateFrameFlowControlOverflow`
  (unit: connection error code + unchanged window); existing RecvUpdate callers
  updated for the new signatures.
- `http2_client_transport_test.cc`:
  `WindowUpdateOverflowingWindowIsConnectionError` (PH2 wire level: FLOW_CONTROL_ERROR
  GOAWAY on the wire, window stays in range).
- `bad_client/window_update_overflow.cc` (new): legacy wire level — server closes
  the connection on the overflow while the client stays connected.
- `flow_control_manager_test.cc`: updated for the signature change.

Sweeps: `bazel test //test/core/transport/chttp2/...` + bad_client under
ASan+UBSan — all green.
