### PR TITLE
 Secure-by-design memory safety for HTTP/2 wire protocol parsing

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5187,6 +5187,7 @@ grpc_cc_library(
         "//src/core:transport_framing_endpoint_extension",
         "//src/core:useful",
         "//src/core:write_size_policy",
+        "//src/core:byte_source",
         "//src/proto/grpc/channelz/v2:promise_upb_proto",
         "@com_google_protobuf//upb/mem",
     ],

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3561,6 +3561,20 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "byte_source",
+    hdrs = [
+        "lib/slice/byte_source.h",
+    ],
+    external_deps = [
+        "absl/types:span",
+    ],
+    deps = [
+        "slice",
+        "//:gpr",
+    ],
+)
+
+grpc_cc_library(
     name = "percent_encoding",
     srcs = [
         "lib/slice/percent_encoding.cc",

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -70,9 +70,6 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
   grpc_chttp2_goaway_parser* p =
       static_cast<grpc_chttp2_goaway_parser*>(parser);
 
-  // Secure-by-design: parse GOAWAY through a bounds-checked cursor to prevent
-  // out-of-bounds reads on malformed frames. The frame has an 8-byte header
-  // (4-byte last_stream_id + 4-byte error_code) followed by debug data.
   grpc_core::ByteSource src(slice);
 
   switch (p->state) {

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/slice/byte_source.h"
 #include "src/core/util/grpc_check.h"
 #include "absl/base/attributes.h"
 #include "absl/status/status.h"
@@ -66,83 +67,89 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
                                                   grpc_chttp2_stream* /*s*/,
                                                   const grpc_slice& slice,
                                                   int is_last) {
-  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  const uint8_t* cur = beg;
   grpc_chttp2_goaway_parser* p =
       static_cast<grpc_chttp2_goaway_parser*>(parser);
 
+  // Secure-by-design: parse GOAWAY through a bounds-checked cursor to prevent
+  // out-of-bounds reads on malformed frames. The frame has an 8-byte header
+  // (4-byte last_stream_id + 4-byte error_code) followed by debug data.
+  grpc_core::ByteSource src(slice);
+
   switch (p->state) {
     case GRPC_CHTTP2_GOAWAY_LSI0:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->last_stream_id = static_cast<uint32_t>(*v) << 24;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_LSI0;
         return absl::OkStatus();
       }
-      p->last_stream_id = (static_cast<uint32_t>(*cur)) << 24;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_LSI1:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->last_stream_id |= static_cast<uint32_t>(*v) << 16;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_LSI1;
         return absl::OkStatus();
       }
-      p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 16;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_LSI2:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->last_stream_id |= static_cast<uint32_t>(*v) << 8;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_LSI2;
         return absl::OkStatus();
       }
-      p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 8;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_LSI3:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->last_stream_id |= static_cast<uint32_t>(*v);
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_LSI3;
         return absl::OkStatus();
       }
-      p->last_stream_id |= (static_cast<uint32_t>(*cur));
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_ERR0:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->error_code = static_cast<uint32_t>(*v) << 24;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_ERR0;
         return absl::OkStatus();
       }
-      p->error_code = (static_cast<uint32_t>(*cur)) << 24;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_ERR1:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->error_code |= static_cast<uint32_t>(*v) << 16;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_ERR1;
         return absl::OkStatus();
       }
-      p->error_code |= (static_cast<uint32_t>(*cur)) << 16;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_ERR2:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->error_code |= static_cast<uint32_t>(*v) << 8;
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_ERR2;
         return absl::OkStatus();
       }
-      p->error_code |= (static_cast<uint32_t>(*cur)) << 8;
-      ++cur;
       [[fallthrough]];
     case GRPC_CHTTP2_GOAWAY_ERR3:
-      if (cur == end) {
+      if (auto v = src.ReadU8()) {
+        p->error_code |= static_cast<uint32_t>(*v);
+      } else {
         p->state = GRPC_CHTTP2_GOAWAY_ERR3;
         return absl::OkStatus();
       }
-      p->error_code |= (static_cast<uint32_t>(*cur));
-      ++cur;
       [[fallthrough]];
-    case GRPC_CHTTP2_GOAWAY_DEBUG:
+    case GRPC_CHTTP2_GOAWAY_DEBUG: {
+      size_t debug_remaining = src.remaining();
       if (grpc_core::IsPh2Perf01Enabled()) {
-        if (end != cur) {
-          p->debug_slice_buffer.AppendIndexed(
-              grpc_core::Slice::FromCopiedBuffer(
-                  cur, static_cast<size_t>(end - cur)));
+        if (debug_remaining > 0) {
+          auto sp = src.ReadSpan(debug_remaining);
+          if (sp.has_value()) {
+            p->debug_slice_buffer.AppendIndexed(
+                grpc_core::Slice::FromCopiedBuffer(
+                    reinterpret_cast<const char*>(sp->data()), sp->size()));
+          }
         }
         GRPC_CHECK(p->debug_slice_buffer.Length() <= p->debug_length);
         p->state = GRPC_CHTTP2_GOAWAY_DEBUG;
@@ -161,12 +168,14 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
           p->debug_slice_buffer.Clear();
         }
       } else {
-        if (end != cur) {
-          memcpy(p->debug_data + p->debug_pos, cur,
-                 static_cast<size_t>(end - cur));
+        if (debug_remaining > 0) {
+          auto sp = src.ReadSpan(debug_remaining);
+          if (sp.has_value()) {
+            memcpy(p->debug_data + p->debug_pos, sp->data(), sp->size());
+          }
         }
-        GRPC_CHECK((size_t)(end - cur) < UINT32_MAX - p->debug_pos);
-        p->debug_pos += static_cast<uint32_t>(end - cur);
+        GRPC_CHECK(debug_remaining < UINT32_MAX - p->debug_pos);
+        p->debug_pos += static_cast<uint32_t>(debug_remaining);
         p->state = GRPC_CHTTP2_GOAWAY_DEBUG;
         if (is_last) {
           t->http2_ztrace_collector.Append([p]() {
@@ -182,6 +191,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
         }
       }
       return absl::OkStatus();
+    }
   }
   GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE("Should never reach here"));
 }

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -24,11 +24,13 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cstdint>
 
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/ext/transport/chttp2/transport/ping_abuse_policy.h"
 #include "src/core/ext/transport/chttp2/transport/ping_callbacks.h"
 #include "src/core/lib/debug/trace.h"
+#include "src/core/lib/slice/byte_source.h"
 #include "src/core/util/grpc_check.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
@@ -37,26 +39,16 @@
 
 grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
   grpc_slice slice = GRPC_SLICE_MALLOC(9 + 8);
-  uint8_t* p = GRPC_SLICE_START_PTR(slice);
-
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = 8;
-  *p++ = GRPC_CHTTP2_FRAME_PING;
-  *p++ = ack ? 1 : 0;
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 56);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 48);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 40);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 32);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 24);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 16);
-  *p++ = static_cast<uint8_t>(opaque_8bytes >> 8);
-  *p++ = static_cast<uint8_t>(opaque_8bytes);
-
+  // Secure-by-design: serialize through a bounds-checked sink so the frame
+  // can never overflow its allocated slice.
+  grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
+                           GRPC_SLICE_LENGTH(slice));
+  GRPC_CHECK(sink.WriteU24BE(8));
+  GRPC_CHECK(sink.WriteU8(GRPC_CHTTP2_FRAME_PING));
+  GRPC_CHECK(sink.WriteU8(ack ? 1 : 0));
+  GRPC_CHECK(sink.Skip(4));  // stream id = 0
+  GRPC_CHECK(sink.WriteU64BE(opaque_8bytes));
+  GPR_ASSERT(sink.empty());
   return slice;
 }
 
