### PR TITLE
[xDS][ext_proc] Handle DEFAULT mode for Headers in ExtProc Processing Mode

### DIFF
--- a/src/core/xds/grpc/xds_http_ext_proc_filter.cc
+++ b/src/core/xds/grpc/xds_http_ext_proc_filter.cc
@@ -70,8 +70,15 @@ const grpc_channel_filter* XdsHttpExtProcFilterFactory::channel_filter() const {
 
 namespace {
 
-bool ParseHeaderProcessingMode(int32_t value, ValidationErrors* errors) {
+// Parses a ProcessingMode.HeaderSendMode value.  Returns true if the headers
+// or trailers should be sent to the ext_proc server.  DEFAULT resolves to
+// default_value, which per the proto docs is SEND for request and response
+// headers and SKIP for trailers.
+bool ParseHeaderProcessingMode(int32_t value, bool default_value,
+                               ValidationErrors* errors) {
   switch (value) {
+    case envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_DEFAULT:
+      return default_value;
     case envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_SEND:
       return true;
     case envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_SKIP:
@@ -109,21 +116,21 @@ ExtProcFilter::ProcessingMode ParseProcessingMode(
     processing_mode.send_request_headers = ParseHeaderProcessingMode(
         envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_request_header_mode(
             proto),
-        errors);
+        /*default_value=*/true, errors);
   }
   {
     ValidationErrors::ScopedField field(errors, ".response_header_mode");
     processing_mode.send_response_headers = ParseHeaderProcessingMode(
         envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_response_header_mode(
             proto),
-        errors);
+        /*default_value=*/true, errors);
   }
   {
     ValidationErrors::ScopedField field(errors, ".response_trailer_mode");
     processing_mode.send_response_trailers = ParseHeaderProcessingMode(
         envoy_extensions_filters_http_ext_proc_v3_ProcessingMode_response_trailer_mode(
             proto),
-        errors);
+        /*default_value=*/false, errors);
   }
   {
     ValidationErrors::ScopedField field(errors, ".request_body_mode");

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -3281,15 +3281,11 @@ TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigRequestHeaderModeDefault) {
   XdsExtension extension = MakeXdsExtension(proto);
   auto config =
       factory_->ParseTopLevelConfig("", decode_context_, extension, &errors_);
-  absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
-                                       "errors validating filter config");
-  EXPECT_EQ(
-      status,
-      absl::InvalidArgumentError(
-          "errors validating filter config: ["
-          "field:http_filter.value[envoy.extensions.filters.http.ext_proc.v3"
-          ".ExternalProcessor].processing_mode.request_header_mode "
-          "error:unsupported header processing mode value: 0]"));
+  ASSERT_TRUE(errors_.ok()) << errors_.status(
+      absl::StatusCode::kInvalidArgument, "unexpected errors");
+  ASSERT_NE(config, nullptr);
+  EXPECT_TRUE(DownCast<const ExtProcFilter::Config&>(*config)
+                  .processing_mode->send_request_headers);
 }
 
 TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigRequestHeaderModeSend) {
@@ -3349,15 +3345,11 @@ TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigResponseHeaderModeDefault) {
   XdsExtension extension = MakeXdsExtension(proto);
   auto config =
       factory_->ParseTopLevelConfig("", decode_context_, extension, &errors_);
-  absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
-                                       "errors validating filter config");
-  EXPECT_EQ(
-      status,
-      absl::InvalidArgumentError(
-          "errors validating filter config: ["
-          "field:http_filter.value[envoy.extensions.filters.http.ext_proc.v3"
-          ".ExternalProcessor].processing_mode.response_header_mode "
-          "error:unsupported header processing mode value: 0]"));
+  ASSERT_TRUE(errors_.ok()) << errors_.status(
+      absl::StatusCode::kInvalidArgument, "unexpected errors");
+  ASSERT_NE(config, nullptr);
+  EXPECT_TRUE(DownCast<const ExtProcFilter::Config&>(*config)
+                  .processing_mode->send_response_headers);
 }
 
 TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigResponseHeaderModeSend) {
@@ -3416,6 +3408,49 @@ TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigResponseTrailerModeDefault) {
   XdsExtension extension = MakeXdsExtension(proto);
   auto config =
       factory_->ParseTopLevelConfig("", decode_context_, extension, &errors_);
+  ASSERT_TRUE(errors_.ok()) << errors_.status(
+      absl::StatusCode::kInvalidArgument, "unexpected errors");
+  ASSERT_NE(config, nullptr);
+  EXPECT_FALSE(DownCast<const ExtProcFilter::Config&>(*config)
+                   .processing_mode->send_response_trailers);
+}
+
+TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigEmptyProcessingMode) {
+  ExternalProcessor proto;
+  auto* grpc_service = proto.mutable_grpc_service();
+  grpc_service->mutable_google_grpc()->set_target_uri("localhost:1234");
+  // Leave all fields unset, which means DEFAULT for the header and trailer
+  // modes and NONE for the body modes.
+  proto.mutable_processing_mode();
+  XdsExtension extension = MakeXdsExtension(proto);
+  auto config =
+      factory_->ParseTopLevelConfig("", decode_context_, extension, &errors_);
+  ASSERT_TRUE(errors_.ok()) << errors_.status(
+      absl::StatusCode::kInvalidArgument, "unexpected errors");
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->type(), ExtProcFilter::Config::Type());
+  const auto& processing_mode =
+      DownCast<const ExtProcFilter::Config&>(*config).processing_mode;
+  ASSERT_TRUE(processing_mode.has_value());
+  EXPECT_TRUE(processing_mode->send_request_headers);
+  EXPECT_TRUE(processing_mode->send_response_headers);
+  EXPECT_FALSE(processing_mode->send_response_trailers);
+  EXPECT_FALSE(processing_mode->send_request_body);
+  EXPECT_FALSE(processing_mode->send_response_body);
+}
+
+TEST_F(XdsExtProcFilterTest,
+       ParseTopLevelConfigGrpcResponseBodyWithDefaultTrailerMode) {
+  ExternalProcessor proto;
+  auto* grpc_service = proto.mutable_grpc_service();
+  grpc_service->mutable_google_grpc()->set_target_uri("localhost:1234");
+  auto* mode = proto.mutable_processing_mode();
+  mode->set_response_body_mode(
+      envoy::extensions::filters::http::ext_proc::v3::ProcessingMode::GRPC);
+  // response_trailer_mode is left unset, which means SKIP.
+  XdsExtension extension = MakeXdsExtension(proto);
+  auto config =
+      factory_->ParseTopLevelConfig("", decode_context_, extension, &errors_);
   absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
                                        "errors validating filter config");
   EXPECT_EQ(
@@ -3424,7 +3459,27 @@ TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigResponseTrailerModeDefault) {
           "errors validating filter config: ["
           "field:http_filter.value[envoy.extensions.filters.http.ext_proc.v3"
           ".ExternalProcessor].processing_mode.response_trailer_mode "
-          "error:unsupported header processing mode value: 0]"));
+          "error:must be set to SEND if response_body_mode is set to GRPC]"));
+}
+
+TEST_F(XdsExtProcFilterTest, ParseOverrideConfigDefaultProcessingMode) {
+  ExtProcPerRoute proto;
+  // Leave all fields unset, which means DEFAULT for the header and trailer
+  // modes and NONE for the body modes.
+  proto.mutable_overrides()->mutable_processing_mode();
+  XdsExtension extension = MakeXdsExtension(proto);
+  auto config =
+      factory_->ParseOverrideConfig("", decode_context_, extension, &errors_);
+  ASSERT_TRUE(errors_.ok()) << errors_.status(
+      absl::StatusCode::kInvalidArgument, "unexpected errors");
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->type(), ExtProcFilter::Config::Type());
+  const auto& processing_mode =
+      DownCast<const ExtProcFilter::Config&>(*config).processing_mode;
+  ASSERT_TRUE(processing_mode.has_value());
+  EXPECT_TRUE(processing_mode->send_request_headers);
+  EXPECT_TRUE(processing_mode->send_response_headers);
+  EXPECT_FALSE(processing_mode->send_response_trailers);
 }
 
 TEST_F(XdsExtProcFilterTest, ParseTopLevelConfigResponseTrailerModeSend) {


### PR DESCRIPTION
Per [processing_mode.proto](https://github.com/envoyproxy/envoy/blob/f71cb8d8dba1ce04f175e82c3e7430ee28d207bb/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto#L28), `DEFAULT` means SEND for request/response headers and SKIP for trailers. `ParseHeaderProcessingMode()` now takes a `default_value` param to encode this.