### PR TITLE
[Ruby] Add support for pre releases for nativedebug gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -287,7 +287,7 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
   gems_by_version = gem_files.group_by do |path|
     full_version = Gem::Package.new(path).spec.version.to_s
-    match = full_version.match(/^(\d+\.\d+\.\d+)/)
+    match = full_version.match(/^(\d+\.\d+\.\d+(?:\.pre\d+)?)/)
     fail "Unexpected version format: #{full_version}" unless match
     match[1]
   rescue StandardError => e

--- a/src/ruby/nativedebug/README.md
+++ b/src/ruby/nativedebug/README.md
@@ -19,11 +19,11 @@ for example, a lot of information will initially be missing.
 
 ## Download Location
 
-**Version 1.79.0 and above**: Download from GCS (exceeds RubyGems 500MB limit)
+**Version 1.84.0.pre1 and above**: Download from GCS (exceeds RubyGems 500MB limit)
 
 ```bash
-VERSION=1.79.0  # your grpc version
-PLATFORM=x86_64-linux  # or x86-linux
+VERSION=1.84.0.pre1  # your grpc version
+PLATFORM=x86_64-linux-gnu  # or x86-linux-gnu
 
 # Download gem
 wget https://storage.googleapis.com/packages.grpc.io/grpc-ruby-native-debug-symbols/v${VERSION}/grpc-native-debug-${VERSION}-${PLATFORM}.gem


### PR DESCRIPTION
Fixes pre release version naming for releasing native debug rubygems

