### PR TITLE
[Python] grpcio_health_checking package fixes for a free threading Python

### DIFF
--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -34,6 +34,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
     def __init__(self) -> None:
         self._server_status = {"": _health_pb2.HealthCheckResponse.SERVING}
         self._server_watchers = collections.defaultdict(asyncio.Condition)
+        self._server_watchers_count = collections.defaultdict(int)
         self._gracefully_shutting_down = False
 
     async def Check(
@@ -50,6 +51,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         self, request: _health_pb2.HealthCheckRequest, context
     ) -> None:
         condition = self._server_watchers[request.service]
+        self._server_watchers_count[request.service] += 1
         last_status = None
         try:
             async with condition:
@@ -74,8 +76,11 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
                     # Polling on health state changes
                     await condition.wait()
         finally:
-            if request.service in self._server_watchers:
-                del self._server_watchers[request.service]
+            self._server_watchers_count[request.service] -= 1
+            if self._server_watchers_count[request.service] <= 0:
+                del self._server_watchers_count[request.service]
+                if request.service in self._server_watchers:
+                    del self._server_watchers[request.service]
 
     async def _set(
         self,

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -87,13 +87,11 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         service: str,
         status: _health_pb2.HealthCheckResponse.ServingStatus,
     ) -> None:
+        self._server_status[service] = status
         if service in self._server_watchers:
-            condition = self._server_watchers.get(service)
+            condition = self._server_watchers[service]
             async with condition:
-                self._server_status[service] = status
                 condition.notify_all()
-        else:
-            self._server_status[service] = status
 
     async def set(
         self,

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -189,4 +189,3 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         with self._send_lock:
             for cb in callbacks:
                 cb(response)
-

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -124,19 +124,21 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
                 blocking_watcher
             )
         service = request.service
-        with self._state_lock:
-            status = self._server_status.get(service)
-            if status is None:
-                status = (
-                    _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
-                )  # pylint: disable=no-member
-            if service not in self._send_response_callbacks:
-                self._send_response_callbacks[service] = set()
-            self._send_response_callbacks[service].add(send_response_callback)
-            context.add_callback(
-                self._on_close_callback(send_response_callback, service)
-            )
         with self._send_lock:
+            with self._state_lock:
+                status = self._server_status.get(service)
+                if status is None:
+                    status = (
+                        _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+                    )  # pylint: disable=no-member
+                if service not in self._send_response_callbacks:
+                    self._send_response_callbacks[service] = set()
+                self._send_response_callbacks[service].add(
+                    send_response_callback
+                )
+                context.add_callback(
+                    self._on_close_callback(send_response_callback, service)
+                )
             send_response_callback(
                 _health_pb2.HealthCheckResponse(status=status)
             )
