### PR TITLE
[security] Close remaining shutdown races in secure endpoints

### DIFF
--- a/src/core/handshaker/security/pipelined_secure_endpoint.cc
+++ b/src/core/handshaker/security/pipelined_secure_endpoint.cc
@@ -639,28 +639,37 @@ class PipelinedSecureEndpoint final : public EventEngine::Endpoint {
       tsi_result result;
       frame_protector_.TraceOp("Write", data->c_slice_buffer());
       {
-        grpc_core::MutexLock lock(frame_protector_.write_mu());
+        grpc_core::ReleasableMutexLock lock(frame_protector_.write_mu());
         result = frame_protector_.Protect(data->c_slice_buffer(),
                                           args.max_frame_size());
+        if (result != TSI_OK) {
+          lock.Release();
+          event_engine_->Run(
+              [on_writable = std::move(on_writable), result]() mutable {
+                on_writable(GRPC_ERROR_CREATE(absl::StrCat(
+                    "Wrap failed (", tsi_result_to_string(result), ")")));
+              });
+          return false;
+        }
+        // If the endpoint shut down whilst protecting, fail out the write.
+        if (wrapped_ep_ == nullptr) {
+          lock.Release();
+          event_engine_->Run([on_writable = std::move(on_writable)]() mutable {
+            on_writable(absl::CancelledError("secure endpoint shutdown"));
+          });
+          return false;
+        }
+        on_write_ = std::move(on_writable);
+        frame_protector_.TraceOp(
+            "Write", frame_protector_.output_buffer()->c_slice_buffer());
+        return wrapped_ep_->Write(
+            [impl = Ref()](absl::Status status) mutable {
+              auto on_write = std::move(impl->on_write_);
+              impl.reset();
+              on_write(status);
+            },
+            frame_protector_.output_buffer(), std::move(args));
       }
-      if (result != TSI_OK) {
-        event_engine_->Run(
-            [on_writable = std::move(on_writable), result]() mutable {
-              on_writable(GRPC_ERROR_CREATE(absl::StrCat(
-                  "Wrap failed (", tsi_result_to_string(result), ")")));
-            });
-        return false;
-      }
-      on_write_ = std::move(on_writable);
-      frame_protector_.TraceOp(
-          "Write", frame_protector_.output_buffer()->c_slice_buffer());
-      return wrapped_ep_->Write(
-          [impl = Ref()](absl::Status status) mutable {
-            auto on_write = std::move(impl->on_write_);
-            impl.reset();
-            on_write(status);
-          },
-          frame_protector_.output_buffer(), std::move(args));
     }
 
     const EventEngine::ResolvedAddress& GetPeerAddress() const {

--- a/src/core/handshaker/security/secure_endpoint.cc
+++ b/src/core/handshaker/security/secure_endpoint.cc
@@ -775,10 +775,12 @@ static void endpoint_write(
 
 static void endpoint_destroy(grpc_endpoint* secure_ep) {
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);
+  ep->frame_protector.write_mu()->Lock();
   ep->frame_protector.read_mu()->Lock();
   ep->wrapped_ep.reset();
   ep->frame_protector.Shutdown();
   ep->frame_protector.read_mu()->Unlock();
+  ep->frame_protector.write_mu()->Unlock();
   SECURE_ENDPOINT_UNREF(ep, "destroy");
 }
 
@@ -1054,28 +1056,37 @@ class SecureEndpoint final : public EventEngine::Endpoint,
       }
       // A small write: encrypt inline and write to the socket.
       {
-        grpc_core::MutexLock lock(frame_protector_.write_mu());
+        grpc_core::ReleasableMutexLock lock(frame_protector_.write_mu());
         result = frame_protector_.Protect(data->c_slice_buffer(),
                                           args.max_frame_size());
+        if (result != TSI_OK) {
+          lock.Release();
+          event_engine_->Run(
+              [on_writable = std::move(on_writable), result]() mutable {
+                on_writable(GRPC_ERROR_CREATE(absl::StrCat(
+                    "Wrap failed (", tsi_result_to_string(result), ")")));
+              });
+          return false;
+        }
+        // If the endpoint shut down whilst protecting, fail out the write.
+        if (wrapped_ep_ == nullptr) {
+          lock.Release();
+          event_engine_->Run([on_writable = std::move(on_writable)]() mutable {
+            on_writable(absl::CancelledError("secure endpoint shutdown"));
+          });
+          return false;
+        }
+        on_write_ = std::move(on_writable);
+        frame_protector_.TraceOp(
+            "Write", frame_protector_.output_buffer()->c_slice_buffer());
+        return wrapped_ep_->Write(
+            [impl = Ref()](absl::Status status) mutable {
+              auto on_write = std::move(impl->on_write_);
+              impl.reset();
+              on_write(status);
+            },
+            frame_protector_.output_buffer(), std::move(args));
       }
