### PR TITLE
[Python] Unpin Cython dependency for source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@
 requires = [
     "setuptools>=77.0.1",
     "wheel",
-    "cython==3.1.1"
+    # 3.1.0 has async memory leak https://github.com/cython/cython/issues/6878
+    "Cython~=3.1,!=3.1.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -578,7 +578,8 @@ except ImportError:
         sys.stderr.write(
             "We could not find Cython. Setup may take 10-20 minutes.\n"
         )
-        SETUP_REQUIRES += ("cython==3.1.1",)
+        # 3.1.0 has async memory leak https://github.com/cython/cython/issues/6878
+        SETUP_REQUIRES += ("cython~=3.1,!=3.1.0",)
 
 COMMAND_CLASS = {
     "doc": commands.SphinxDocumentation,

--- a/src/python/grpcio_observability/pyproject.toml
+++ b/src/python/grpcio_observability/pyproject.toml
@@ -16,7 +16,8 @@
 requires = [
     "setuptools>=77.0.1",
     "wheel",
-    "Cython==3.1.1",
+    # 3.1.0 has async memory leak https://github.com/cython/cython/issues/6878
+    "Cython~=3.1,!=3.1.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tools/distrib/python/grpcio_tools/pyproject.toml
+++ b/tools/distrib/python/grpcio_tools/pyproject.toml
@@ -16,7 +16,8 @@
 requires = [
     "setuptools>=77.0.1",
     "wheel",
-    "Cython==3.1.1",
+    # 3.1.0 has async memory leak https://github.com/cython/cython/issues/6878
+    "Cython~=3.1,!=3.1.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Relaxes the Cython pin for source builds from `3.1.1` to `3.x`, while still requiring `>=3.1.1`.

Fixes #41582.