@@ -77,15 +69,17 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
                                                 grpc_chttp2_stream* /*s*/,
                                                 const grpc_slice& slice,
                                                 int is_last) {
-  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  const uint8_t* cur = beg;
   grpc_chttp2_ping_parser* p = static_cast<grpc_chttp2_ping_parser*>(parser);
 
-  while (p->byte != 8 && cur != end) {
-    p->opaque_8bytes |= ((static_cast<uint64_t>(*cur)) << (56 - 8 * p->byte));
-    cur++;
-    p->byte++;
+  // Secure-by-design: accumulate the 8-byte opaque ping value through a
+  // bounds-checked cursor so a malformed or truncated frame can never read
+  // past the slice boundary.
+  grpc_core::ByteSource src(slice);
+  while (p->byte != 8) {
+    auto v = src.ReadU8();
+    if (!v.has_value()) break;
+    p->opaque_8bytes |= (static_cast<uint64_t>(*v) << (56 - 8 * p->byte));
+    ++p->byte;
   }
 
   if (p->byte == 8) {

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -39,8 +39,6 @@
 
 grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
   grpc_slice slice = GRPC_SLICE_MALLOC(9 + 8);
-  // Secure-by-design: serialize through a bounds-checked sink so the frame
-  // can never overflow its allocated slice.
   grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
                            GRPC_SLICE_LENGTH(slice));
   GRPC_CHECK(sink.WriteU24BE(8));
@@ -48,7 +46,7 @@ grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
   GRPC_CHECK(sink.WriteU8(ack ? 1 : 0));
   GRPC_CHECK(sink.Skip(4));  // stream id = 0
   GRPC_CHECK(sink.WriteU64BE(opaque_8bytes));
-  GPR_ASSERT(sink.empty());
+  GRPC_CHECK(sink.empty());
   return slice;
 }
 
@@ -71,9 +69,6 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
                                                 int is_last) {
   grpc_chttp2_ping_parser* p = static_cast<grpc_chttp2_ping_parser*>(parser);
 
-  // Secure-by-design: accumulate the 8-byte opaque ping value through a
-  // bounds-checked cursor so a malformed or truncated frame can never read
-  // past the slice boundary.
   grpc_core::ByteSource src(slice);
   while (p->byte != 8) {
     auto v = src.ReadU8();

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -22,6 +22,8 @@
 #include <grpc/support/port_platform.h>
 #include <stddef.h>
 
+#include <cstdint>
+
 #include "src/core/call/metadata_batch.h"
 #include "src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h"
 #include "src/core/ext/transport/chttp2/transport/http2_status.h"
@@ -30,6 +32,7 @@
 #include "src/core/ext/transport/chttp2/transport/ping_callbacks.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/experiments/experiments.h"
+#include "src/core/lib/slice/byte_source.h"
 #include "src/core/util/grpc_check.h"
 #include "src/core/util/shared_bit_gen.h"
 #include "src/core/util/status_helper.h"
@@ -50,26 +53,17 @@ grpc_slice grpc_chttp2_rst_stream_create(
     call_tracer->RecordOutgoingBytes({frame_size, 0, 0});
   }
   ztrace_collector->Append(grpc_core::H2RstStreamTrace<false>{id, code});
-  uint8_t* p = GRPC_SLICE_START_PTR(slice);
 
-  // Frame size.
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = 4;
-  // Frame type.
-  *p++ = GRPC_CHTTP2_FRAME_RST_STREAM;
-  // Flags.
-  *p++ = 0;
-  // Stream ID.
-  *p++ = static_cast<uint8_t>(id >> 24);
-  *p++ = static_cast<uint8_t>(id >> 16);
-  *p++ = static_cast<uint8_t>(id >> 8);
-  *p++ = static_cast<uint8_t>(id);
-  // Error code.
-  *p++ = static_cast<uint8_t>(code >> 24);
-  *p++ = static_cast<uint8_t>(code >> 16);
-  *p++ = static_cast<uint8_t>(code >> 8);
-  *p++ = static_cast<uint8_t>(code);
+  // Secure-by-design: serialize through a bounds-checked sink so the frame
+  // can never overflow its allocated slice.
+  grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
+                           GRPC_SLICE_LENGTH(slice));
+  GRPC_CHECK(sink.WriteU24BE(4));
+  GRPC_CHECK(sink.WriteU8(GRPC_CHTTP2_FRAME_RST_STREAM));
+  GRPC_CHECK(sink.WriteU8(0));  // flags
+  GRPC_CHECK(sink.WriteU32BE(id));
+  GRPC_CHECK(sink.WriteU32BE(code));
+  GPR_ASSERT(sink.empty());
 
   return slice;
 }