-      if (result != TSI_OK) {
-        event_engine_->Run(
-            [on_writable = std::move(on_writable), result]() mutable {
-              on_writable(GRPC_ERROR_CREATE(absl::StrCat(
-                  "Wrap failed (", tsi_result_to_string(result), ")")));
-            });
-        return false;
-      }
-      on_write_ = std::move(on_writable);
-      frame_protector_.TraceOp(
-          "Write", frame_protector_.output_buffer()->c_slice_buffer());
-      return wrapped_ep_->Write(
-          [impl = Ref()](absl::Status status) mutable {
-            auto on_write = std::move(impl->on_write_);
-            impl.reset();
-            on_write(status);
-          },
-          frame_protector_.output_buffer(), std::move(args));
     }
 
     const EventEngine::ResolvedAddress& GetPeerAddress() const {
@@ -1112,6 +1123,7 @@ class SecureEndpoint final : public EventEngine::Endpoint,
       std::unique_ptr<EventEngine::Endpoint> wrapped_ep;
       grpc_core::MutexLock write_lock(frame_protector_.write_mu());
       grpc_core::MutexLock read_lock(frame_protector_.read_mu());
+      grpc_core::MutexLock shutdown_read_lock(&shutdown_read_mu_);
       wrapped_ep = std::move(wrapped_ep_);
       frame_protector_.Shutdown();
       GRPC_TRACE_LOG(secure_endpoint, INFO)
@@ -1246,13 +1258,22 @@ class SecureEndpoint final : public EventEngine::Endpoint,
         // Otherwise, we need to read more data from the underlying endpoint.
         ReadArgs args = read_args_;
         args.set_read_hint_bytes(frame_protector_.min_progress_size());
-        bool read_completed_immediately = wrapped_ep_->Read(
-            [impl = Ref()](absl::Status status) mutable {
-              grpc_core::ExecCtx exec_ctx;
-              impl->ContinueRead(/*is_initial_call=*/false,
-                                 /*status=*/std::move(status));
-            },
-            frame_protector_.source_buffer(), args);
+        bool read_completed_immediately;
+        {
+          // Serialize the null check against Shutdown: the endpoint is torn
+          // down under shutdown_read_mu_ (see Shutdown), and EventEngine
+          // guarantees the read callback is never invoked inline from Read,
+          // so holding this mutex across the call is safe.
+          grpc_core::MutexLock shutdown_lock(&shutdown_read_mu_);
+          if (wrapped_ep_ == nullptr) continue;
+          read_completed_immediately = wrapped_ep_->Read(
+              [impl = Ref()](absl::Status status) mutable {
+                grpc_core::ExecCtx exec_ctx;
+                impl->ContinueRead(/*is_initial_call=*/false,
+                                   /*status=*/std::move(status));
+              },
+              frame_protector_.source_buffer(), args);
+        }
         if (!read_completed_immediately) return false;
       }
     }
@@ -1354,6 +1375,11 @@ class SecureEndpoint final : public EventEngine::Endpoint,
     ReadArgs read_args_;
     absl::AnyInvocable<void(absl::Status)> on_write_;
     std::unique_ptr<EventEngine::Endpoint> wrapped_ep_;
