### PR TITLE
[chttp2] Count true-binary marker in Huffman metadata size

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -556,7 +556,7 @@ HPackParser::String::StringResult HPackParser::String::ParseBinary(
       case State::kBinary:
         // Binary, we're done
         {
-          size_t wire_len = decompressed.size();
+          size_t wire_len = decompressed.size() + 1;
           return StringResult{HpackParseStatus::kOk, wire_len,
                               String(std::move(decompressed))};
         }

--- a/test/core/transport/chttp2/hpack_parser_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_test.cc
@@ -553,6 +553,13 @@ INSTANTIATE_TEST_SUITE_P(
                       "received metadata size exceeds hard limit"),
                   0},
              }},
+        Test{"HuffmanTrueBinaryMetadataSizeLimit",
+             {},
+             38,
+             {{"0005782d62696e82ffc7",
+               absl::ResourceExhaustedError(
+                   "received metadata size exceeds hard limit"),
+               kEndOfHeaders}}},
         Test{
             "SingleByteBE",
             {},


### PR DESCRIPTION
## Summary

Count the leading NUL marker when a Huffman-decoded binary header uses gRPC's
true-binary representation.

`ParseBinary` removes that marker from the value returned to the application,
but it also used the shortened value to calculate `wire_size`. This made the
metadata limit and HPACK table accounting one byte low for each affected field.
The non-Huffman path already includes the marker in its accounting.

## Testing

Added an exact-boundary parser regression for a Huffman-encoded `x-bin` value
whose decoded content is only the true-binary marker. It runs in both whole-slice
and one-byte split modes.

Run with:

```text
bazelisk test //test/core/transport/chttp2:hpack_parser_test
bazelisk test //test/core/transport/chttp2:hpack_encoder_test
bazelisk test //test/core/transport/chttp2:hpack_sync_fuzzer
```
