### PR TITLE
DO NOT REVIEW

### DIFF
--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -449,7 +449,7 @@ def targets():
         CppDistribTest(
             "linux",
             "x64",
-            "debian11_aarch64_cross",
+            "debian13_aarch64_cross",
             "cmake_aarch64_cross",
             presubmit=False,
         ),


### PR DESCRIPTION
A distribtest is referring to the deleted image (`cpp_debian11_aarch64_cross_x64`), which is now migrated to `cpp_debian11_aarch64_cross_x64`