@@ -150,14 +152,14 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
           status: HealthCheckResponse.status enum value indicating the status of
             the service
         """
-        with self._state_lock:
-            if self._gracefully_shutting_down:
-                return
-            self._server_status[service] = status
-            callbacks = list(self._send_response_callbacks.get(service, ()))
-
-        response = _health_pb2.HealthCheckResponse(status=status)
         with self._send_lock:
+            with self._state_lock:
+                if self._gracefully_shutting_down:
+                    return
+                self._server_status[service] = status
+                callbacks = list(self._send_response_callbacks.get(service, ()))
+
+            response = _health_pb2.HealthCheckResponse(status=status)
             for cb in callbacks:
                 cb(response)
 
@@ -175,17 +177,17 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         )  # pylint: disable=no-member
         callbacks = []
 
-        with self._state_lock:
-            if self._gracefully_shutting_down:
-                return
-            for service in self._server_status:
-                self._server_status[service] = not_serving
-                callbacks += list(
-                    self._send_response_callbacks.get(service, ())
-                )
-            self._gracefully_shutting_down = True
-
-        response = _health_pb2.HealthCheckResponse(status=not_serving)
         with self._send_lock:
+            with self._state_lock:
+                if self._gracefully_shutting_down:
+                    return
+                for service in self._server_status:
+                    self._server_status[service] = not_serving
+                    callbacks += list(
+                        self._send_response_callbacks.get(service, ())
+                    )
+                self._gracefully_shutting_down = True
+
+            response = _health_pb2.HealthCheckResponse(status=not_serving)
             for cb in callbacks:
                 cb(response)

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -79,7 +79,13 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
     def __init__(
         self, experimental_non_blocking=True, experimental_thread_pool=None
     ):
-        self._lock = threading.RLock()
+        # guards servicer state maps. Taken by the CQ thread, so it must NOT
+        # be held across blocking send
+        self._state_lock = threading.RLock()
+        # guards server responses so two callbacks never issue overlapping
+        # batches on the same streaming call (which hangs under free threading);
+        # disjoint to `self._state_lock` and never taken by the CQ thread.
+        self._send_lock = threading.RLock()
         self._server_status = {"": _health_pb2.HealthCheckResponse.SERVING}
         self._send_response_callbacks = {}
         self.Watch.__func__.experimental_non_blocking = (
@@ -90,7 +96,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
 
     def _on_close_callback(self, send_response_callback, service):
         def callback():
-            with self._lock:
+            with self._state_lock:
                 self._send_response_callbacks[service].remove(
                     send_response_callback
                 )
@@ -99,7 +105,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         return callback
 
     def Check(self, request, context):
-        with self._lock:
+        with self._state_lock:
             status = self._server_status.get(request.service)
             if status is None:
                 context.set_code(grpc.StatusCode.NOT_FOUND)
@@ -118,20 +124,21 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
                 blocking_watcher
             )
         service = request.service
-        with self._lock:
+        with self._state_lock:
             status = self._server_status.get(service)
             if status is None:
                 status = (
                     _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
                 )  # pylint: disable=no-member
-            send_response_callback(
-                _health_pb2.HealthCheckResponse(status=status)
-            )
             if service not in self._send_response_callbacks:
                 self._send_response_callbacks[service] = set()
             self._send_response_callbacks[service].add(send_response_callback)
             context.add_callback(
                 self._on_close_callback(send_response_callback, service)
+            )
+        with self._send_lock:
+            send_response_callback(
+                _health_pb2.HealthCheckResponse(status=status)
             )
         return blocking_watcher
 
@@ -143,17 +150,16 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
           status: HealthCheckResponse.status enum value indicating the status of
             the service
         """
-        with self._lock:
+        with self._state_lock:
             if self._gracefully_shutting_down:
                 return
             self._server_status[service] = status
-            if service in self._send_response_callbacks:
-                for send_response_callback in self._send_response_callbacks[
-                    service
-                ]:
-                    send_response_callback(
-                        _health_pb2.HealthCheckResponse(status=status)
-                    )
+            callbacks = list(self._send_response_callbacks.get(service, ()))
+
+        response = _health_pb2.HealthCheckResponse(status=status)
+        with self._send_lock:
+            for cb in callbacks:
+                cb(response)
 
     def enter_graceful_shutdown(self):
         """Permanently sets the status of all services to NOT_SERVING.
@@ -164,11 +170,23 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
 
         This is an EXPERIMENTAL API.
         """
-        with self._lock:
+        not_serving = (
+            _health_pb2.HealthCheckResponse.NOT_SERVING
+        )  # pylint: disable=no-member
+        callbacks = []
+
+        with self._state_lock:
             if self._gracefully_shutting_down:
                 return
             for service in self._server_status:
-                self.set(
-                    service, _health_pb2.HealthCheckResponse.NOT_SERVING
-                )  # pylint: disable=no-member
+                self._server_status[service] = not_serving
+                callbacks += list(
+                    self._send_response_callbacks.get(service, ())
+                )
             self._gracefully_shutting_down = True
+
+        response = _health_pb2.HealthCheckResponse(status=not_serving)
+        with self._send_lock:
+            for cb in callbacks:
+                cb(response)
+

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -84,7 +84,9 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         self._state_lock = threading.RLock()
         # guards server responses so two callbacks never issue overlapping
         # batches on the same streaming call (which hangs under free threading);