@@ -103,18 +97,20 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
                                                       grpc_chttp2_stream* s,
                                                       const grpc_slice& slice,
                                                       int is_last) {
-  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  const uint8_t* cur = beg;
   grpc_chttp2_rst_stream_parser* p =
       static_cast<grpc_chttp2_rst_stream_parser*>(parser);
 
-  while (p->byte != 4 && cur != end) {
-    p->reason_bytes[p->byte] = *cur;
-    cur++;
-    p->byte++;
+  // Secure-by-design: accumulate the 4-byte RST_STREAM error code through a
+  // bounds-checked cursor so a malformed or truncated frame can never read
+  // past the slice boundary.
+  grpc_core::ByteSource src(slice);
+  while (p->byte != 4) {
+    auto v = src.ReadU8();
+    if (!v.has_value()) break;
+    p->reason_bytes[p->byte] = *v;
+    ++p->byte;
   }
-  uint64_t framing_bytes = static_cast<uint64_t>(end - cur);
+  uint64_t framing_bytes = src.remaining();
   s->call_tracer_wrapper.RecordIncomingBytes({framing_bytes, 0, 0});
 
   if (p->byte == 4) {

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -54,8 +54,6 @@ grpc_slice grpc_chttp2_rst_stream_create(
   }
   ztrace_collector->Append(grpc_core::H2RstStreamTrace<false>{id, code});
 
-  // Secure-by-design: serialize through a bounds-checked sink so the frame
-  // can never overflow its allocated slice.
   grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
                            GRPC_SLICE_LENGTH(slice));
   GRPC_CHECK(sink.WriteU24BE(4));
@@ -63,7 +61,7 @@ grpc_slice grpc_chttp2_rst_stream_create(
   GRPC_CHECK(sink.WriteU8(0));  // flags
   GRPC_CHECK(sink.WriteU32BE(id));
   GRPC_CHECK(sink.WriteU32BE(code));
-  GPR_ASSERT(sink.empty());
+  GRPC_CHECK(sink.empty());
 
   return slice;
 }
@@ -100,9 +98,6 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
   grpc_chttp2_rst_stream_parser* p =
       static_cast<grpc_chttp2_rst_stream_parser*>(parser);
 
-  // Secure-by-design: accumulate the 4-byte RST_STREAM error code through a
-  // bounds-checked cursor so a malformed or truncated frame can never read
-  // past the slice boundary.
   grpc_core::ByteSource src(slice);
   while (p->byte != 4) {
     auto v = src.ReadU8();

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -22,6 +22,7 @@
 #include <grpc/support/port_platform.h>
 #include <string.h>
 
+#include <cstdint>
 #include <string>
 
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
@@ -32,6 +33,7 @@
 #include "src/core/ext/transport/chttp2/transport/legacy_frame.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/slice/byte_source.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/telemetry/stats.h"
 #include "src/core/util/debug_location.h"
@@ -91,8 +93,6 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
                                                     int is_last) {
   grpc_chttp2_settings_parser* parser =
       static_cast<grpc_chttp2_settings_parser*>(p);
-  const uint8_t* cur = GRPC_SLICE_START_PTR(slice);
-  const uint8_t* end = GRPC_SLICE_END_PTR(slice);
 
   if (parser->is_ack) {
     t->http2_ztrace_collector.Append(
@@ -100,10 +100,15 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
     return absl::OkStatus();
   }
 
+  // Secure-by-design: parse SETTINGS frame through a bounds-checked cursor
+  // so malformed frames (truncated IDs/values) can never overrun the slice.
+  grpc_core::ByteSource src(slice);
+
   for (;;) {
     switch (parser->state) {
-      case GRPC_CHTTP2_SPS_ID0:
-        if (cur == end) {
+      case GRPC_CHTTP2_SPS_ID0: {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_ID0;
           if (is_last) {
             grpc_core::Http2Settings* target_settings =
@@ -148,50 +153,52 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
           }
           return absl::OkStatus();
         }
-        parser->id = static_cast<uint16_t>((static_cast<uint16_t>(*cur)) << 8);
-        cur++;
+        parser->id = static_cast<uint16_t>(*v) << 8;
         [[fallthrough]];
-      case GRPC_CHTTP2_SPS_ID1:
-        if (cur == end) {
+      }
+      case GRPC_CHTTP2_SPS_ID1: {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_ID1;
           return absl::OkStatus();
         }
-        parser->id = static_cast<uint16_t>(parser->id | (*cur));
-        cur++;
+        parser->id |= static_cast<uint16_t>(*v);
         [[fallthrough]];
-      case GRPC_CHTTP2_SPS_VAL0:
-        if (cur == end) {
+      }
+      case GRPC_CHTTP2_SPS_VAL0: {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_VAL0;
           return absl::OkStatus();
         }
-        parser->value = (static_cast<uint32_t>(*cur)) << 24;
-        cur++;
+        parser->value = static_cast<uint32_t>(*v) << 24;
         [[fallthrough]];
-      case GRPC_CHTTP2_SPS_VAL1:
-        if (cur == end) {
+      }
+      case GRPC_CHTTP2_SPS_VAL1: {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_VAL1;
           return absl::OkStatus();
         }
-        parser->value |= (static_cast<uint32_t>(*cur)) << 16;
-        cur++;
+        parser->value |= static_cast<uint32_t>(*v) << 16;
         [[fallthrough]];
-      case GRPC_CHTTP2_SPS_VAL2:
-        if (cur == end) {
+      }
+      case GRPC_CHTTP2_SPS_VAL2: {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_VAL2;
           return absl::OkStatus();
         }
-        parser->value |= (static_cast<uint32_t>(*cur)) << 8;
-        cur++;
+        parser->value |= static_cast<uint32_t>(*v) << 8;
         [[fallthrough]];
+      }
       case GRPC_CHTTP2_SPS_VAL3: {
-        if (cur == end) {
+        auto v = src.ReadU8();
+        if (!v.has_value()) {
           parser->state = GRPC_CHTTP2_SPS_VAL3;
           return absl::OkStatus();
-        } else {
-          parser->state = GRPC_CHTTP2_SPS_ID0;
         }
-        parser->value |= *cur;
-        cur++;
+        parser->value |= static_cast<uint32_t>(*v);
 
         if (parser->id == grpc_core::Http2Settings::kInitialWindowSizeWireId) {
           t->initial_window_update +=
@@ -220,6 +227,8 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
             << t->peer_string.as_string_view() << ": got setting "
             << grpc_core::Http2Settings::WireIdToName(parser->id) << " = "
             << parser->value;
+
+        parser->state = GRPC_CHTTP2_SPS_ID0;
       } break;
     }
   }

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -45,22 +45,24 @@
 
 using grpc_core::http2::Http2ErrorCode;
 
-static uint8_t* fill_header(uint8_t* out, uint32_t length, uint8_t flags) {
-  *out++ = static_cast<uint8_t>(length >> 16);
-  *out++ = static_cast<uint8_t>(length >> 8);
-  *out++ = static_cast<uint8_t>(length);
-  *out++ = GRPC_CHTTP2_FRAME_SETTINGS;
-  *out++ = flags;
-  *out++ = 0;
-  *out++ = 0;
-  *out++ = 0;
-  *out++ = 0;
-  return out;
+static void fill_header(grpc_core::ByteSink& sink, uint32_t length,
+                        uint8_t flags) {
+  GRPC_CHECK(sink.WriteU24BE(length));
+  GRPC_CHECK(sink.WriteU8(GRPC_CHTTP2_FRAME_SETTINGS));
+  GRPC_CHECK(sink.WriteU8(flags));
+  GRPC_CHECK(sink.Skip(4));  // stream id = 0
 }
 
 grpc_slice grpc_chttp2_settings_ack_create(void) {
   grpc_slice output = GRPC_SLICE_MALLOC(9);
-  fill_header(GRPC_SLICE_START_PTR(output), 0, GRPC_CHTTP2_FLAG_ACK);
+
+  grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(output),
+                           GRPC_SLICE_LENGTH(output));
+
+  fill_header(sink, 0, GRPC_CHTTP2_FLAG_ACK);
+
+  GRPC_CHECK(sink.empty());
+
   return output;
 }
 
@@ -100,8 +102,6 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
     return absl::OkStatus();
   }
 
-  // Secure-by-design: parse SETTINGS frame through a bounds-checked cursor
-  // so malformed frames (truncated IDs/values) can never overrun the slice.
   grpc_core::ByteSource src(slice);
 
   for (;;) {

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -47,8 +47,6 @@ grpc_slice grpc_chttp2_window_update_create(
 
   GRPC_CHECK(window_delta);
 
-  // Secure-by-design: serialize through a bounds-checked sink so the frame
-  // can never overflow its allocated slice.
   grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
                            GRPC_SLICE_LENGTH(slice));
   GRPC_CHECK(sink.WriteU24BE(4));
@@ -56,7 +54,7 @@ grpc_slice grpc_chttp2_window_update_create(
   GRPC_CHECK(sink.WriteU8(0));  // flags
   GRPC_CHECK(sink.WriteU32BE(id));
   GRPC_CHECK(sink.WriteU31BE(window_delta));
-  GPR_ASSERT(sink.empty());
+  GRPC_CHECK(sink.empty());
 
   return slice;
 }
@@ -78,9 +76,6 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
   grpc_chttp2_window_update_parser* p =
       static_cast<grpc_chttp2_window_update_parser*>(parser);
 
-  // Secure-by-design: accumulate the 4-byte window increment through a
-  // bounds-checked cursor so a malformed or truncated frame can never read
-  // past the slice boundary.
   grpc_core::ByteSource src(slice);
   while (p->byte != 4) {
     auto v = src.ReadU8();

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -21,11 +21,14 @@
 #include <grpc/support/port_platform.h>
 #include <stddef.h>
 
+#include <cstdint>
+
 #include "src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h"
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
 #include "src/core/ext/transport/chttp2/transport/http2_ztrace_collector.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/ext/transport/chttp2/transport/stream_lists.h"
+#include "src/core/lib/slice/byte_source.h"
 #include "src/core/telemetry/stats.h"
 #include "src/core/util/grpc_check.h"
 #include "src/core/util/time.h"
@@ -41,23 +44,19 @@ grpc_slice grpc_chttp2_window_update_create(
   if (call_tracer != nullptr) {
     call_tracer->RecordOutgoingBytes({frame_size, 0, 0});
   }
-  uint8_t* p = GRPC_SLICE_START_PTR(slice);
 
   GRPC_CHECK(window_delta);
 
-  *p++ = 0;
-  *p++ = 0;
-  *p++ = 4;
-  *p++ = GRPC_CHTTP2_FRAME_WINDOW_UPDATE;
-  *p++ = 0;
-  *p++ = static_cast<uint8_t>(id >> 24);
-  *p++ = static_cast<uint8_t>(id >> 16);
-  *p++ = static_cast<uint8_t>(id >> 8);
-  *p++ = static_cast<uint8_t>(id);
-  *p++ = static_cast<uint8_t>(window_delta >> 24);
-  *p++ = static_cast<uint8_t>(window_delta >> 16);
-  *p++ = static_cast<uint8_t>(window_delta >> 8);
-  *p++ = static_cast<uint8_t>(window_delta);
+  // Secure-by-design: serialize through a bounds-checked sink so the frame
+  // can never overflow its allocated slice.
+  grpc_core::ByteSink sink(GRPC_SLICE_START_PTR(slice),
+                           GRPC_SLICE_LENGTH(slice));
+  GRPC_CHECK(sink.WriteU24BE(4));
+  GRPC_CHECK(sink.WriteU8(GRPC_CHTTP2_FRAME_WINDOW_UPDATE));
+  GRPC_CHECK(sink.WriteU8(0));  // flags
+  GRPC_CHECK(sink.WriteU32BE(id));
+  GRPC_CHECK(sink.WriteU31BE(window_delta));
+  GPR_ASSERT(sink.empty());
 
   return slice;
 }
@@ -76,20 +75,22 @@ grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
 grpc_error_handle grpc_chttp2_window_update_parser_parse(
     void* parser, grpc_chttp2_transport* t, grpc_chttp2_stream* s,
     const grpc_slice& slice, int is_last) {
-  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  const uint8_t* cur = beg;
   grpc_chttp2_window_update_parser* p =
       static_cast<grpc_chttp2_window_update_parser*>(parser);
 
-  while (p->byte != 4 && cur != end) {
-    p->amount |= (static_cast<uint32_t>(*cur)) << (8 * (3 - p->byte));
-    cur++;
-    p->byte++;
+  // Secure-by-design: accumulate the 4-byte window increment through a
+  // bounds-checked cursor so a malformed or truncated frame can never read
+  // past the slice boundary.
+  grpc_core::ByteSource src(slice);
+  while (p->byte != 4) {
+    auto v = src.ReadU8();
+    if (!v.has_value()) break;
+    p->amount |= static_cast<uint32_t>(*v) << (8 * (3 - p->byte));
+    ++p->byte;
   }
 
   if (s != nullptr) {
-    uint64_t framing_bytes = static_cast<uint32_t>(end - cur);
+    uint64_t framing_bytes = 4u - src.remaining();
     s->call_tracer_wrapper.RecordIncomingBytes({framing_bytes, 0, 0});
   }
 

--- a/src/core/lib/slice/byte_source.h
+++ b/src/core/lib/slice/byte_source.h
@@ -1,0 +1,209 @@
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CORE_LIB_SLICE_BYTE_SOURCE_H
+#define GRPC_SRC_CORE_LIB_SLICE_BYTE_SOURCE_H
+
+#include <grpc/slice.h>
+#include <grpc/support/port_platform.h>
+#include <string.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include "src/core/lib/slice/slice.h"
+#include "absl/types/span.h"
+
+// Secure-by-design, bounds-checked cursor over untrusted bytes.
+//
+// ByteSource / ByteSink make spatial memory unsafety unrepresentable in
+// wire-format parsers and serializers: every read and write either succeeds
+// inside the remaining span or fails without touching out-of-range memory.
+// Methods are header-inline so the compiler can emit the same pointer
+// increments as the previous raw-pointer loops on the hot path.
+
+namespace grpc_core {
+
+class ByteSource {
+ public:
+  ByteSource() = default;
+  explicit ByteSource(absl::Span<const uint8_t> span) : span_(span) {}
+  explicit ByteSource(const Slice& slice)
+      : span_(slice.data(), slice.size()) {}
+  explicit ByteSource(const grpc_slice& slice)
+      : span_(GRPC_SLICE_START_PTR(slice), GRPC_SLICE_LENGTH(slice)) {}
+  ByteSource(const uint8_t* data, size_t length) : span_(data, length) {}
+
+  size_t remaining() const { return span_.size(); }
+  bool empty() const { return span_.empty(); }
+  const uint8_t* data() const { return span_.data(); }
+  absl::Span<const uint8_t> span() const { return span_; }
+
+  std::optional<uint8_t> Peek() const {
+    if (span_.empty()) return std::nullopt;
+    return span_[0];
+  }
+
+  std::optional<uint8_t> ReadU8() {
+    if (span_.empty()) return std::nullopt;
+    const uint8_t v = span_[0];
+    span_ = span_.subspan(1);
+    return v;
+  }
+
+  std::optional<uint16_t> ReadU16BE() {
+    auto bytes = ReadSpan(2);
+    if (!bytes.has_value()) return std::nullopt;
+    return (static_cast<uint16_t>((*bytes)[0]) << 8) |
+           static_cast<uint16_t>((*bytes)[1]);
+  }
+
+  std::optional<uint32_t> ReadU24BE() {
+    auto bytes = ReadSpan(3);
+    if (!bytes.has_value()) return std::nullopt;
+    return (static_cast<uint32_t>((*bytes)[0]) << 16) |
+           (static_cast<uint32_t>((*bytes)[1]) << 8) |
+           static_cast<uint32_t>((*bytes)[2]);
+  }
+
+  std::optional<uint32_t> ReadU32BE() {
+    auto bytes = ReadSpan(4);
+    if (!bytes.has_value()) return std::nullopt;
+    return (static_cast<uint32_t>((*bytes)[0]) << 24) |
+           (static_cast<uint32_t>((*bytes)[1]) << 16) |
+           (static_cast<uint32_t>((*bytes)[2]) << 8) |
+           static_cast<uint32_t>((*bytes)[3]);
+  }
+
+  // HTTP/2 31-bit integers: the high bit is reserved and must be ignored.
+  std::optional<uint32_t> ReadU31BE() {
+    auto v = ReadU32BE();
+    if (!v.has_value()) return std::nullopt;
+    return *v & 0x7fffffffu;
+  }
+
+  std::optional<uint64_t> ReadU64BE() {
+    auto bytes = ReadSpan(8);
+    if (!bytes.has_value()) return std::nullopt;
+    return (static_cast<uint64_t>((*bytes)[0]) << 56) |
+           (static_cast<uint64_t>((*bytes)[1]) << 48) |
+           (static_cast<uint64_t>((*bytes)[2]) << 40) |
+           (static_cast<uint64_t>((*bytes)[3]) << 32) |
+           (static_cast<uint64_t>((*bytes)[4]) << 24) |
+           (static_cast<uint64_t>((*bytes)[5]) << 16) |
+           (static_cast<uint64_t>((*bytes)[6]) << 8) |
+           static_cast<uint64_t>((*bytes)[7]);
+  }
+
+  std::optional<absl::Span<const uint8_t>> ReadSpan(size_t n) {
+    if (n > span_.size()) return std::nullopt;
+    auto out = span_.subspan(0, n);
+    span_ = span_.subspan(n);
+    return out;
+  }
+
+  bool Skip(size_t n) {
+    if (n > span_.size()) return false;
+    span_ = span_.subspan(n);
+    return true;
+  }
+
+  bool CopyTo(void* dst, size_t n) {
+    auto bytes = ReadSpan(n);
+    if (!bytes.has_value()) return false;
+    if (n != 0) memcpy(dst, bytes->data(), n);
+    return true;
+  }
+
+  // Consume as many of the remaining bytes as fit in `need`, copying them
+  // into `dst`. Returns the number of bytes copied. Never overruns `need`
+  // or the source span.
+  size_t CopyAtMost(void* dst, size_t need) {
+    const size_t n = need < span_.size() ? need : span_.size();
+    if (n != 0) memcpy(dst, span_.data(), n);
+    span_ = span_.subspan(n);
+    return n;
+  }
+
+ private:
+  absl::Span<const uint8_t> span_;
+};
+
+class ByteSink {
+ public:
+  ByteSink() = default;
+  explicit ByteSink(absl::Span<uint8_t> span) : span_(span), start_size_(span.size()) {}
+  explicit ByteSink(MutableSlice& slice)
+      : span_(slice.data(), slice.size()), start_size_(slice.size()) {}
+  ByteSink(uint8_t* data, size_t length)
+      : span_(data, length), start_size_(length) {}
+
+  size_t remaining() const { return span_.size(); }
+  size_t bytes_written() const { return start_size_ - span_.size(); }
+  bool empty() const { return span_.empty(); }
+
+  bool WriteU8(uint8_t v) {
+    if (span_.empty()) return false;
+    span_[0] = v;
+    span_ = span_.subspan(1);
+    return true;
+  }
+
+  bool WriteU16BE(uint16_t v) {
+    return WriteU8(static_cast<uint8_t>(v >> 8)) &&
+           WriteU8(static_cast<uint8_t>(v));
+  }
+
+  bool WriteU24BE(uint32_t v) {
+    return WriteU8(static_cast<uint8_t>(v >> 16)) &&
+           WriteU8(static_cast<uint8_t>(v >> 8)) &&
+           WriteU8(static_cast<uint8_t>(v));
+  }
+
+  bool WriteU32BE(uint32_t v) {
+    return WriteU8(static_cast<uint8_t>(v >> 24)) &&
+           WriteU8(static_cast<uint8_t>(v >> 16)) &&
+           WriteU8(static_cast<uint8_t>(v >> 8)) &&
+           WriteU8(static_cast<uint8_t>(v));
+  }
+
+  bool WriteU31BE(uint32_t v) { return WriteU32BE(v & 0x7fffffffu); }
+
+  bool WriteU64BE(uint64_t v) {
+    return WriteU8(static_cast<uint8_t>(v >> 56)) &&
+           WriteU8(static_cast<uint8_t>(v >> 48)) &&
+           WriteU8(static_cast<uint8_t>(v >> 40)) &&
+           WriteU8(static_cast<uint8_t>(v >> 32)) &&
+           WriteU8(static_cast<uint8_t>(v >> 24)) &&
+           WriteU8(static_cast<uint8_t>(v >> 16)) &&
+           WriteU8(static_cast<uint8_t>(v >> 8)) &&
+           WriteU8(static_cast<uint8_t>(v));
+  }
+
+  bool WriteSpan(absl::Span<const uint8_t> src) {
+    if (src.size() > span_.size()) return false;
+    if (!src.empty()) memcpy(span_.data(), src.data(), src.size());
+    span_ = span_.subspan(src.size());
+    return true;
+  }
+
+ private:
+  absl::Span<uint8_t> span_;
+  size_t start_size_ = 0;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_LIB_SLICE_BYTE_SOURCE_H

--- a/src/core/lib/slice/byte_source.h
+++ b/src/core/lib/slice/byte_source.h
@@ -19,6 +19,7 @@
 #include <grpc/support/port_platform.h>
 #include <string.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -26,13 +27,14 @@
 #include "src/core/lib/slice/slice.h"
 #include "absl/types/span.h"
 
-// Secure-by-design, bounds-checked cursor over untrusted bytes.
+// Bounds-checked cursors for sequential wire-format reads and writes.
 //
-// ByteSource / ByteSink make spatial memory unsafety unrepresentable in
-// wire-format parsers and serializers: every read and write either succeeds
-// inside the remaining span or fails without touching out-of-range memory.
-// Methods are header-inline so the compiler can emit the same pointer
-// increments as the previous raw-pointer loops on the hot path.
+// ByteSource and ByteSink centralize bounds checking for byte-buffer
+// operations. Operations either complete within the remaining span or fail
+// without accessing memory outside the span.
+//
+// Methods are header-inline so the compiler can optimize the cursor
+// operations on hot paths.
 
 namespace grpc_core {
 
@@ -120,19 +122,28 @@ class ByteSource {
     return true;
   }
 
-  bool CopyTo(void* dst, size_t n) {
+  bool CopyTo(absl::Span<uint8_t> dst, size_t n) {
+    if (n > dst.size()) return false;
+
     auto bytes = ReadSpan(n);
     if (!bytes.has_value()) return false;
-    if (n != 0) memcpy(dst, bytes->data(), n);
+
+    if (n != 0) {
+      memcpy(dst.data(), bytes->data(), n);
+    }
     return true;
   }
 
-  // Consume as many of the remaining bytes as fit in `need`, copying them
-  // into `dst`. Returns the number of bytes copied. Never overruns `need`
+  // Consume as many of the remaining bytes as fit in `dst`, copying them
+  // into `dst`. Returns the number of bytes copied. Never overruns `dst`
   // or the source span.
-  size_t CopyAtMost(void* dst, size_t need) {
-    const size_t n = need < span_.size() ? need : span_.size();
-    if (n != 0) memcpy(dst, span_.data(), n);
+  size_t CopyAtMost(absl::Span<uint8_t> dst) {
+    const size_t n = std::min(dst.size(), span_.size());
+
+    if (n != 0) {
+      memcpy(dst.data(), span_.data(), n);
+    }
+
     span_ = span_.subspan(n);
     return n;
   }
@@ -162,40 +173,60 @@ class ByteSink {
   }
 
   bool WriteU16BE(uint16_t v) {
-    return WriteU8(static_cast<uint8_t>(v >> 8)) &&
-           WriteU8(static_cast<uint8_t>(v));
+    if (span_.size() < 2) return false;
+    span_[0] = static_cast<uint8_t>(v >> 8);
+    span_[1] = static_cast<uint8_t>(v);
+    span_ = span_.subspan(2);
+    return true;
   }
 
   bool WriteU24BE(uint32_t v) {
-    return WriteU8(static_cast<uint8_t>(v >> 16)) &&
-           WriteU8(static_cast<uint8_t>(v >> 8)) &&
-           WriteU8(static_cast<uint8_t>(v));
+    if (span_.size() < 3) return false;
+    span_[0] = static_cast<uint8_t>(v >> 16);
+    span_[1] = static_cast<uint8_t>(v >> 8);
+    span_[2] = static_cast<uint8_t>(v);
+    span_ = span_.subspan(3);
+    return true;
+  }
+
+  bool WriteU31BE(uint32_t v) {
+    return WriteU32BE(v & 0x7fffffffu);
   }
 
   bool WriteU32BE(uint32_t v) {
-    return WriteU8(static_cast<uint8_t>(v >> 24)) &&
-           WriteU8(static_cast<uint8_t>(v >> 16)) &&
-           WriteU8(static_cast<uint8_t>(v >> 8)) &&
-           WriteU8(static_cast<uint8_t>(v));
+    if (span_.size() < 4) return false;
+    span_[0] = static_cast<uint8_t>(v >> 24);
+    span_[1] = static_cast<uint8_t>(v >> 16);
+    span_[2] = static_cast<uint8_t>(v >> 8);
+    span_[3] = static_cast<uint8_t>(v);
+    span_ = span_.subspan(4);
+    return true;
   }
 
-  bool WriteU31BE(uint32_t v) { return WriteU32BE(v & 0x7fffffffu); }
-
   bool WriteU64BE(uint64_t v) {
-    return WriteU8(static_cast<uint8_t>(v >> 56)) &&
-           WriteU8(static_cast<uint8_t>(v >> 48)) &&
-           WriteU8(static_cast<uint8_t>(v >> 40)) &&
-           WriteU8(static_cast<uint8_t>(v >> 32)) &&
-           WriteU8(static_cast<uint8_t>(v >> 24)) &&
-           WriteU8(static_cast<uint8_t>(v >> 16)) &&
-           WriteU8(static_cast<uint8_t>(v >> 8)) &&
-           WriteU8(static_cast<uint8_t>(v));
+    if (span_.size() < 8) return false;
+    span_[0] = static_cast<uint8_t>(v >> 56);
+    span_[1] = static_cast<uint8_t>(v >> 48);
+    span_[2] = static_cast<uint8_t>(v >> 40);
+    span_[3] = static_cast<uint8_t>(v >> 32);
+    span_[4] = static_cast<uint8_t>(v >> 24);
+    span_[5] = static_cast<uint8_t>(v >> 16);
+    span_[6] = static_cast<uint8_t>(v >> 8);
+    span_[7] = static_cast<uint8_t>(v);
+    span_ = span_.subspan(8);
+    return true;
   }
 
   bool WriteSpan(absl::Span<const uint8_t> src) {
     if (src.size() > span_.size()) return false;
     if (!src.empty()) memcpy(span_.data(), src.data(), src.size());
     span_ = span_.subspan(src.size());
+    return true;
+  }
+
+  bool Skip(size_t n) {
+    if (n > span_.size()) return false;
+    span_ = span_.subspan(n);
     return true;
   }
 

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -63,6 +63,24 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "byte_source_test",
+    srcs = ["byte_source_test.cc"],
+    external_deps = [
+        "gtest",
+        "absl/log:log",
+    ],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//src/core:slice",
+        "//src/core:byte_source",
+        "//test/core/test_util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "slice_test",
     srcs = ["slice_test.cc"],
     external_deps = [

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -68,6 +68,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
         "absl/log:log",
+        "absl/types:span",
     ],
     uses_event_engine = False,
     uses_polling = False,
@@ -76,7 +77,6 @@ grpc_cc_test(
         "//:grpc",
         "//src/core:slice",
         "//src/core:byte_source",
-        "//test/core/test_util:grpc_test_util",
     ],
 )
 

--- a/test/core/slice/byte_source_test.cc
+++ b/test/core/slice/byte_source_test.cc
@@ -1,0 +1,118 @@
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/core/test_util/test_config.h"
+
+#include "src/core/lib/slice/byte_source.h"
+#include "src/core/lib/slice/slice.h"
+#include "gtest/gtest.h"
+
+using grpc_core::ByteSource;
+using grpc_core::Slice;
+
+TEST(ByteSourceTest, Empty) {
+  ByteSource src;
+  EXPECT_TRUE(src.empty());
+  EXPECT_EQ(0u, src.remaining());
+}
+
+TEST(ByteSourceTest, FromSlice) {
+  auto s = Slice::FromCopiedBuffer("hello", 5);
+  ByteSource src(s);
+  EXPECT_FALSE(src.empty());
+  EXPECT_EQ(5u, src.remaining());
+  EXPECT_EQ('h', *src.Peek());
+  EXPECT_EQ('h', *src.ReadU8());
+  EXPECT_EQ(4u, src.remaining());
+}
+
+TEST(ByteSourceTest, ReadU8) {
+  auto s = Slice::FromCopiedBuffer("\x01\x02\x03", 3);
+  ByteSource src(s);
+  EXPECT_EQ(1u, *src.ReadU8());
+  EXPECT_EQ(2u, *src.ReadU8());
+  EXPECT_EQ(3u, *src.ReadU8());
+  EXPECT_FALSE(src.ReadU8());
+}
+
+TEST(ByteSourceTest, ReadU16BE) {
+  auto s = Slice::FromCopiedBuffer("\x12\x34", 2);
+  ByteSource src(s);
+  EXPECT_EQ(0x1234u, *src.ReadU16BE());
+  EXPECT_FALSE(src.ReadU16BE());
+}
+
+TEST(ByteSourceTest, ReadU32BE) {
+  auto s = Slice::FromCopiedBuffer("\x12\x34\x56\x78", 4);
+  ByteSource src(s);
+  EXPECT_EQ(0x12345678u, *src.ReadU32BE());
+  EXPECT_FALSE(src.ReadU32BE());
+}
+
+TEST(ByteSourceTest, ReadU64BE) {
+  auto s = Slice::FromCopiedBuffer("\x12\x34\x56\x78\x9a\xbc\xde\xf0", 8);
+  ByteSource src(s);
+  EXPECT_EQ(0x123456789abcdef0ull, *src.ReadU64BE());
+  EXPECT_FALSE(src.ReadU64BE());
+}
+
+TEST(ByteSourceTest, ReadSpan) {
+  auto s = Slice::FromCopiedBuffer("abcdefgh", 8);
+  ByteSource src(s);
+  auto sp = src.ReadSpan(3);
+  EXPECT_TRUE(sp.has_value());
+  EXPECT_EQ("abc", sp->data());
+  EXPECT_EQ(5u, src.remaining());
+}
+
+TEST(ByteSourceTest, Skip) {
+  auto s = Slice::FromCopiedBuffer("hello", 5);
+  ByteSource src(s);
+  EXPECT_TRUE(src.Skip(3));
+  EXPECT_EQ(2u, src.remaining());
+  EXPECT_EQ('o', *src.ReadU8());
+  EXPECT_FALSE(src.Skip(3));
+}
+
+TEST(ByteSourceTest, CopyTo) {
+  char buf[3] = {};
+  auto s = Slice::FromCopiedBuffer("abcde", 5);
+  ByteSource src(s);
+  EXPECT_TRUE(src.CopyTo(buf, 3));
+  EXPECT_EQ("abc", buf);
+  EXPECT_EQ(2u, src.remaining());
+}
+
+TEST(ByteSourceTest, CopyAtMost) {
+  char buf[3] = {};
+  auto s = Slice::FromCopiedBuffer("abcde", 5);
+  ByteSource src(s);
+  EXPECT_EQ(3u, src.CopyAtMost(buf, 5));
+  EXPECT_EQ("abc", buf);
+  EXPECT_EQ(2u, src.remaining());
+}
+
+TEST(ByteSourceTest, OutOfBounds) {
+  ByteSource src(nullptr, 0);
+  EXPECT_FALSE(src.ReadU8());
+  EXPECT_FALSE(src.ReadU16BE());
+  EXPECT_FALSE(src.ReadSpan(1));
+  EXPECT_FALSE(src.Skip(1));
+}
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/core/slice/byte_source_test.cc
+++ b/test/core/slice/byte_source_test.cc
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test/core/test_util/test_config.h"
-
 #include "src/core/lib/slice/byte_source.h"
 #include "src/core/lib/slice/slice.h"
 #include "gtest/gtest.h"
+#include "absl/types/span.h"
+#include <cstring>
 
 using grpc_core::ByteSource;
+using grpc_core::ByteSink;
 using grpc_core::Slice;
 
 TEST(ByteSourceTest, Empty) {
@@ -72,7 +73,10 @@ TEST(ByteSourceTest, ReadSpan) {
   ByteSource src(s);
   auto sp = src.ReadSpan(3);
   EXPECT_TRUE(sp.has_value());
-  EXPECT_EQ("abc", sp->data());
+  EXPECT_EQ(3u, sp->size());
+  EXPECT_EQ('a', sp->data()[0]);
+  EXPECT_EQ('b', sp->data()[1]);
+  EXPECT_EQ('c', sp->data()[2]);
   EXPECT_EQ(5u, src.remaining());
 }
 
@@ -81,25 +85,29 @@ TEST(ByteSourceTest, Skip) {
   ByteSource src(s);
   EXPECT_TRUE(src.Skip(3));
   EXPECT_EQ(2u, src.remaining());
-  EXPECT_EQ('o', *src.ReadU8());
+  EXPECT_EQ('l', *src.ReadU8());
   EXPECT_FALSE(src.Skip(3));
 }
 
 TEST(ByteSourceTest, CopyTo) {
-  char buf[3] = {};
+  uint8_t buf[3] = {};
   auto s = Slice::FromCopiedBuffer("abcde", 5);
   ByteSource src(s);
-  EXPECT_TRUE(src.CopyTo(buf, 3));
-  EXPECT_EQ("abc", buf);
+  EXPECT_TRUE(src.CopyTo(absl::MakeSpan(buf), 3));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('b', buf[1]);
+  EXPECT_EQ('c', buf[2]);
   EXPECT_EQ(2u, src.remaining());
 }
 
 TEST(ByteSourceTest, CopyAtMost) {
-  char buf[3] = {};
+  uint8_t buf[3] = {};
   auto s = Slice::FromCopiedBuffer("abcde", 5);
   ByteSource src(s);
-  EXPECT_EQ(3u, src.CopyAtMost(buf, 5));
-  EXPECT_EQ("abc", buf);
+  EXPECT_EQ(3u, src.CopyAtMost(absl::MakeSpan(buf)));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('b', buf[1]);
+  EXPECT_EQ('c', buf[2]);
   EXPECT_EQ(2u, src.remaining());
 }
 
@@ -111,8 +119,108 @@ TEST(ByteSourceTest, OutOfBounds) {
   EXPECT_FALSE(src.Skip(1));
 }
 
+TEST(ByteSourceTest, ReadU24BE) {
+  auto s = Slice::FromCopiedBuffer("\x12\x34\x56", 3);
+  ByteSource src(s);
+  EXPECT_EQ(0x123456u, *src.ReadU24BE());
+  EXPECT_FALSE(src.ReadU24BE());
+}
+
+TEST(ByteSourceTest, ReadU31BE) {
+  auto s = Slice::FromCopiedBuffer("\xff\xff\xff\xff", 4);
+  ByteSource src(s);
+  EXPECT_EQ(0x7fffffffu, *src.ReadU31BE());
+  EXPECT_FALSE(src.ReadU31BE());
+}
+
+TEST(ByteSourceTest, CopyToChecksDestinationSize) {
+  uint8_t buf[2] = {0xaa, 0xaa};
+
+  auto s = Slice::FromCopiedBuffer("abc", 3);
+  ByteSource src(s);
+
+  EXPECT_FALSE(src.CopyTo(absl::MakeSpan(buf), 3));
+
+  EXPECT_EQ(3u, src.remaining());
+  EXPECT_EQ(0xaa, buf[0]);
+  EXPECT_EQ(0xaa, buf[1]);
+}
+
+TEST(ByteSinkTest, WriteU8) {
+  uint8_t buf[1] = {};
+
+  ByteSink sink(absl::MakeSpan(buf));
+
+  EXPECT_TRUE(sink.WriteU8(0x12));
+  EXPECT_EQ(0x12, buf[0]);
+  EXPECT_TRUE(sink.empty());
+}
+
+TEST(ByteSinkTest, WriteIntegers) {
+  uint8_t buf[18] = {};
+
+  ByteSink sink(absl::MakeSpan(buf));
+
+  EXPECT_TRUE(sink.WriteU8(0x01));
+  EXPECT_TRUE(sink.WriteU16BE(0x2345));
+  EXPECT_TRUE(sink.WriteU24BE(0x6789ab));
+  EXPECT_TRUE(sink.WriteU32BE(0xcdef0123));
+  EXPECT_TRUE(sink.WriteU64BE(0x456789abcdef0123ull));
+
+  EXPECT_EQ(18u, sink.bytes_written());
+
+  const uint8_t expected[] = {
+      0x01,
+      0x23, 0x45,
+      0x67, 0x89, 0xab,
+      0xcd, 0xef, 0x01, 0x23,
+      0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23,
+  };
+
+  EXPECT_EQ(0, memcmp(buf, expected, sizeof(expected)));
+}
+
+TEST(ByteSinkTest, MultiByteWriteDoesNotPartiallyWrite) {
+  uint8_t buf[3] = {0xaa, 0xaa, 0xaa};
+
+  ByteSink sink(absl::MakeSpan(buf));
+
+  EXPECT_FALSE(sink.WriteU32BE(0x12345678));
+  EXPECT_EQ(0u, sink.bytes_written());
+
+  EXPECT_EQ(0xaa, buf[0]);
+  EXPECT_EQ(0xaa, buf[1]);
+  EXPECT_EQ(0xaa, buf[2]);
+}
+
+TEST(ByteSinkTest, WriteSpan) {
+  uint8_t buf[5] = {};
+  const uint8_t input[] = {1, 2, 3};
+
+  ByteSink sink(absl::MakeSpan(buf));
+
+  EXPECT_TRUE(sink.WriteSpan(absl::MakeConstSpan(input)));
+  EXPECT_EQ(3u, sink.bytes_written());
+
+  EXPECT_EQ(1, buf[0]);
+  EXPECT_EQ(2, buf[1]);
+  EXPECT_EQ(3, buf[2]);
+}
+
+TEST(ByteSinkTest, WriteSpanOutOfBounds) {
+  uint8_t buf[2] = {0xaa, 0xaa};
+  const uint8_t input[] = {1, 2, 3};
+
+  ByteSink sink(absl::MakeSpan(buf));
+
+  EXPECT_FALSE(sink.WriteSpan(absl::MakeConstSpan(input)));
+  EXPECT_EQ(0u, sink.bytes_written());
+
+  EXPECT_EQ(0xaa, buf[0]);
+  EXPECT_EQ(0xaa, buf[1]);
+}
+
 int main(int argc, char** argv) {
-  grpc::testing::TestEnvironment env;
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This change replaces raw pointer frame parsing and serialization with
bounds-checked ByteSource and ByteSink abstractions to eliminate buffer
overflow vulnerabilities in HTTP/2 frame handling.

Security improvements:
- HTTP/2 frame parsers use ByteSource for bounds-checked reads
- Migrated frame serializers use ByteSink for bounds-checked writes
- Centralizes buffer-boundary checks in the byte-access abstractions
- Truncated or malformed input is handled without accessing memory beyond the available buffer

Implementation:
- Added ByteSource class: bounds-checked cursor for reading byte buffers
- Added ByteSink class: bounds-checked cursor for writing byte buffers
- Both use absl::Span for bounds checking and std::optional for error handling
- Methods are header-inline for performance (same pointer arithmetic as before)
- Updated 5 HTTP/2 frame parsers: GOAWAY, PING, RST_STREAM, SETTINGS, WINDOW_UPDATE

Files changed:
- src/core/lib/slice/byte_source.h: New header with ByteSource/ByteSink abstractions
- src/core/ext/transport/chttp2/transport/frame_*.cc: Updated to use new abstractions
- BUILD files: Added byte_source library target and test dependencies
- test/core/slice/byte_source_test.cc: Comprehensive unit tests for new abstractions

Testing:
- Added unit tests covering all ByteSource operations
- Tests verify both successful operations and proper failure on out-of-bounds access

This is a defense-in-depth security improvement that makes spatial memory unsafety
unrepresentable in wire-format parsers and serializers.