+    // Serializes the read-start null check against Shutdown so that a read
+    // cannot be issued on the wrapped endpoint after it is torn down. The
+    // read callbacks never take this mutex, so it can be held across the
+    // wrapped Read call.
+    grpc_core::Mutex shutdown_read_mu_;
     std::shared_ptr<EventEngine> event_engine_;
     const size_t large_read_threshold_;
     const size_t large_write_threshold_;

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -205,6 +205,30 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "secure_endpoint_shutdown_race_test",
+    srcs = ["secure_endpoint_shutdown_race_test.cc"],
+    external_deps = [
+        "absl/status",
+        "absl/synchronization",
+        "gtest",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc_security_base",
+        "//:iomgr",
+        "//:orphanable",
+        "//:tsi_base",
+        "//:tsi_fake_credentials",
+        "//src/core:channel_args",
+        "//src/core:default_event_engine",
+        "//src/core:experiments",
+        "//src/core:resource_quota",
+        "//test/core/test_util:grpc_test_util_base",
+    ],
+)
+
+grpc_cc_test(
     name = "secure_endpoint_read_coalescing_test",
     srcs = ["secure_endpoint_read_coalescing_test.cc"],
     external_deps = [

--- a/test/core/handshake/secure_endpoint_shutdown_race_test.cc
+++ b/test/core/handshake/secure_endpoint_shutdown_race_test.cc
@@ -1,0 +1,157 @@
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/event_engine/slice.h>
+#include <grpc/event_engine/slice_buffer.h>
+#include <grpc/grpc.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "src/core/handshaker/security/secure_endpoint.h"
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/event_engine/extensions/receive_coalescing_extension.h"
+#include "src/core/lib/event_engine/query_extensions.h"
+#include "src/core/lib/experiments/config.h"
+#include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/iomgr/event_engine_shims/endpoint.h"
+#include "src/core/lib/resource_quota/resource_quota.h"
+#include "src/core/tsi/fake_transport_security.h"
+#include "src/core/tsi/transport_security_interface.h"
+#include "src/core/util/orphanable.h"
+#include "test/core/test_util/mock_endpoint.h"
+#include "gtest/gtest.h"
+#include "absl/synchronization/notification.h"
+
+using grpc_event_engine::experimental::EventEngine;
+using grpc_event_engine::experimental::MockEndpointController;
+
+namespace grpc_core {
+namespace {
+
+// Protects a message with a fake frame protector so that it can be fed to the
+// secure endpoint as if it arrived on the wire.
+std::string ProtectFrame(tsi_frame_protector* protector,
+                         const std::string& plaintext) {
+  std::string result;
+  const unsigned char* msg =
+      reinterpret_cast<const unsigned char*>(plaintext.data());
+  size_t msg_len = plaintext.size();
+  while (msg_len > 0) {
+    unsigned char buf[4096];
+    size_t processed_msg_size = msg_len;
+    size_t protected_buf_size = sizeof(buf);
+    tsi_result res = tsi_frame_protector_protect(
+        protector, msg, &processed_msg_size, buf, &protected_buf_size);
+    EXPECT_EQ(res, TSI_OK);
+    if (res != TSI_OK) break;
+    result.append(reinterpret_cast<char*>(buf), protected_buf_size);
+    msg += processed_msg_size;
+    msg_len -= processed_msg_size;
+  }
+  size_t still_pending = 0;
+  do {
+    unsigned char buf[4096];
+    size_t protected_buf_size = sizeof(buf);
+    tsi_result res = tsi_frame_protector_protect_flush(
+        protector, buf, &protected_buf_size, &still_pending);
+    EXPECT_EQ(res, TSI_OK);
+    if (res != TSI_OK) break;
+    result.append(reinterpret_cast<char*>(buf), protected_buf_size);
+  } while (still_pending > 0);
+  return result;
+}
+
+class SecureEndpointShutdownRaceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    engine_ = grpc_event_engine::experimental::GetDefaultEventEngine();
+    mock_ctrl_ = MockEndpointController::Create(engine_);
+    fake_protector_ = tsi_create_fake_frame_protector(nullptr);
+    fake_protector_for_encryption_ = tsi_create_fake_frame_protector(nullptr);
+    ChannelArgs args = ChannelArgs().SetObject(ResourceQuota::Default());
+    grpc_endpoint* wrapped_mock_ep = mock_ctrl_->TakeCEndpoint();
+    auto secure_ep = grpc_secure_endpoint_create(
+        fake_protector_, nullptr, OrphanablePtr<grpc_endpoint>(wrapped_mock_ep),
+        nullptr, 0, args);
+    secure_ep_ = grpc_event_engine::experimental::
+        grpc_take_wrapped_event_engine_endpoint(secure_ep.release());
+    auto* ext = grpc_event_engine::experimental::QueryExtension<
+        grpc_event_engine::experimental::ReceiveCoalescingExtension>(
+        secure_ep_.get());
+    ASSERT_NE(ext, nullptr);
+    ext->EnableRpcReceiveCoalescing();
+  }
+
+  void TearDown() override {
+    secure_ep_.reset();
+    tsi_frame_protector_destroy(fake_protector_for_encryption_);
+  }
+
+  std::shared_ptr<EventEngine> engine_;
+  std::shared_ptr<MockEndpointController> mock_ctrl_;
+  tsi_frame_protector* fake_protector_;  // owned by secure_ep_
+  tsi_frame_protector* fake_protector_for_encryption_;
+  std::unique_ptr<EventEngine::Endpoint> secure_ep_;
+};
+
+// A read that is being re-armed when the endpoint is shut down must complete
+// with an error rather than racing the teardown. The read machinery
+// (ContinueRead) re-arms reads from read callbacks running on event engine
+// threads while the test thread destroys the endpoint; with receive coalescing
+// enabled and a hint larger than any single frame, the read keeps accumulating
+// and re-arming until shutdown.
+TEST_F(SecureEndpointShutdownRaceTest, ReadRacingShutdownCompletesWithError) {
+  absl::Notification read_done;
+  absl::Status read_status;
+  grpc_event_engine::experimental::SliceBuffer read_buffer;
+  EventEngine::Endpoint::ReadArgs args;
+  args.set_read_hint_bytes(1 << 20);
+  secure_ep_->Read(
+      [&read_done, &read_status](absl::Status s) {
+        read_status = s;
+        read_done.Notify();
+      },
+      &read_buffer, args);
+  // Keep the read loop busy re-arming reads, then destroy the endpoint in the
+  // middle of it.
+  std::thread feeder([&]() {
+    for (int i = 0; i < 100000; ++i) {
+      mock_ctrl_->TriggerReadEvent(
+          grpc_event_engine::experimental::Slice::FromCopiedString(
+              ProtectFrame(fake_protector_for_encryption_, "payload")));
+    }
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  secure_ep_.reset();
+  ASSERT_TRUE(read_done.WaitForNotificationWithTimeout(absl::Seconds(30)));
+  EXPECT_FALSE(read_status.ok());
+  feeder.join();
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  grpc_core::ForceEnableExperiment("secure_endpoint_read_coalescing", true);
+  ::testing::InitGoogleTest(&argc, argv);
+  // Must call to create default EventEngine.
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
+}


### PR DESCRIPTION
`secure_endpoint.cc` and `pipelined_secure_endpoint.cc` have each been patched repeatedly (2eca2927f3, 45156d1719, 65fbb87983, 01fa65c4a0, 5d149e33dc, 983be72ae6) for one shape: Protect/Unprotect/read/write activity running after `Shutdown()` tears down the wrapped endpoint or the frame protector's memory owner. Each fix armed one instance; this change closes the remaining un-armed instances of the same shape.

## Fixes

**Read path — check-then-use across `Shutdown` (EE impl).** `SecureEndpoint::Impl::ContinueRead` checked `wrapped_ep_ == nullptr` under `read_mu`, released it, and only later called `wrapped_ep_->Read(...)`. `Impl::Shutdown()` (run from the destructor) takes `write_mu`+`read_mu` and moves `wrapped_ep_` out, so teardown could interpose between the check and the read. The pipelined implementation closed the equivalent gap in 983be72ae6 with a dedicated `shutdown_read_mu_` held across check-and-read; the EE implementation never got the equivalent. It now has one: `shutdown_read_mu_` is held from the null check through the wrapped `Read` call, and `Shutdown()` acquires it in the same write→read→shutdown_read order as the pipelined impl. EventEngine guarantees read callbacks are never invoked inline from `Read`, and the callback path never takes `shutdown_read_mu_`, so holding it across the call cannot deadlock.

Verified with ThreadSanitizer: a new test (`secure_endpoint_shutdown_race_test`) enables receive coalescing with a read hint larger than any fed frame so the read machinery continuously re-arms, destroys the endpoint mid-loop, and TSan reports a data race pre-patch (`Impl::ContinueRead` → `MockEndpoint::Read` racing `Impl::Shutdown` → `~MockEndpoint`, "data race in free") and is clean post-patch.

**Write path — guard both small-write paths.** The async write path has checked `wrapped_ep_ == nullptr` under `write_mu` before writing since 65fbb87983; the inline small-write paths did not: `SecureEndpoint::Impl::Write` and `PipelinedSecureEndpoint::Impl::Write` released `write_mu` after `Protect` and then dereferenced `wrapped_ep_` unlocked. Both now hold `write_mu` across Protect, the null check, and the wrapped `Write` call, failing the write with `CancelledError("secure endpoint shutdown")` if teardown won the race — the same failure mode the async path already uses.

**Legacy impl — destroy now takes `write_mu`.** The legacy `endpoint_destroy` reset the wrapped endpoint and shut down the frame protector under `read_mu` only, while `Protect` (and the `shutdown_` flag read added by 5d149e33dc) runs under `write_mu`. The EE `Shutdown()` takes both mutexes; the legacy destroy now takes them in the same order (write→read), so `memory_owner_.Reset()` can no longer race a concurrent `Protect`.

## Tests

- `test/core/handshake/secure_endpoint_shutdown_race_test.cc` (new): `ReadRacingShutdownCompletesWithError` — TSan reproducer described above.
- Existing `secure_endpoint_read_coalescing_test` and the `//test/core/handshake/...` suite pass under ASan+UBSan with these changes.

## Notes

- Lock-ordering: write→read→shutdown_read everywhere; consistent with the pipelined impl's existing annotations.
- No public API or wire-behavior change; all new failure paths deliver the same `CancelledError("secure endpoint shutdown")` the existing guards use.
