### PR TITLE
[Python] aio: prevent grpc_op leak on batch cancellation or failure (fixes #43360)

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -44,6 +44,7 @@ cdef class CallbackWrapper:
     cdef CallbackContext context
     cdef object _reference_of_future
     cdef object _reference_of_failure_handler
+    cdef object _reference_of_tag
 
     @staticmethod
     cdef void functor_run(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -32,7 +32,7 @@ cdef class CallbackFailureHandler:
 
 cdef class CallbackWrapper:
 
-    def __cinit__(self, object future, object loop, CallbackFailureHandler failure_handler):
+    def __cinit__(self, object future, object loop, CallbackFailureHandler failure_handler, object tag=None):
         self.context.functor.functor_run = self.functor_run
         self.context.waiter = <cpython.PyObject*>future
         self.context.loop = <cpython.PyObject*>loop
@@ -42,6 +42,7 @@ cdef class CallbackWrapper:
         # data path. We should make it as efficient as possible.
         self._reference_of_future = future
         self._reference_of_failure_handler = failure_handler
+        self._reference_of_tag = tag
         # NOTE(lidiz) We need to ensure when Core invokes our callback, the
         # callback function itself is not deallocated. Otherwise, we will get
         # a segfault. We can view this as Core holding a ref.
@@ -85,7 +86,8 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
     cdef CallbackWrapper wrapper = CallbackWrapper(
         future,
         loop,
-        CallbackFailureHandler('execute_batch', operations, ExecuteBatchError))
+        CallbackFailureHandler('execute_batch', operations, ExecuteBatchError),
+        batch_operation_tag)
     cdef grpc_call_error error = grpc_call_start_batch(
         grpc_call_wrapper.call,
         batch_operation_tag.c_ops,
@@ -93,6 +95,7 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
         wrapper.c_functor(), NULL)
 
     if error != GRPC_CALL_OK:
+        cpython.Py_DECREF(wrapper)
         grpc_call_error_string = grpc_call_error_to_string(error).decode()
         raise ExecuteBatchError("Failed grpc_call_start_batch: {} with grpc_call_error value: '{}'".format(error, grpc_call_error_string))
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
@@ -54,6 +54,17 @@ cdef class _BatchOperationTag:
     self._user_tag = user_tag
     self._operations = operations
     self._retained_call = call
+    self.c_ops = NULL
+    self.c_nops = 0
+
+  def __dealloc__(self):
+    cdef Operation operation
+    if self.c_ops != NULL:
+      if self._operations is not None:
+        for operation in self._operations:
+          operation.un_c()
+      gpr_free(self.c_ops)
+      self.c_ops = NULL
 
   cdef void prepare(self) except *:
     cdef Operation operation
@@ -69,7 +80,9 @@ cdef class _BatchOperationTag:
     if 0 < self.c_nops:
       for operation in self._operations:
         operation.un_c()
-      gpr_free(self.c_ops)
+      if self.c_ops != NULL:
+        gpr_free(self.c_ops)
+        self.c_ops = NULL
       return BatchOperationEvent(
           c_event.type, c_event.success, self._user_tag, self._operations)
     else:


### PR DESCRIPTION
### Description

Fixes #43360.

In `grpc.aio`, batch operations allocate an array of `grpc_op` in `_BatchOperationTag.prepare()` via `gpr_malloc()`.

Previously:
1. `_BatchOperationTag` had no `__dealloc__`, relying entirely on `event()` being invoked by `execute_batch` to free `c_ops` and call `operation.un_c()`.
2. When a batch failed (e.g. `SEND_STATUS_FROM_SERVER` on an already-cancelled call) or when the awaiting asyncio task was cancelled mid-flight (e.g. `call.cancel()` or `asyncio.timeout()` during `RECV_MESSAGE`), `await future` raised an exception, and `event()` was never reached. The un-freed `c_ops` arrays remained on the heap indefinitely (causing cumulative RSS bloat on high-throughput servers / streaming clients).
3. Furthermore, `CallbackWrapper` did not retain a reference to `batch_operation_tag`. If a coroutine was cancelled while gRPC Core was still running the batch in the background, the tag could potentially be dropped prematurely.

### Changes
1. Added `__dealloc__` to `_BatchOperationTag` in `src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi` to safely call `operation.un_c()` and `gpr_free(self.c_ops)` if `self.c_ops != NULL`.
2. Initialized `self.c_ops = NULL` in `_BatchOperationTag.__cinit__` and reset `self.c_ops = NULL` after `gpr_free(self.c_ops)` in `event()`.
3. Added `_reference_of_tag` to `CallbackWrapper` in `src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi` and `callback_common.pyx.pxi`, ensuring `batch_operation_tag` is pinned in memory until Core completes the batch and executes `functor_run`.
4. Balanced `wrapper` decref if `grpc_call_start_batch` returns an error code.

Closes #43360.
