### PR TITLE
posix_engine: safely handle ConsumeWakeup errors and reset wakeup_fd after fork (fixes #43062)

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -652,7 +652,15 @@ Poller::WorkResult PollPoller::Work(
       }
     } else {
       if (pfds[0].revents & kPollinCheck) {
-        GRPC_CHECK(wakeup_fd_->ConsumeWakeup().ok());
+        auto consume_status = wakeup_fd_->ConsumeWakeup();
+        if (!consume_status.ok()) {
+          GRPC_TRACE_LOG(polling, ERROR)
+              << "Failed to consume wakeup on wakeup_fd: " << consume_status;
+          auto new_wakeup_fd = CreateWakeupFd(&posix_interface());
+          if (new_wakeup_fd.ok()) {
+            wakeup_fd_ = std::move(*new_wakeup_fd);
+          }
+        }
       }
       for (i = 1; i < pfd_count; i++) {
         PollEventHandle* head = watchers[i];
@@ -726,6 +734,7 @@ void PollPoller::HandleForkInChild() {
   if (grpc_core::IsEventEngineForkEnabled()) {
     posix_interface().AdvanceGeneration();
   }
+  ResetKickState();
   PollEventHandle* handle;
   {
     grpc_core::MutexLock lock(&mu_);


### PR DESCRIPTION
### Description

Fixes #43062.

In grpcio 1.83.0, when a child process is spawned via `fork()` (common on macOS when running subprocesses with custom working directories or environments) while background polling threads are active in the parent:
1. If fork handlers are skipped or during post-fork initialization, `posix_interface().AdvanceGeneration()` invalidates the generation of the inherited wakeup FD.
2. When the child poller enters `PollPoller::Work`, `wakeup_fd_->ConsumeWakeup()` fails because the file descriptor is either unconsumed, closed, or mismatched with the advanced generation.
3. Previously, this triggered `GRPC_CHECK(wakeup_fd_->ConsumeWakeup().ok())`, crashing the child process immediately with `Check failed: wakeup_fd_->ConsumeWakeup().ok()`.

This patch resolves the issue by:
- In `PollPoller::HandleForkInChild()`, resetting the wakeup FD state via `ResetKickState()` so a fresh wakeup FD is initialized with the new generation for the child process.
- In `PollPoller::Work()`, safely consuming the wakeup event without hard-crashing via `GRPC_CHECK`; if `ConsumeWakeup()` fails, it logs an error and lazily re-creates the wakeup FD rather than aborting the process.
