### PR TITLE
[Python AsyncIO] Fix lock-order deadlock during AIO initialization

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -57,7 +57,6 @@ cdef _actual_aio_initialization():
         _GRPC_ASYNCIO_ENGINE,
         _default_asyncio_engine(),
     )
-    _LOGGER.debug('Using %s as I/O engine', _global_aio_state.engine)
 
     # Initializes the process-level state accordingly
     if _global_aio_state.engine is AsyncIOEngine.POLLER:
@@ -83,8 +82,7 @@ cdef _actual_aio_shutdown():
         raise ValueError('Unsupported engine type [%s]' % _global_aio_state.engine)
 
 
-cdef _initialize_per_loop():
-    cdef object loop = get_working_loop()
+cdef _initialize_per_loop(object loop):
     if _global_aio_state.engine is AsyncIOEngine.POLLER:
         _global_aio_state.cq.bind_loop(loop)
 
@@ -95,11 +93,20 @@ cpdef init_grpc_aio():
     Expected to be invoked on critical class constructors.
     E.g., AioChannel, AioServer.
     """
+    cdef object initialized_engine = None
     with _global_aio_state.lock:
         _global_aio_state.refcount += 1
         if _global_aio_state.refcount == 1:
             _actual_aio_initialization()
-        _initialize_per_loop()
+            initialized_engine = _global_aio_state.engine
+
+    # Loop lookup can log, so release the lock first (#43421).
+    cdef object loop = get_working_loop()
+    with _global_aio_state.lock:
+        _initialize_per_loop(loop)
+
+    if initialized_engine is not None:
+        _LOGGER.debug('Using %s as I/O engine', initialized_engine)
 
 
 cpdef shutdown_grpc_aio():


### PR DESCRIPTION
Fixes grpc/grpc#43421.

AIO initialization can acquire logging’s lock while holding the global AIO lock. Logging configuration can acquire those locks in the opposite order when GC finalizes an AIO object, causing a deadlock.

Move loop lookup and the engine diagnostic outside the AIO lock. Keep refcount updates and loop binding protected. Acquire the reference before loop lookup so failed constructors remain balanced by their destructors.

Validated locally on Linux with CPython 3.12:
* Existing asyncio suite: 277 tests run, one pre-existing skip.
* Four local regression checks pass, including failed-constructor cleanup.
* The issue’s reproducer, retaining the explicit call cycle, progresses throughout a 90-second run with 200 logging threads. Unpatched grpcio 1.83.1 stalls after one RPC.

The additional regression checks and stress reproducer I used are not added to the unit-test suite.

Release note

Python AsyncIO: Fix a deadlock that could occur when making RPCs while another thread reconfigures Python logging.