-        # disjoint to `self._state_lock` and never taken by the CQ thread.
+        # Acquired as the OUTER lock -- before self._state_lock -- and held
+        # across whole status read + send, so a Watch's initial send and a
+        # concurrent set() / graceful_shutdown() broadcast cannot interleave
         self._send_lock = threading.RLock()
         self._server_status = {"": _health_pb2.HealthCheckResponse.SERVING}
         self._send_response_callbacks = {}

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -246,7 +246,7 @@ class HealthServicerTest(AioTestBase):
             and self._servicer._server_watchers_count.get(_WATCH_SERVICE, 0)
             != 1
         ):
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.1)
 
         # The surviving watcher should still observe subsequent changes
         await self._servicer.set(

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -216,7 +216,6 @@ class HealthServicerTest(AioTestBase):
         self.assertTrue(queue1.empty())
         self.assertTrue(queue2.empty())
 
-
     async def test_watcher_survives_sibling_disconnect(self):
         request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
         queue1 = asyncio.Queue()

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -216,6 +216,54 @@ class HealthServicerTest(AioTestBase):
         self.assertTrue(queue1.empty())
         self.assertTrue(queue2.empty())
 
+
+    async def test_watcher_survives_sibling_disconnect(self):
+        request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
+        queue1 = asyncio.Queue()
+        queue2 = asyncio.Queue()
+        call1 = self._stub.Watch(request)
+        call2 = self._stub.Watch(request)
+        task1 = self.loop.create_task(_pipe_to_queue(call1, queue1))
+        task2 = self.loop.create_task(_pipe_to_queue(call2, queue2))
+
+        self.assertEqual(
+            health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+            (await queue1.get()).status,
+        )
+        self.assertEqual(
+            health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+            (await queue2.get()).status,
+        )
+
+        call1.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task1
+
+        # wait for the serving coro to process client cancellation, so
+        # the status update below cannot race ahead of it
+        timeout = time.monotonic() + test_constants.TIME_ALLOWANCE
+        while (
+            time.monotonic() < timeout
+            and self._servicer._server_watchers_count.get(_WATCH_SERVICE, 0)
+            != 1
+        ):
+            await asyncio.sleep(1)
+
+        # The surviving watcher should still observe subsequent changes
+        await self._servicer.set(
+            _WATCH_SERVICE, health_pb2.HealthCheckResponse.SERVING
+        )
+        self.assertEqual(
+            health_pb2.HealthCheckResponse.SERVING, (await queue2.get()).status
+        )
+
+        call2.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task2
+
+        self.assertTrue(queue1.empty())
+        self.assertTrue(queue2.empty())
+
     async def test_cancelled_watch_removed_from_watch_list(self):
         request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
         call = self._stub.Watch(request)


### PR DESCRIPTION
## Found issues
1. Deadlock in a sync stack `HealthServicer` class. Call stack as follows
```
=== Application thread ===
HealthServicer.set(service, status)               (health.py)
    with self._lock                               # LOCK TAKEN
        send_response_callback(response)          (health.py)
            _send_response(...)                   (_server.py)
                with state.condition:             (_server.py)
                    start_server_batch(...)       (_server.py)
                    while True:                   (_server.py)
                        state.condition.wait()    # PARKED: waits for the send completion event

=== completion queue thread ===
_process_event_and_continue(...)                  (_server.py)
    rpc_state, callbacks = event.tag(event)       (_server.py)
        for callback in callbacks:                (_server.py)
            callback()                            (_server.py)
                _on_close_callback(...)           (health.py)
                    with self._lock               (health.py) # BLOCKED: held by application thread
```

2. One watcher disconnect will make all other watchers for that particular service unresponsive. Call stack as follows
```
=== Watcher A and Watcher B both watching service "S" ===
aio HealthServicer.Watch("S")                      (_async.py)
    condition - self._server_watchers["S"]         # SHARED condition
    await condition.wait()                         (_async.py)

=== Watcher A's client cancels its RPC ===
finally:                                           (_async.py)
    del self._server_watchers["S"]                 (_async.py)

=== Application updates the status of service S===
await self._set("S", SERVING)                      (_async.py)
    _set("S", SERVING)                             (_async.py)
    if "S" in self._server_watchers ---> False     (_async.py)
    else: self._server_status[service] = status    (_async.py)
```

## Proposed fixes
1. Introduce a second `threading.Lock` object in the `HealthServicer`. The existing one is going to protect the class state from concurrent access. The new one is going to protect callbacks from overlapping during batches on the same streaming call. Both of the locks are disjoint, meaning they are never held together.

2. Introduce a reference counting mechanism for all watchers per service. `self._server_watchers` entry will be removed, when there are no more active watchers for a given service.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

